### PR TITLE
fix: update smoke test to match new homepage hero copy

### DIFF
--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -262,7 +262,7 @@ test('homepage, demo, meet, and pricing render website content', async () => {
   assert.equal(homeResponse.status, 200);
   const homeHtml = await homeResponse.text();
   assert.match(homeHtml, /pl-site-page/);
-  assert.match(homeHtml, /AI agent for your/);
+  assert.match(homeHtml, /Automatically update your/);
   assert.match(homeHtml, /How Promptless works/);
   assert.match(homeHtml, /Demo/);
   assert.match(homeHtml, /Pricing/);


### PR DESCRIPTION
## Summary
- The homepage hero copy was changed to "Automatically update your" in #254, but the smoke test still asserted the old "AI agent for your" text
- This caused the `verify` job to fail, blocking deploys

## Test plan
- [x] `npm run test:smoke` passes locally (12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)