### PR TITLE
feat: add GA4 analytics to docs site

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -62,6 +62,16 @@ export default defineConfig({
       editLink: {
         baseUrl: 'https://github.com/Promptless/docs/tree/main',
       },
+      head: [
+        {
+          tag: 'script',
+          attrs: { src: 'https://www.googletagmanager.com/gtag/js?id=G-NHEW11ZR9F', async: true },
+        },
+        {
+          tag: 'script',
+          content: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','G-NHEW11ZR9F');`,
+        },
+      ],
     }),
   ],
   vite: {


### PR DESCRIPTION
## Motivation
The docs site was migrated from Framer to Astro/Starlight but lost GA4 analytics in the process. We need to restore tracking to maintain historical data continuity with the same property ID (`G-NHEW11ZR9F`).

## Summary
- Adds GA4 (`G-NHEW11ZR9F`) to every page via Starlight's `head` config in `astro.config.mjs`
- Injects the gtag.js loader and inline config script into `<head>`
- Single-file change, no new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)