### PR TITLE
Update homepage hero, site title, and remove captcha

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -36,7 +36,7 @@ export default defineConfig({
   integrations: [
     react(),
     starlight({
-      title: 'Promptless | Documentation',
+      title: 'Promptless | Automatic updates for your customer-facing docs',
       description: 'Automated docs that eliminate manual overhead and keep your docs current with your codebase',
       logo: {
         src: './fern/docs/assets/logo.svg',

--- a/src/components/site/BrokenLinkReportForm.astro
+++ b/src/components/site/BrokenLinkReportForm.astro
@@ -2,14 +2,12 @@
 const rawApiBaseUrl = import.meta.env.PUBLIC_FREE_TOOLS_API_BASE_URL?.trim();
 const fallbackApiBaseUrl = import.meta.env.PROD ? 'https://api.gopromptless.ai' : 'http://127.0.0.1:5000';
 const apiBaseUrl = (rawApiBaseUrl || fallbackApiBaseUrl).replace(/\/+$/, '');
-const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY?.trim() || '';
 ---
 
 <form
   class="pl-free-tools-form"
   id="broken-link-report-form"
   data-api-base={apiBaseUrl}
-  data-turnstile-enabled={turnstileSiteKey ? 'true' : 'false'}
   novalidate
 >
   <div class="pl-free-tools-form-grid">
@@ -74,27 +72,11 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY?.trim() || ''
     <input id="broken-link-website" name="website" type="text" tabindex="-1" autocomplete="off" />
   </div>
 
-  {
-    turnstileSiteKey ? (
-      <div class="pl-free-tools-turnstile">
-        <div class="cf-turnstile" data-sitekey={turnstileSiteKey} data-theme="light" data-action="broken_link_report"></div>
-      </div>
-    ) : (
-      <p class="pl-free-tools-turnstile-note">Captcha is disabled in this environment.</p>
-    )
-  }
-
   <div class="pl-free-tools-actions">
     <button type="submit">Send me the report</button>
     <p id="broken-link-form-status" class="pl-free-tools-status" aria-live="polite"></p>
   </div>
 </form>
-
-{
-  turnstileSiteKey ? (
-    <script is:inline src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-  ) : null
-}
 
 <script is:inline>
   (() => {
@@ -106,7 +88,6 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY?.trim() || ''
     if (!(submitButton instanceof HTMLButtonElement)) return;
 
     const apiBase = form.dataset.apiBase || 'http://127.0.0.1:5000';
-    const turnstileEnabled = form.dataset.turnstileEnabled === 'true';
     const fixedConcurrency = 10;
     const fixedTimeoutSeconds = 10;
 
@@ -170,15 +151,6 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY?.trim() || ''
         return;
       }
 
-      let turnstileToken = '';
-      if (turnstileEnabled) {
-        turnstileToken = String(formData.get('cf-turnstile-response') || '').trim();
-        if (!turnstileToken) {
-          setStatus('Please complete the captcha challenge.', 'error');
-          return;
-        }
-      }
-
       submitButton.disabled = true;
       submitButton.dataset.loading = 'true';
       setStatus('Submitting request...', 'neutral');
@@ -199,7 +171,6 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY?.trim() || ''
               concurrency: fixedConcurrency,
               timeout_seconds: fixedTimeoutSeconds,
             },
-            turnstile_token: turnstileToken || undefined,
             website,
           }),
         });
@@ -215,9 +186,6 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY?.trim() || ''
         form.reset();
         const anchorsToggle = form.querySelector('#broken-link-check-anchors');
         if (anchorsToggle instanceof HTMLInputElement) anchorsToggle.checked = true;
-        if (turnstileEnabled && window.turnstile) {
-          window.turnstile.reset();
-        }
       } catch (error) {
         setStatus(error instanceof Error ? error.message : 'Request failed. Please try again.', 'error');
       } finally {

--- a/src/components/site/Hero.astro
+++ b/src/components/site/Hero.astro
@@ -6,9 +6,9 @@ interface Props {
 }
 
 const {
-  prefix = 'AI agent for your',
-  words = ['API docs', 'tutorials', 'release notes', 'support articles', 'API docs'],
-  subtitle = 'Eliminate docs drift and automate the most painful parts of docs maintenance.',
+  prefix = 'Automatically update your',
+  words = ['screenshots', 'release notes', 'support articles', 'knowledge base', 'API docs', 'tutorials', 'how-to guides', 'screenshots'],
+  subtitle = 'AI agents that eliminate docs drift and automate the most painful parts of docs maintenance.',
 } = Astro.props;
 ---
 

--- a/src/content/website/home.mdx
+++ b/src/content/website/home.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI agent for your API docs
+title: Automatically update your docs
 description: Eliminate docs drift and automate the most painful parts of docs maintenance.
 routePath: /
 order: 1
@@ -7,10 +7,8 @@ hidden: false
 ---
 import Hero from '@components/site/Hero.astro';
 import Testimonials from '@components/site/Testimonials.astro';
-import WhyPromptless from '@components/site/WhyPromptless.astro';
 import HowItWorks from '@components/site/HowItWorks.astro';
 
 <Hero />
 <Testimonials />
 <HowItWorks />
-<WhyPromptless />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,7 +19,6 @@ const { Content } = await entry.render();
     { depth: 2, slug: 'book-a-demo', text: 'Book a demo' },
     { depth: 2, slug: 'testimonials', text: 'Testimonials' },
     { depth: 2, slug: 'how-promptless-works', text: 'How Promptless works' },
-    { depth: 2, slug: 'why-promptless', text: 'Why Promptless?' },
   ]}
   frontmatter={{
     title: entry.data.title,

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -1095,12 +1095,6 @@
   overflow: hidden;
 }
 
-.pl-free-tools-turnstile-note {
-  margin: 0;
-  color: #596275;
-  font-size: 0.82rem;
-}
-
 .pl-free-tools-actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- **Hero title**: Changed from "AI agent for your" to "Automatically update your" with expanded spinning words (screenshots, release notes, support articles, knowledge base, API docs, tutorials, how-to guides)
- **Subtitle**: Updated to "AI agents that eliminate docs drift and automate the most painful parts of docs maintenance."
- **Site title**: Changed to "Promptless | Automatic updates for your customer-facing docs"
- **Why Promptless section**: Removed from homepage (to be re-added later with improvements)
- **Captcha**: Removed Turnstile captcha from broken link checker form

## Test plan
- [ ] Verify homepage hero renders with new title and spinning words
- [ ] Check site `<title>` tag in browser tab
- [ ] Confirm WhyPromptless section is gone from homepage
- [ ] Test broken link checker form submission works without captcha

🤖 Generated with [Claude Code](https://claude.com/claude-code)