### PR TITLE
feat: add section nav chips to mobile menu

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig({
       customCss: ['./src/styles/custom.css', './src/styles/site.css'],
       sidebar: generatedSidebar,
       components: {
+        Sidebar: './src/components/starlight/Sidebar.astro',
         Header: './src/components/starlight/Header.astro',
         SiteTitle: './src/components/starlight/SiteTitle.astro',
         PageTitle: './src/components/starlight/PageTitle.astro',

--- a/src/components/starlight/Sidebar.astro
+++ b/src/components/starlight/Sidebar.astro
@@ -1,0 +1,74 @@
+---
+import MobileMenuFooter from 'virtual:starlight/components/MobileMenuFooter';
+import SidebarPersister from '@astrojs/starlight/components/SidebarPersister.astro';
+import SidebarSublist from '@astrojs/starlight/components/SidebarSublist.astro';
+import PrimaryTabs from '@components/shared/PrimaryTabs.astro';
+
+const { sidebar } = Astro.locals.starlightRoute;
+---
+
+<div class="pl-mobile-section-chips md:sl-hidden">
+  <PrimaryTabs class="pl-chip-tabs" />
+</div>
+
+<SidebarPersister>
+	<SidebarSublist sublist={sidebar} />
+</SidebarPersister>
+
+<div class="md:sl-hidden">
+	<MobileMenuFooter />
+</div>
+
+<style>
+  @layer starlight.core {
+    .pl-mobile-section-chips {
+      padding-bottom: 0.75rem;
+      margin-bottom: 0.5rem;
+      border-bottom: 1px solid var(--pl-header-border, var(--sl-color-gray-6));
+    }
+
+    .pl-mobile-section-chips :global(.pl-chip-tabs) {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      margin: 0;
+      align-items: center;
+    }
+
+    .pl-mobile-section-chips :global(.pl-chip-tabs .pl-site-tab) {
+      padding: 0.32rem 0.65rem;
+      font-size: 0.82rem;
+      font-weight: 500;
+      border: 1px solid var(--sl-color-gray-5);
+      border-radius: 999px;
+      color: var(--pl-tab-fg);
+      background: transparent;
+      white-space: nowrap;
+    }
+
+    .pl-mobile-section-chips :global(.pl-chip-tabs .pl-site-tab:hover) {
+      border-color: var(--pl-tab-fg-hover, var(--sl-color-gray-3));
+      color: var(--pl-tab-fg-hover);
+    }
+
+    .pl-mobile-section-chips :global(.pl-chip-tabs .pl-site-tab.active) {
+      background: var(--pl-tab-fg-active, #6366f1);
+      border-color: var(--pl-tab-fg-active, #6366f1);
+      color: #fff;
+    }
+
+    .pl-mobile-section-chips :global(.pl-chip-tabs .pl-site-tab::after) {
+      display: none;
+    }
+
+    .pl-mobile-section-chips :global(.pl-chip-tabs .pl-site-tab .pl-site-tab-icon) {
+      width: 0.9rem;
+      height: 0.9rem;
+      opacity: 0.8;
+    }
+
+    .pl-mobile-section-chips :global(.pl-chip-tabs .pl-site-tab.active .pl-site-tab-icon) {
+      opacity: 1;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- On mobile, primary section tabs (Docs, Blog, Changelog, etc.) were completely inaccessible — hidden behind `display: none` with no equivalent in the hamburger menu
- Adds a horizontal wrapping chip/pill row at the top of the mobile sidebar via a custom Starlight `Sidebar` component override
- Active section gets a filled background; icons are included in each chip

## Test plan
- [ ] Open docs site on mobile (or narrow viewport)
- [ ] Tap hamburger menu — section chips should appear above sidebar nav
- [ ] Verify active section is highlighted
- [ ] Verify tapping a chip navigates to the correct section
- [ ] Verify desktop layout is unchanged (chips are hidden via `md:sl-hidden`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)