### PR TITLE
docs: Add redirect from /github/adding-repos to GitHub integration page

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -221,3 +221,5 @@ favicon: ./docs/assets/favicon.ico
 redirects:
   - source: "/promptless-1-0"
     destination: "/docs/getting-started/promptless-1-0"
+  - source: "/github/adding-repos"
+    destination: "/docs/integrations/github-integration#adding-more-repos-after-installation"


### PR DESCRIPTION
## Summary
- Adds a URL redirect from `/github/adding-repos` to `/docs/integrations/github-integration#adding-more-repos-after-installation`

## Test plan
- [ ] Verify redirect works after deployment by visiting `/github/adding-repos`

🤖 Generated with [Claude Code](https://claude.com/claude-code)