### PR TITLE
Add author field and Opinion section to blog post

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -13,6 +13,7 @@ const blog = defineCollection({
     title: z.string(),
     description: z.string(),
     subtitle: z.string().optional(),
+    author: z.string().optional(),
     section: z.string().optional(),
     date: z.coerce.date(),
     hidden: z.boolean().optional().default(false),

--- a/src/content/blog/technical/writing-code-was-hard-actually.mdx
+++ b/src/content/blog/technical/writing-code-was-hard-actually.mdx
@@ -5,8 +5,9 @@ description: >-
   The revisionist claim that writing code was never the hard part arrives
   conveniently at the moment AI makes it cheap to produce. But the market, the
   machine, and the engineers who built it all tell a different story.
+author: InlinePizza
 date: '2026-02-24T00:00:00.000Z'
-section: Technical
+section: Opinion
 hidden: false
 ---
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -27,6 +27,9 @@ const { Content, headings } = await render(entry);
   <p class="collection-back-link">
     <a href="/blog">← Back to Blog</a>
   </p>
+  {entry.data.author && (
+    <p class="collection-post-author">By {entry.data.author}</p>
+  )}
   <Content />
   <p class="collection-back-link collection-back-link-bottom">
     <a href="/blog">← Back to Blog</a>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -42,6 +42,9 @@ const getSectionLabel = (section?: string) => section || 'Other';
               <h2 class="collection-feed-title">
                 <a href={`/blog/${entry.slug}`}>{entry.data.title}</a>
               </h2>
+              {entry.data.author && (
+                <p class="collection-feed-author">By {entry.data.author}</p>
+              )}
               {(entry.data.description || entry.data.subtitle) && (
                 <p class="collection-feed-description">{entry.data.description || entry.data.subtitle}</p>
               )}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -642,6 +642,20 @@ main:has(.pl-site-page.pl-site-page-compact) .content-panel + .content-panel {
   text-decoration: underline;
 }
 
+.collection-feed-author {
+  margin: 0;
+  color: var(--sl-color-gray-3);
+  font-size: var(--sl-text-xs);
+  font-weight: 500;
+}
+
+.collection-post-author {
+  margin: 0 0 1.5rem;
+  color: var(--sl-color-gray-3);
+  font-size: var(--sl-text-sm);
+  font-weight: 500;
+}
+
 .collection-feed-description {
   margin: 0;
   max-width: 72ch;


### PR DESCRIPTION
Add optional author field to blog schema and display it on both the listing and individual post pages. Update the new blog post with author "InlinePizza" and section "Opinion".