### PR TITLE
fix: repair broken links found during pre-launch audit

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -20,6 +20,7 @@ const redirects = {
   '/use-cases': '/',
   '/faq': '/',
   '/api-reference': '/',
+  '/oss': '/docs/getting-started/promptless-oss',
   '/blog/all': '/blog',
   '/changelog/all': '/changelog',
   ...Object.fromEntries(redirectEntries),

--- a/fern/docs/security-and-privacy/index.md
+++ b/fern/docs/security-and-privacy/index.md
@@ -6,9 +6,9 @@ Promptless is committed to protecting the security and privacy of our customers'
 
 Our security documentation is organized into the following sections:
 
-- [Single Sign-On (SSO) Setup](./setup-sso.md) - Enterprise authentication via SAML 2.0 and OpenID Connect (OIDC)
-- [Compliance and Certifications](./compliance.md) - SOC 2 certification, penetration testing, audit logging, and incident notification procedures
-- [Data Handling and Security](./data-handling.md) - Details about our data security practices, authentication controls, and enterprise security features
-- [Network Architecture](./network-architecture.md) - Information about our infrastructure and security architecture
-- [Promptless Subprocessors](./subprocessors.md) - List of third-party services we use and our model-agnostic approach
-- [Privacy Policy](./privacy-policy.md) - Link to our detailed privacy policy
+- [Single Sign-On (SSO) Setup](/docs/security-and-privacy/single-sign-on-sso-setup) - Enterprise authentication via SAML 2.0 and OpenID Connect (OIDC)
+- [Compliance and Certifications](/docs/security-and-privacy/compliance-and-certifications) - SOC 2 certification, penetration testing, audit logging, and incident notification procedures
+- [Data Handling and Security](/docs/security-and-privacy/data-handling-and-classification) - Details about our data security practices, authentication controls, and enterprise security features
+- [Network Architecture](/docs/security-and-privacy/network-architecture) - Information about our infrastructure and security architecture
+- [Promptless Subprocessors](/docs/security-and-privacy/promptless-subprocessors) - List of third-party services we use and our model-agnostic approach
+- [Privacy Policy](/docs/security-and-privacy/privacy-policy) - Link to our detailed privacy policy

--- a/src/components/site/PricingCards.astro
+++ b/src/components/site/PricingCards.astro
@@ -22,7 +22,7 @@ const defaultGrowthBundle = GROWTH_BUNDLE_OPTIONS[0];
   <p class="pl-site-pricing-trial-badge">All plans include a 30-day free trial.</p>
   <p class="pl-site-pricing-intro">Pricing scales with the size and complexity of your docs site.</p>
   <p class="pl-site-pricing-oss-line">
-    Open-source, non-commercial project? <a href="https://promptless.ai/oss">Learn about our OSS program</a>.
+    Open-source, non-commercial project? <a href="https://promptless.ai/docs/getting-started/promptless-oss">Learn about our OSS program</a>.
   </p>
 
   <div class="pl-site-pricing-grid">

--- a/src/components/site/pricing/pricing.config.ts
+++ b/src/components/site/pricing/pricing.config.ts
@@ -37,7 +37,7 @@ export const GROWTH_PLAN: PricingPlanConfig = {
   title: 'Growth',
   summary: 'For teams with larger docs sites and broader integrations.',
   ctaLabel: 'Book demo',
-  ctaHref: 'https://cal.com/promptless/demo',
+  ctaHref: 'https://cal.com/team/promptless/15m-discovery-call',
 };
 
 export const ENTERPRISE_PLAN: PricingPlanConfig = {
@@ -45,7 +45,7 @@ export const ENTERPRISE_PLAN: PricingPlanConfig = {
   title: 'Enterprise',
   summary: 'For teams with massive docs sites or advanced governance needs.',
   ctaLabel: 'Book demo',
-  ctaHref: 'https://cal.com/promptless/demo',
+  ctaHref: 'https://cal.com/team/promptless/15m-discovery-call',
 };
 
 export const GROWTH_BUNDLE_OPTIONS: GrowthBundleOption[] = [

--- a/src/content/docs/docs/integrations/github-enterprise-integration.mdx
+++ b/src/content/docs/docs/integrations/github-enterprise-integration.mdx
@@ -25,7 +25,7 @@ This setup is required for GitHub Enterprise Server instances and GitHub Enterpr
 ## Prerequisites
 
 - GitHub Enterprise admin access to create and configure GitHub Apps
-- Network access to Promptless endpoints (see [IP whitelisting](#ip-whitelisting) section)
+- Network access to Promptless endpoints (see [IP whitelisting](#step-6-ip-whitelisting) section)
 - Ability to generate and securely store private keys and client secrets
 
 ## Step 1: Register New GitHub App

--- a/src/content/docs/docs/security-and-privacy/privacy-policy.mdx
+++ b/src/content/docs/docs/security-and-privacy/privacy-policy.mdx
@@ -19,7 +19,7 @@ Our privacy policy covers important aspects of data handling, including:
 ## Complete Privacy Policy
 
 For the complete, current version of our privacy policy, please visit:
-[Promptless Privacy Policy](https://www.gopromptless.ai/privacy)
+[Promptless Privacy Policy](https://promptless.ai/privacy)
 
 ## Privacy Inquiries
 

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -303,7 +303,7 @@ test('homepage, demo, meet, and pricing render website content', async () => {
   assert.match(pricingHtml, /2,000-5,000 Pages/);
   assert.match(pricingHtml, /Slack \+ GitHub integrations/);
   assert.match(pricingHtml, /Open-source, non-commercial project\?/);
-  assert.match(pricingHtml, /href=\"https:\/\/promptless\.ai\/oss\"/);
+  assert.match(pricingHtml, /href=\"https:\/\/promptless\.ai\/docs\/getting-started\/promptless-oss\"/);
   assert.match(pricingHtml, /Book demo/);
   assert.doesNotMatch(pricingHtml, /<h3>Compare plans<\/h3>/);
 });


### PR DESCRIPTION
## Summary
- Fix 6 `.md` relative links in the security-and-privacy index page that were 404ing — replaced with absolute paths matching actual page slugs
- Update privacy policy link from old `www.gopromptless.ai/privacy` domain to `promptless.ai/privacy`
- Fix cal.com demo links on pricing page (Growth + Enterprise) to correct `/team/promptless/15m-discovery-call` URL
- Update `/oss` link on pricing to `/docs/getting-started/promptless-oss` and add a redirect in `astro.config.mjs` for any external links to `/oss`
- Fix `#ip-whitelisting` anchor on GHE integration page to match actual heading ID (`#step-6-ip-whitelisting`)
- Update smoke test assertion for new OSS link

## Test plan
- [ ] Verify security-and-privacy landing page links all resolve
- [ ] Verify privacy policy page links to `promptless.ai/privacy`
- [ ] Verify pricing page "Book demo" buttons go to correct cal.com link
- [ ] Verify `/oss` redirects to `/docs/getting-started/promptless-oss`
- [ ] Verify IP whitelisting anchor link works on GHE integration page
- [ ] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)