### PR TITLE
fix: resolve typecheck failure in Sidebar override

### DIFF
--- a/src/components/starlight/Sidebar.astro
+++ b/src/components/starlight/Sidebar.astro
@@ -1,5 +1,5 @@
 ---
-import MobileMenuFooter from 'virtual:starlight/components/MobileMenuFooter';
+import MobileMenuFooter from './MobileMenuFooter.astro';
 import SidebarPersister from '@astrojs/starlight/components/SidebarPersister.astro';
 import SidebarSublist from '@astrojs/starlight/components/SidebarSublist.astro';
 import PrimaryTabs from '@components/shared/PrimaryTabs.astro';


### PR DESCRIPTION
## Summary
- Fixes the `astro check` typecheck failure introduced in #257
- The `virtual:starlight/components/MobileMenuFooter` import doesn't have type declarations, causing `ts(2307)`
- Replaced with a direct import of our custom `MobileMenuFooter.astro` component

## Test plan
- [ ] `astro check` passes (0 errors locally)
- [ ] Mobile menu still renders correctly with MobileMenuFooter at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)