### PR TITLE
Add blog post: Writing code was hard, actually

### DIFF
--- a/src/content/blog/technical/writing-code-was-hard-actually.mdx
+++ b/src/content/blog/technical/writing-code-was-hard-actually.mdx
@@ -1,0 +1,59 @@
+---
+title: Writing code was hard, actually
+subtitle: Published February 2026
+description: >-
+  The revisionist claim that writing code was never the hard part arrives
+  conveniently at the moment AI makes it cheap to produce. But the market, the
+  machine, and the engineers who built it all tell a different story.
+date: '2026-02-24T00:00:00.000Z'
+section: Technical
+hidden: false
+---
+
+Every few days, someone important posts a version of "writing code was never the hard part." Engineers are describing changes in plain English and Claude Code writes the code. Non-technical people are building real products without touching a line of code. The hard part, we're told, was always understanding what to build, not building it. Understanding requirements, designing systems, communicating with stakeholders. The code? That was the easy bit.
+
+This is revisionism. It is convenient revisionism, because it arrives at exactly the moment that AI tools are making code free to produce, and it flatters exactly the people who never wrote any. But it is revisionism all the same.
+
+## The timing gives it away
+
+If writing code was never the hard part, someone should have been saying this in 2018. The requirements problem existed then. System design existed then. But nobody was writing blog posts about how coding was a trivial formality, because it obviously wasn't.
+
+What actually happened is that teams of PhD researchers spent decades on language modeling, and the technique only started working once compute hit a massive scale—gigawatts of power, purpose-built supercomputers, billions of dollars in investment converging with decades of algorithmic research to partially automate code generation.
+
+That's not evidence the task was easy. That's evidence it was so hard that it took one of the largest concentrations of capital and talent in human history to make a dent in it.
+
+## The machine is the proof
+
+If writing code were easy, you would not need the machine.
+
+You don't spend billions of dollars training a model on purpose-built supercomputers to automate something trivial. The very existence of the tool is proof that the task was hard. That's what tools are _for_. And this particular tool is among the most complex artifacts humanity has ever produced.
+
+Can you describe the chip architecture, power delivery, and network topology required to run the coding tool you're using to declare that coding was never hard? The machine that makes coding look easy is itself a miracle of engineering that virtually nobody on Earth fully understands end to end. That's a funny kind of "easy."
+
+## The market was not confused
+
+For thirty years, companies fought over software engineers. Salaries climbed steadily. Entire recruiting industries existed just to find people who could do the job. Was the market wrong this entire time? The "never the hard part" crowd has to pick one: either the labor market was wildly irrational for three decades, or writing software was in fact hard.
+
+## The engineers built the thing
+
+Here's what really gets me about this narrative. It's not like a bunch of outsiders looked over at software engineers and thought, "those lazy bastards soaking up all that pay for easy work—let's build AI to expose them." Coal miners did not do this. Management consultants did not do this. The people who built LLMs are software engineers. Researchers who write code. Infrastructure teams who write code. ML engineers who write code. They spent their careers mastering the skill, and then used that mastery to partially automate it.
+
+When robotics engineers build a robot that welds car frames, we don't say welding was never the hard part. We say they solved a hard problem. The same logic applies here, and the only reason people don't apply it is because there's a narrative incentive not to.
+
+## Just say what you mean
+
+There's a real observation underneath all the revisionism. The economic value of writing code, in isolation, is declining. AI tools are making it cheaper and faster to produce working software. The mix of skills that makes an engineer valuable is shifting. Those are true, defensible claims.
+
+But that's not what people are saying. They're reaching backward in time to retroactively trivialize the skill. There's an enormous difference between "this skill is becoming less scarce" and "this skill was never impressive." One is an honest market assessment. The other is rewriting history.
+
+It's like looking at a nineteen-year-old who graduated Harvard three years early and saying "why would I hire this person? They've never run an investment bank. Lacrosse? Model UN? Useless." Sure, but when they were thirteen, they were better than every other thirteen-year-old in the country. That's what the resume means. You have to read it in context.
+
+That's what's happening here. A generation of engineers built the modern digital world, and now the beneficiaries of that work are looking back and saying it wasn't impressive. It was.
+
+## Now coding is solved. So what?
+
+Coding is solved. Today it is not the hard part. Fair enough.
+
+But as we adapt, it's worth remembering who made the machine. Not the executives. Not the thought leaders. Engineers made it. The same people now being called trivial built the tool being used to call them trivial. That should give everyone pause.
+
+The engineers who built the modern digital world aren't suddenly less capable because their hardest problem got automated. If anything, they're the ones best positioned to tackle what comes next. They've already proven they can do hard things. Now they have better tools.


### PR DESCRIPTION
## Summary
- Adds a new technical blog post: "Writing code was hard, actually"
- Pushes back on the revisionist narrative that writing code was never the hard part, arguing that the timing, the market, the machine itself, and the engineers who built it all tell a different story
- Located at `/blog/technical/writing-code-was-hard-actually`

## Test plan
- [ ] Verify the post renders correctly at `/blog/technical/writing-code-was-hard-actually`
- [ ] Verify it appears on the blog listing page with correct date, section tag, and description
- [ ] Check formatting of headings, italics, and em dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)