### PR TITLE
fix: Book demo button text invisible in mobile nav

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -369,6 +369,14 @@ starlight-theme-select {
   mask-image: url('/site/icons/meet.svg');
 }
 
+.sidebar-content .pl-mobile-menu-primary {
+  color: #fff;
+}
+
+.sidebar-content .pl-mobile-menu-primary:hover {
+  color: #fff;
+}
+
 .sidebar-content details > summary .caret {
   color: color-mix(in srgb, var(--sl-color-text) 40%, #9ca3af);
 }


### PR DESCRIPTION
## Summary
- The "Book demo" button in the mobile sidebar menu had invisible (dark) text on a dark background
- Root cause: the unlayered `.sidebar-content a[href]` rule in `custom.css` was overriding `color: #fff` set inside `@layer starlight.core` on `.pl-mobile-menu-primary` due to CSS cascade layer precedence
- Fix: add an unlayered `.sidebar-content .pl-mobile-menu-primary` rule to ensure white text wins the cascade

## Test plan
- [ ] Open mobile nav on any docs page — "Book demo" button should show white text on dark background
- [ ] Hover state should also remain white text

🤖 Generated with [Claude Code](https://claude.com/claude-code)