### PR TITLE
fix: hero rotating words animation and add new terms

### DIFF
--- a/src/components/site/Hero.astro
+++ b/src/components/site/Hero.astro
@@ -7,7 +7,7 @@ interface Props {
 
 const {
   prefix = 'Automatically update your',
-  words = ['screenshots', 'release notes', 'support articles', 'knowledge base', 'API docs', 'tutorials', 'how-to guides', 'screenshots'],
+  words = ['customer docs', 'screenshots', 'release notes', 'developer docs', 'support articles', 'knowledge base', 'API docs', 'changelogs', 'tutorials', 'code examples', 'how-to guides', 'customer docs'],
   subtitle = 'AI agents that eliminate docs drift and automate the most painful parts of docs maintenance.',
 } = Astro.props;
 ---

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -31,29 +31,56 @@
 }
 
 .pl-site-hero-words > span {
-  animation: pl-site-word-loop 8s linear infinite;
+  animation: pl-site-word-loop 22s linear infinite;
 }
 
 @keyframes pl-site-word-loop {
   0%,
-  18% {
+  7% {
     transform: translateY(0%);
   }
-  23%,
-  41% {
+  9%,
+  16% {
     transform: translateY(-100%);
   }
-  46%,
-  64% {
+  18%,
+  25% {
     transform: translateY(-200%);
   }
-  69%,
-  87% {
+  27%,
+  34% {
     transform: translateY(-300%);
   }
-  92%,
-  100% {
+  36%,
+  43% {
     transform: translateY(-400%);
+  }
+  45%,
+  52% {
+    transform: translateY(-500%);
+  }
+  55%,
+  62% {
+    transform: translateY(-600%);
+  }
+  64%,
+  71% {
+    transform: translateY(-700%);
+  }
+  73%,
+  80% {
+    transform: translateY(-800%);
+  }
+  82%,
+  89% {
+    transform: translateY(-900%);
+  }
+  91%,
+  98% {
+    transform: translateY(-1000%);
+  }
+  100% {
+    transform: translateY(-1100%);
   }
 }
 


### PR DESCRIPTION
## Motivation
The hero section's rotating word animation was broken — it only cycled through 5 of 8 words, so it never showed "tutorials", "how-to guides", or the final "screenshots". This caused a jarring jump when the animation looped. Also wanted to expand the word list with more doc types.

## Summary
- **Fixed animation**: Updated CSS keyframes to cycle through all words with seamless looping (duplicate first/last word so the restart is invisible)
- **Added new terms**: customer docs, developer docs, changelogs, code examples — spread throughout the rotation for variety
- **Adjusted timing**: Duration scaled from 8s → 22s to maintain ~2s per word with 12 total words

🤖 Generated with [Claude Code](https://claude.com/claude-code)