### PR TITLE
Fix sidebar visual hierarchy and right sidebar overflow

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -310,6 +310,22 @@ starlight-theme-select {
   text-transform: uppercase;
 }
 
+/* Nested group headers (e.g. Triggers, Context Sources) — tone down to match links */
+.sidebar-content details details > summary {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: color-mix(in srgb, var(--sl-color-text) 84%, #374151);
+  padding: 0.42rem 0.58rem;
+}
+
+.sidebar-content details details > summary .large {
+  font-size: inherit;
+  font-weight: inherit;
+  color: inherit;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
 .sidebar-content a[href] {
   border-radius: 0.5rem;
   color: color-mix(in srgb, var(--sl-color-text) 84%, #374151);
@@ -394,6 +410,13 @@ starlight-theme-select {
   font-size: 0.68rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+/* Hide right sidebar until viewport is wide enough for full layout */
+@media (max-width: 87.99rem) {
+  .right-sidebar-container {
+    display: none;
+  }
 }
 
 .right-sidebar-panel a {


### PR DESCRIPTION
## Summary
- Tone down nested sidebar group headers (Triggers, Context Sources, Doc Collections) to match regular link styling instead of appearing as prominent section headers
- Hide the "On this page" right sidebar at viewports below 88rem where the layout doesn't have enough space, preventing text overflow/clipping

## Test plan
- [ ] Verify nested sidebar groups under "Configuring Promptless" look less prominent
- [ ] Resize browser to ~1152px and confirm right sidebar is hidden
- [ ] Resize browser to ~1408px+ and confirm right sidebar appears normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)