### PR TITLE
docs: Fix 49 broken links across documentation

### DIFF
--- a/fern/docs/configuration/context-sources.md
+++ b/fern/docs/configuration/context-sources.md
@@ -15,15 +15,15 @@ Context sources are **optional** but highly recommended. They can significantly 
 ## Available Context Sources
 
 <CardGroup cols={2}>
-  <Card title="Linear" icon="fa-solid fa-circle" href="/docs/configuration/context-sources/linear">
+  <Card title="Linear" icon="fa-solid fa-circle" href="/docs/configuring-promptless/context-sources/linear">
     Access Linear issues, projects, and team workflows for project management context
   </Card>
   
-  <Card title="Jira" icon="fa-brands fa-jira" href="/docs/configuration/context-sources/jira">
+  <Card title="Jira" icon="fa-brands fa-jira" href="/docs/configuring-promptless/context-sources/jira">
     Query Jira tickets and project data using JQL search capabilities
   </Card>
   
-  <Card title="Confluence" icon="fa-brands fa-confluence" href="/docs/configuration/context-sources/confluence">
+  <Card title="Confluence" icon="fa-brands fa-confluence" href="/docs/configuring-promptless/context-sources/confluence">
     Search Confluence spaces for existing documentation patterns, terminology, and architectural decisions
   </Card>
 </CardGroup>

--- a/fern/docs/configuration/doc-collections.md
+++ b/fern/docs/configuration/doc-collections.md
@@ -20,18 +20,18 @@ The most common setup uses GitHub repositories to store documentation content th
 - Vocs
 - Custom platforms as long as the content is in a repo
 
-Learn more: [GitHub Repos (Docs as Code)](/docs/configuration/doc-collections/github-repos)
+Learn more: [GitHub Repos (Docs as Code)](/docs/configuring-promptless/doc-collections/git-hub-repos-docs-as-code)
 
 ## Direct Platform Integrations
 
 For teams using content management systems that don't sync with GitHub, Promptless offers direct integrations with popular platforms.
 
 <CardGroup cols={2}>
-  <Card title="Zendesk" icon="fa-solid fa-ticket" href="/docs/configuration/doc-collections/zendesk">
+  <Card title="Zendesk" icon="fa-solid fa-ticket" href="/docs/configuring-promptless/doc-collections/zendesk">
     Help center articles and knowledge base content management
   </Card>
   
-  <Card title="Intercom" icon="fa-solid fa-comments" href="/docs/configuration/doc-collections/intercom">
+  <Card title="Intercom" icon="fa-solid fa-comments" href="/docs/configuring-promptless/doc-collections/intercom-beta">
     Customer support documentation and help center content
   </Card>
 </CardGroup>

--- a/fern/docs/configuration/doc-collections/github-repos.md
+++ b/fern/docs/configuration/doc-collections/github-repos.md
@@ -50,7 +50,7 @@ When auto-publish is enabled for your project:
 
 - Promptless automatically creates a new PR in your documentation repository with suggested changes
 - For GitHub PR triggers, the documentation PR is linked in a comment on the original code PR
-- For [commit triggers](/docs/configuration/triggers/github-commits), you can enable auto-merge to automatically merge documentation PRs as soon as they're created (nested checkbox under auto-publish in project settings)
+- For [commit triggers](/docs/configuring-promptless/triggers/git-hub-commits), you can enable auto-merge to automatically merge documentation PRs as soon as they're created (nested checkbox under auto-publish in project settings)
 
 ## Automated CI Check and Build Issue Resolution
 

--- a/fern/docs/configuration/doc-collections/intercom.md
+++ b/fern/docs/configuration/doc-collections/intercom.md
@@ -45,7 +45,7 @@ Intercom as a documentation platform is especially useful for:
 
 ## Setup Instructions
 
-To connect Intercom to Promptless, see the [Intercom Integration](/docs/integrations/intercom) setup guide.
+To connect Intercom to Promptless, see the [Intercom Integration](/docs/integrations/intercom-integration-beta) setup guide.
 
 <Info>
 Contact [help@gopromptless.ai](mailto:help@gopromptless.ai) to enable the Intercom integration for your account.

--- a/fern/docs/configuration/doc-collections/zendesk.md
+++ b/fern/docs/configuration/doc-collections/zendesk.md
@@ -41,4 +41,4 @@ Zendesk as a documentation platform is especially useful for:
 
 ## Setup Instructions
 
-To connect Zendesk to Promptless, see the [Zendesk Integration](/docs/integrations/zendesk) setup guide.
+To connect Zendesk to Promptless, see the [Zendesk Integration](/docs/integrations/zendesk-integration) setup guide.

--- a/fern/docs/configuration/triggers.md
+++ b/fern/docs/configuration/triggers.md
@@ -7,23 +7,23 @@ Triggers are events that initiate automated documentation updates in Promptless.
 ## Available Trigger Types
 
 <CardGroup cols={2}>
-  <Card title="GitHub PRs" icon="fa-brands fa-github" href="/docs/configuration/triggers/github-prs">
+  <Card title="GitHub PRs" icon="fa-brands fa-github" href="/docs/configuring-promptless/triggers/git-hub-p-rs">
     Automatically triggered when pull requests are opened in your GitHub repositories
   </Card>
   
-  <Card title="GitHub Commits" icon="fa-brands fa-github" href="/docs/configuration/triggers/github-commits">
+  <Card title="GitHub Commits" icon="fa-brands fa-github" href="/docs/configuring-promptless/triggers/git-hub-commits">
     Monitor direct commits to default branches for documentation updates
   </Card>
   
-  <Card title="Slack" icon="brands slack" href="/docs/configuration/triggers/slack">
+  <Card title="Slack" icon="brands slack" href="/docs/configuring-promptless/triggers/slack-messages">
     Trigger updates from Slack conversations and support threads
   </Card>
   
-  <Card title="Microsoft Teams" icon="fa-brands fa-microsoft" href="/docs/configuration/triggers/microsoft-teams">
+  <Card title="Microsoft Teams" icon="fa-brands fa-microsoft" href="/docs/configuring-promptless/triggers/microsoft-teams-messages">
     Trigger updates from Microsoft Teams messages and mentions
   </Card>
   
-  <Card title="Zendesk (Beta)" icon="fa-solid fa-ticket" href="/docs/configuration/triggers/zendesk">
+  <Card title="Zendesk (Beta)" icon="fa-solid fa-ticket" href="/docs/configuring-promptless/triggers/zendesk-tickets-beta">
     Monitor support tickets for documentation gaps based on recurring user questions
   </Card>
 </CardGroup>
@@ -52,7 +52,7 @@ Need a trigger type that isn't currently supported? Contact us at [help@goprompt
 
 ## Auto-publish Mode
 
-When auto-publish is enabled for your project, Promptless automatically creates pull requests in your documentation repository with suggested changes. For [commit triggers](/docs/configuration/triggers/github-commits), you can optionally enable auto-merge to automatically merge documentation PRs as soon as they're created.
+When auto-publish is enabled for your project, Promptless automatically creates pull requests in your documentation repository with suggested changes. For [commit triggers](/docs/configuring-promptless/triggers/git-hub-commits), you can optionally enable auto-merge to automatically merge documentation PRs as soon as they're created.
 
 Auto-publish is available for GitHub-based documentation platforms. For CMS platforms like Zendesk or Intercom, documentation updates are created as drafts for review.
 

--- a/fern/docs/configuration/triggers/microsoft-teams.md
+++ b/fern/docs/configuration/triggers/microsoft-teams.md
@@ -37,7 +37,7 @@ Promptless only reads Microsoft Teams content when you explicitly trigger it by 
 
 ## Setup Instructions
 
-To connect Microsoft Teams to Promptless, see the [Microsoft Teams Integration](/docs/integrations/microsoft-teams) setup guide.
+To connect Microsoft Teams to Promptless, see the [Microsoft Teams Integration](/docs/integrations/microsoft-teams-integration) setup guide.
 
 <Info>
 Microsoft Teams integration requires admin center access to install the Promptless Teams app. See the setup guide for detailed installation instructions.

--- a/fern/docs/configuration/triggers/zendesk.md
+++ b/fern/docs/configuration/triggers/zendesk.md
@@ -37,4 +37,4 @@ Zendesk triggers are especially useful for:
 
 ## Setup Instructions
 
-To connect Zendesk to Promptless, see the [Zendesk Integration](/docs/integrations/zendesk) setup guide.
+To connect Zendesk to Promptless, see the [Zendesk Integration](/docs/integrations/zendesk-integration) setup guide.

--- a/fern/docs/core-concepts.mdx
+++ b/fern/docs/core-concepts.mdx
@@ -57,7 +57,7 @@ graph LR
 - **Team Communication**: Slack messages and Microsoft Teams mentions can trigger documentation updates
 - **Support Patterns (Beta)**: Zendesk tickets help identify gaps in documentation based on recurring user questions
 
-Learn more in [Configuring Promptless → Triggers](/docs/configuration/triggers).
+Learn more in [Configuring Promptless → Triggers](/docs/configuring-promptless/triggers).
 
 ### 2. Context Sources Enrich Promptless's Understanding
 
@@ -71,7 +71,7 @@ Learn more in [Configuring Promptless → Triggers](/docs/configuration/triggers
 Context sources are queried in real-time and no customer data is stored by Promptless, ensuring your sensitive information remains secure.
 </Note>
 
-Learn more in [Configuring Promptless → Context Sources](/docs/configuration/context-sources).
+Learn more in [Configuring Promptless → Context Sources](/docs/configuring-promptless/context-sources).
 
 ### 3. Documentation Platforms Receive Updates
 
@@ -81,7 +81,7 @@ Learn more in [Configuring Promptless → Context Sources](/docs/configuration/c
 - **Direct Platform Integration**: Beta support for publishing directly to Zendesk and Intercom
 - **Multi-platform Publishing**: Single trigger can update multiple documentation platforms simultaneously
 
-Learn more in [Configuring Promptless → Doc Collections](/docs/configuration/doc-collections).
+Learn more in [Configuring Promptless → Doc Collections](/docs/configuring-promptless/doc-collections).
 
 ## Key Benefits of This Architecture
 

--- a/fern/docs/faq.mdx
+++ b/fern/docs/faq.mdx
@@ -4,7 +4,7 @@ Here you'll find answers to common questions about using Promptless.
 
 ## Getting Started & Onboarding
 
-For account creation and team management questions, please see our [Account Management](/docs/managing-accounts) page.
+For account creation and team management questions, please see our [Account Management](/docs/account-management/account-management) page.
 
 ## Platform Usage
 
@@ -24,7 +24,7 @@ By default, no. Promptless only accesses Slack content when you explicitly trigg
 
 However, you can optionally enable **passive listening** for specific channels. When enabled, Promptless will monitor only the channels you explicitly select in your project configuration. This is completely opt-in - you choose which channels to monitor and can add or remove channels at any time. If you don't enable this option, we will not be monitoring any slack channels.
 
-For more details, see our [Slack Integration documentation](/docs/integrations/slack-integration) and [Working with Slack](/docs/features/slack-interactions#4-passive-channel-listening).
+For more details, see our [Slack Integration documentation](/docs/integrations/slack-integration) and [Working with Slack](/docs/how-to-use-promptless/working-with-slack#4-passive-channel-listening).
 
 ### Does Promptless analyze my entire codebase?
 

--- a/fern/docs/features/index.mdx
+++ b/fern/docs/features/index.mdx
@@ -8,15 +8,15 @@ Promptless offers multiple ways to interact with the platform and generate docum
 ## Interaction Methods
 
 <CardGroup cols={1}>
-  <Card title="Working with Slack" icon="brands slack" href="/how-to-use-promptless/working-with-slack">
+  <Card title="Working with Slack" icon="brands slack" href="/docs/how-to-use-promptless/working-with-slack">
     Use message actions, DMs, and channel mentions to trigger documentation updates and follow-up edits directly from Slack conversations.
   </Card>
 
-  <Card title="Interacting with Promptless PRs" icon="brands github" href="/how-to-use-promptless/interacting-with-promptless-p-rs">
+  <Card title="Interacting with Promptless PRs" icon="brands github" href="/docs/how-to-use-promptless/interacting-with-promptless-p-rs">
     Provide follow-up instructions through GitHub PR comments and reviews after your documentation PR is opened.
   </Card>
 
-  <Card title="Using the Web Interface" icon="regular browser" href="/how-to-use-promptless/using-the-web-interface">
+  <Card title="Using the Web Interface" icon="regular browser" href="/docs/how-to-use-promptless/using-the-web-interface">
     Highlight text, add comments, and provide feedback directly in Promptless's web interface.
   </Card>
 </CardGroup>

--- a/fern/docs/features/web-ui-feedback.mdx
+++ b/fern/docs/features/web-ui-feedback.mdx
@@ -13,7 +13,7 @@ Each suggestion includes a title and description that explains what changes are 
 
 ### Providing feedback
 
-Promptless offers several ways to provide feedback on suggestions. Learn about all available feedback methods in the [Providing Feedback](/features/providing-feedback) guide.
+Promptless offers several ways to provide feedback on suggestions. Learn about all available feedback methods in the [Providing Feedback](/docs/how-to-use-promptless/providing-feedback) guide.
 
 ### Triggers page
 

--- a/fern/docs/integrations/atlassian.mdx
+++ b/fern/docs/integrations/atlassian.mdx
@@ -53,7 +53,7 @@ For Atlassian Cloud-hosted Jira instances:
   </Step>
 
   <Step title="Complete Connection">
-    Click "Accept" and verify the connection in Promptless. If you don't see the option to accept, you may not have the required permissions. Contact your Jira administrator or invite them to Promptless. For more information about adding new members, see our [Account Management](/docs/managing-accounts) page.
+    Click "Accept" and verify the connection in Promptless. If you don't see the option to accept, you may not have the required permissions. Contact your Jira administrator or invite them to Promptless. For more information about adding new members, see our [Account Management](/docs/account-management/account-management) page.
   </Step>
 </Steps>
 
@@ -66,8 +66,8 @@ After connecting, manage Promptless access by going to your avatar > Account set
 
 Once connected, you can use Jira and Confluence as context sources to enhance documentation suggestions:
 
-- **Jira**: Automatically retrieve ticket information and search for related issues using JQL queries. See the [Jira Context Source](/docs/configuration/context-sources/jira) page for details.
-- **Confluence**: Search your Confluence spaces for existing documentation patterns, terminology, and architectural decisions. See the [Confluence Context Source](/docs/configuration/context-sources/confluence) page for details.
+- **Jira**: Automatically retrieve ticket information and search for related issues using JQL queries. See the [Jira Context Source](/docs/configuring-promptless/context-sources/jira) page for details.
+- **Confluence**: Search your Confluence spaces for existing documentation patterns, terminology, and architectural decisions. See the [Confluence Context Source](/docs/configuring-promptless/context-sources/confluence) page for details.
 
 <Frame>
   <img src="https://promptless-customer-doc-assets.s3.amazonaws.com/docs-images/org_2lvkgU9erOFxYhtEVVC0ymPrPdF/atlassian-integration-confluence-jira-unified-517b0f75.png" alt="Atlassian integration showing both Jira projects and Confluence spaces in a unified interface" />
@@ -119,7 +119,7 @@ Create the account using an email alias like `your_email+promptless@company.com`
 
 ## Data Processing and Security
 
-For information about how Promptless processes Jira data, including redaction capabilities and privacy controls, see the [Jira Context Source](/docs/configuration/context-sources/jira) page.
+For information about how Promptless processes Jira data, including redaction capabilities and privacy controls, see the [Jira Context Source](/docs/configuring-promptless/context-sources/jira) page.
 
 ## Troubleshooting
 

--- a/fern/docs/integrations/bitbucket.mdx
+++ b/fern/docs/integrations/bitbucket.mdx
@@ -89,4 +89,4 @@ Once configured, the Bitbucket integration works similarly to the GitHub integra
 4. Promptless adds a comment to your Bitbucket pull request with a link to review the documentation changes
 5. You can review and approve the suggested documentation updates in the Promptless dashboard
 
-For more information on how triggers work in general, see the [Triggers](/docs/core-concepts/triggers) documentation.
+For more information on how triggers work in general, see the [Triggers](/docs/configuring-promptless/triggers) documentation.

--- a/fern/docs/integrations/github-enterprise.mdx
+++ b/fern/docs/integrations/github-enterprise.mdx
@@ -11,7 +11,7 @@ This setup is required for GitHub Enterprise Server instances and GitHub Enterpr
 ## Prerequisites
 
 - GitHub Enterprise admin access to create and configure GitHub Apps
-- Network access to Promptless endpoints (see [IP whitelisting](#ip-whitelisting) section)
+- Network access to Promptless endpoints (see [IP whitelisting](#step-6-ip-whitelisting) section)
 - Ability to generate and securely store private keys and client secrets
 
 ## Step 1: Register New GitHub App

--- a/fern/docs/integrations/github.mdx
+++ b/fern/docs/integrations/github.mdx
@@ -73,9 +73,9 @@ This ensures that Promptless has read and write access to the repositories that 
 
 Once connected, you can use GitHub for:
 
-- **[Triggers](/docs/configuration/triggers)**: Monitor pull requests and commits for documentation updates
-- **[Context Sources](/docs/configuration/context-sources/github)**: Search code repositories and issues for technical context
-- **[Doc Collections](/docs/configuration/doc-collections/github-repos)**: Publish documentation updates to GitHub-based platforms
+- **[Triggers](/docs/configuring-promptless/triggers)**: Monitor pull requests and commits for documentation updates
+- **[Context Sources](/docs/configuring-promptless/context-sources)**: Search code repositories and issues for technical context
+- **[Doc Collections](/docs/configuring-promptless/doc-collections/git-hub-repos-docs-as-code)**: Publish documentation updates to GitHub-based platforms
 
 ## Frequently Asked Questions
 

--- a/fern/docs/integrations/intercom.md
+++ b/fern/docs/integrations/intercom.md
@@ -18,7 +18,7 @@ To set up the Intercom integration:
 
 ## What You Can Do with Intercom
 
-Once connected, you can use Intercom as a [documentation platform](/docs/configuration/doc-collections/intercom) to publish help center articles and customer support documentation.
+Once connected, you can use Intercom as a [documentation platform](/docs/configuring-promptless/doc-collections/intercom-beta) to publish help center articles and customer support documentation.
 
 <Note>
 The Intercom integration creates or updates drafts in Intercom. You'll need to review and publish these drafts from within your Intercom dashboard before they become visible to your users.

--- a/fern/docs/integrations/linear.mdx
+++ b/fern/docs/integrations/linear.mdx
@@ -35,4 +35,4 @@ Promptless uses OAuth 2.0 to authenticate with Linear, following their [official
 
 ## What You Can Do with Linear
 
-Once connected, you can use Linear as a [context source](/docs/configuration/context-sources/linear) to search for related issues and project management data that enhances documentation accuracy.
+Once connected, you can use Linear as a [context source](/docs/configuring-promptless/context-sources/linear) to search for related issues and project management data that enhances documentation accuracy.

--- a/fern/docs/integrations/microsoft-teams.mdx
+++ b/fern/docs/integrations/microsoft-teams.mdx
@@ -63,6 +63,6 @@ First, download the Promptless Teams app package from the [Promptless integratio
 
 Once connected, you can use Microsoft Teams for:
 
-- **[Triggers](/docs/configuration/triggers/microsoft-teams)**: Tag @Promptless in channels or DMs to trigger documentation updates
+- **[Triggers](/docs/configuring-promptless/triggers/microsoft-teams-messages)**: Tag @Promptless in channels or DMs to trigger documentation updates
 
-For more details about configuration, see [Microsoft Teams Triggers](/docs/configuration/triggers/microsoft-teams).
+For more details about configuration, see [Microsoft Teams Triggers](/docs/configuring-promptless/triggers/microsoft-teams-messages).

--- a/fern/docs/integrations/slack.mdx
+++ b/fern/docs/integrations/slack.mdx
@@ -38,11 +38,11 @@ Disclaimer: Promptless uses LLMs from OpenAI and Anthropic that have the potenti
 
 Once connected, you can use Slack for:
 
-- **[Triggers](/docs/configuration/triggers/slack)**: Tag @Promptless or use message actions to trigger documentation updates
-- **[Context Sources](/docs/configuration/context-sources/slack)**: Search Slack conversations for team discussions and decisions
+- **[Triggers](/docs/configuring-promptless/triggers/slack-messages)**: Tag @Promptless or use message actions to trigger documentation updates
+- **[Context Sources](/docs/configuring-promptless/context-sources)**: Search Slack conversations for team discussions and decisions
 
 ## Privacy and Channel Access
 
 By default, Promptless only reads Slack content when you explicitly trigger it by tagging @Promptless or using the "Update Docs" message action. If you enable passive listening in your project settings, Promptless will monitor only the specific channels you select. Promptless cannot access private channels unless it has been specifically invited to those channels.
 
-For more details about using Slack with Promptless, see [Working with Slack](/docs/features/slack-interactions).
+For more details about using Slack with Promptless, see [Working with Slack](/docs/how-to-use-promptless/working-with-slack).

--- a/fern/docs/integrations/zendesk.mdx
+++ b/fern/docs/integrations/zendesk.mdx
@@ -28,5 +28,5 @@ Promptless uses Zendesk's [official OAuth 2.0 authentication](https://developer.
 
 Once connected, you can use Zendesk for:
 
-- **[Triggers](/docs/configuration/triggers/zendesk)**: Monitor resolved support tickets for documentation gaps (Beta)
-- **[Doc Collections](/docs/configuration/doc-collections/zendesk)**: Publish documentation updates directly to your Zendesk Help Center
+- **[Triggers](/docs/configuring-promptless/triggers/zendesk-tickets-beta)**: Monitor resolved support tickets for documentation gaps (Beta)
+- **[Doc Collections](/docs/configuring-promptless/doc-collections/zendesk)**: Publish documentation updates directly to your Zendesk Help Center

--- a/fern/docs/open-source.mdx
+++ b/fern/docs/open-source.mdx
@@ -25,11 +25,11 @@ The basic setup for your open source project involves three steps:
   </Step>
 
   <Step title="Set Up Doc Collections">
-    [Doc Collections](/docs/doc-collections) tell Promptless where your documentation lives.
+    [Doc Collections](/docs/configuring-promptless/doc-collections) tell Promptless where your documentation lives.
 
     You can create multiple doc collections if needed—for example, if your changelog is in a different location from your main docs. You can also specify a particular directory if your docs live in a monorepo alongside your code.
 
-    See [GitHub Repos (Docs as Code)](/docs/doc-collections/git-hub-repos-docs-as-code) for setup instructions.
+    See [GitHub Repos (Docs as Code)](/docs/configuring-promptless/doc-collections/git-hub-repos-docs-as-code) for setup instructions.
   </Step>
 
   <Step title="Create a Project">
@@ -47,7 +47,7 @@ The basic setup for your open source project involves three steps:
 
 ## Recommended Trigger Configuration
 
-Most projects trigger Promptless on opened PRs. For popular open source projects—where many contributor PRs get closed without merging—consider using [GitHub Commit triggers](/docs/triggers/git-hub-commits) instead. This way, Promptless only runs when PRs are actually merged to your default branch. We recommend changing this setting after your initial calibration.
+Most projects trigger Promptless on opened PRs. For popular open source projects—where many contributor PRs get closed without merging—consider using [GitHub Commit triggers](/docs/configuring-promptless/triggers/git-hub-commits) instead. This way, Promptless only runs when PRs are actually merged to your default branch. We recommend changing this setting after your initial calibration.
 
 ## Additional Use Cases
 

--- a/fern/docs/pilot-guide.mdx
+++ b/fern/docs/pilot-guide.mdx
@@ -77,7 +77,7 @@ We always recommend kicking off customer pilots with an in-person workshop.
 
 <Steps>
   <Step title="Understand your Promptless setup">
-    Review your configuration and how [triggers](/docs/core-concepts/triggers), [context sources](/docs/core-concepts/context-sources), and [documentation platforms](/docs/core-concepts/doc-c-m-ss) work for your team
+    Review your configuration and how [triggers](/docs/configuring-promptless/triggers), [context sources](/docs/configuring-promptless/context-sources), and [documentation platforms](/docs/configuring-promptless/doc-collections) work for your team
   </Step>
   <Step title="Publish your first updates">
     Review suggestions together and publish documentation updates during the session

--- a/fern/docs/security-and-privacy/privacy-policy.md
+++ b/fern/docs/security-and-privacy/privacy-policy.md
@@ -13,7 +13,7 @@ Our privacy policy covers important aspects of data handling, including:
 ## Complete Privacy Policy
 
 For the complete, current version of our privacy policy, please visit:
-[Promptless Privacy Policy](https://www.gopromptless.ai/privacy)
+[Promptless Privacy Policy](https://promptless.ai/privacy)
 
 ## Privacy Inquiries
 


### PR DESCRIPTION
## Summary

- Fixed 49 broken links across 24 documentation files identified by crawling docs.promptless.ai
- Root causes: wrong section slugs (`/configuration/` vs `/configuring-promptless/`), Fern-generated page slug mismatches, missing `/docs` prefixes, incorrect cross-section paths, a broken anchor, and a stale external domain
- Also fixed 3 broken links in the hidden `pilot-guide.mdx` page not caught by the crawler

## Details

| Category | Count | Example |
|----------|-------|---------|
| Wrong section slug (`configuration` -> `configuring-promptless`) | 30 | `/docs/configuration/triggers` -> `/docs/configuring-promptless/triggers` |
| Page slug mismatches (Fern title-based slugs) | 12 | `triggers/slack` -> `triggers/slack-messages` |
| Missing `/docs` prefix | 3 | `/how-to-use-promptless/...` -> `/docs/how-to-use-promptless/...` |
| Wrong cross-section paths | 6 | `/docs/features/slack-interactions` -> `/docs/how-to-use-promptless/working-with-slack` |
| Broken anchor | 1 | `#ip-whitelisting` -> `#step-6-ip-whitelisting` |
| Stale external domain | 1 | `www.gopromptless.ai/privacy` -> `promptless.ai/privacy` |

## Test plan

- [ ] Re-run `uv run --project server python tools/broken-links/check_broken_links.py https://docs.promptless.ai` after deploy to confirm 0 broken links
- [ ] Spot-check a few pages in preview to verify links navigate correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)