### PR TITLE
feat: Add docs debt quiz and idle modal

### DIFF
--- a/src/components/site/DocsDebtModal.module.css
+++ b/src/components/site/DocsDebtModal.module.css
@@ -1,0 +1,251 @@
+/* Overlay */
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  overflow-y: auto;
+  justify-content: center;
+  background: rgba(212, 212, 212, 0.7);
+  padding: 1rem;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  animation: fadeIn 0.25s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Centering wrapper */
+.wrapper {
+  padding: 2rem 0;
+  margin: auto;
+  max-width: 32rem;
+  width: 100%;
+}
+
+/* Card */
+.card {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  padding: 1.25rem 1.5rem 1.5rem;
+  box-shadow: 0 25px 50px -12px rgba(28, 25, 23, 0.15);
+  border-radius: 0.75rem;
+  animation: slideUp 0.3s ease;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Close button */
+.close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 0;
+  background: transparent;
+  color: #a3a3a3;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  padding: 0;
+}
+
+.close:hover {
+  background: #f5f5f5;
+  color: #171717;
+}
+
+.close svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+/* Kicker */
+.kicker {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: #65a30d;
+}
+
+/* Heading */
+.heading {
+  margin: 0.75rem 0 0;
+  font-size: 1.65rem;
+  font-weight: 500;
+  color: #171717;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+/* Body text */
+.bodyText {
+  margin: 1rem 0 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #525252;
+}
+
+.bodyText + .bodyText {
+  margin-top: 0.75rem;
+}
+
+/* Selling points */
+.points {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.point {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pointIcon {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.pointText {
+  font-size: 1rem;
+  color: #525252;
+}
+
+/* Form */
+.form {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.emailInput {
+  width: 100%;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  background: #fff;
+  padding: 0.7rem 0.9rem;
+  font: inherit;
+  font-size: 0.9375rem;
+  color: #171717;
+  transition: border-color 0.15s;
+}
+
+.emailInput::placeholder {
+  color: #a3a3a3;
+}
+
+.emailInput:focus {
+  outline: none;
+  border-color: #171717;
+}
+
+/* CTA button */
+.cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  border: 0;
+  border-radius: 0.625rem;
+  background: linear-gradient(to bottom, #171717, #0a0a0a);
+  color: #fff;
+  font: inherit;
+  font-size: 1rem;
+  font-weight: 700;
+  padding: 0.85rem 1.5rem;
+  cursor: pointer;
+  transition: transform 0.15s;
+}
+
+.cta:hover {
+  transform: scale(1.02);
+}
+
+.cta:active {
+  transform: scale(0.98);
+}
+
+/* Disclaimer */
+.disclaimer {
+  margin: 1rem 0 0;
+  text-align: center;
+  font-size: 0.8rem;
+  color: #a3a3a3;
+}
+
+/* Responsive */
+@media (min-width: 640px) {
+  .card {
+    padding: 2rem;
+  }
+
+  .kicker {
+    font-size: 0.8rem;
+  }
+
+  .heading {
+    margin-top: 1rem;
+    font-size: 2rem;
+  }
+
+  .bodyText {
+    margin-top: 1.25rem;
+    font-size: 1.1rem;
+  }
+
+  .bodyText + .bodyText {
+    margin-top: 0.85rem;
+  }
+
+  .points {
+    margin-top: 1.75rem;
+    gap: 1rem;
+  }
+
+  .pointIcon {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  .pointText {
+    font-size: 1.1rem;
+  }
+
+  .form {
+    margin-top: 1.75rem;
+  }
+
+  .emailInput {
+    padding: 0.8rem 1rem;
+    font-size: 1rem;
+  }
+
+  .disclaimer {
+    font-size: 0.84rem;
+  }
+}

--- a/src/components/site/DocsDebtModal.tsx
+++ b/src/components/site/DocsDebtModal.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './DocsDebtModal.module.css';
+
+const IDLE_MS = 30_000; // 30 seconds of inactivity
+const DISMISS_KEY = 'pl_docs_debt_modal_dismissed';
+
+function ClockIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      className={styles.pointIcon}
+      style={{ color: '#0ea5e9' }}
+    >
+      <path
+        opacity="0.4"
+        d="M1.25 12C1.25 6.063 6.063 1.25 12 1.25S22.75 6.063 22.75 12 17.937 22.75 12 22.75 1.25 17.937 1.25 12Z"
+        fill="currentColor"
+      />
+      <path
+        d="M12 7a1 1 0 0 1 1 1v3.586l1.707 1.707a1 1 0 0 1-1.414 1.414l-2-2A1 1 0 0 1 11 12V8a1 1 0 0 1 1-1Z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+function WarningIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      className={styles.pointIcon}
+      style={{ color: '#f59e0b' }}
+    >
+      <path
+        opacity="0.4"
+        d="M14.911 3.965C14.083 2.946 13.185 2.25 12 2.25c-1.185 0-2.083.696-2.911 1.715-.618.76-1.27 1.791-2.033 3.06l-.8 1.346-1.925 3.245-.048.08C3.135 13.634 2.228 15.162 1.724 16.395c-.514 1.255-.699 2.41-.1 3.468l.118.192c.619.92 1.651 1.312 2.907 1.499C5.967 21.75 7.747 21.75 10.002 21.75h13.996c2.255 0 4.035 0 5.353-.196 1.339-.2 2.425-.633 3.025-1.691l.103-.2c.472-1.002.279-2.092-.203-3.269-.383-.938-.999-2.046-1.777-3.375l-.83-1.403-1.925-3.245-.046-.078C16.595 6.434 15.723 4.963 14.911 3.965Z"
+        fill="currentColor"
+      />
+      <path
+        d="M11 17v-4.5a1 1 0 1 1 2 0V17a1 1 0 1 1-2 0ZM11 9v-.012a1 1 0 1 1 2 0V9a1 1 0 1 1-2 0Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function EnvelopeIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      className={styles.pointIcon}
+      style={{ color: '#84cc16' }}
+    >
+      <path
+        d="M1.268 10.662c.031-1.466.057-2.677.227-3.658l2.249 1.157c-.1-.035-.178-.038-.248 0-.147.08-.157.283-.176.689a35 35 0 0 0-.057 1.93 68 68 0 0 0 0 2.44c.034 1.56.059 2.619.2 3.434.134.767.356 1.224.737 1.605.377.378.84.604 1.633.742.838.146 1.931.176 3.534.216 1.922.048 3.342.048 5.264 0 1.603-.04 2.696-.07 3.535-.216.793-.138 1.255-.365 1.632-.742.381-.382.603-.838.737-1.606.141-.815.167-1.874.2-3.434.02-.97.02-1.471 0-2.44a35 35 0 0 0-.057-1.93c-.02-.405-.03-.608-.176-.689-.07-.038-.148-.035-.248 0l2.249-1.158c.17.982.196 2.193.227 3.658l.002.075a68 68 0 0 1 0 2.526l-.002.075c-.031 1.466-.057 2.677-.227 3.658-.182 1.045-.541 1.921-1.29 2.672-.754.755-1.643 1.115-2.706 1.3-1.001.174-2.243.205-3.752.243l-.075.002c-1.956.05-3.409.05-5.365 0l-.075-.001c-1.51-.039-2.751-.07-3.752-.244-1.063-.185-1.952-.545-2.706-1.3-.75-.751-1.108-1.627-1.29-2.672-.17-.981-.196-2.192-.227-3.658l-.002-.075a68 68 0 0 1 0-2.526l.002-.075Z"
+        fill="currentColor"
+      />
+      <path
+        opacity="0.4"
+        d="M9.319 2.787a68 68 0 0 1 5.364 0l.075.001c1.51.039 2.751.07 3.752.244.37.064.72.15 1.05.267a1 1 0 0 1 .25.096c.516.214.982.513 1.406.937.749.751 1.108 1.627 1.29 2.672l-2.25 1.157a1 1 0 0 1-.44.226l-4.235 2.4c-1.3.736-2.4 1.213-3.58 1.213-1.182 0-2.28-.477-3.58-1.213l-4.236-2.4a1 1 0 0 1-.44-.226L1.496 7.004c.182-1.045.54-1.921 1.29-2.672.46-.462.953-.756 1.468-.97a1 1 0 0 1 .24-.09c.33-.117.68-.203 1.05-.267 1.001-.174 2.243-.205 3.752-.243l.075-.002Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+interface DocsDebtModalProps {
+  forceShow?: boolean;
+}
+
+export default function DocsDebtModal({ forceShow = false }: DocsDebtModalProps) {
+  const [visible, setVisible] = useState(forceShow);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const dismiss = useCallback(() => {
+    setVisible(false);
+    try {
+      sessionStorage.setItem(DISMISS_KEY, '1');
+    } catch {
+      // storage full or unavailable
+    }
+  }, []);
+
+  // Sync with forceShow prop changes
+  useEffect(() => {
+    if (forceShow) setVisible(true);
+  }, [forceShow]);
+
+  useEffect(() => {
+    // Skip idle timer if using forceShow
+    if (forceShow) return;
+
+    // Don't show if already dismissed this session
+    try {
+      if (sessionStorage.getItem(DISMISS_KEY)) return;
+    } catch {
+      // proceed if storage unavailable
+    }
+
+    const resetTimer = () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setVisible(true), IDLE_MS);
+    };
+
+    const events = ['mousemove', 'keydown', 'scroll', 'touchstart', 'click'] as const;
+    events.forEach((e) => window.addEventListener(e, resetTimer, { passive: true }));
+    resetTimer();
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      events.forEach((e) => window.removeEventListener(e, resetTimer));
+    };
+  }, [forceShow]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!visible) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') dismiss();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [visible, dismiss]);
+
+  // Lock body scroll
+  useEffect(() => {
+    if (!visible) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [visible]);
+
+  if (!visible) return null;
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const email = new FormData(form).get('email') as string;
+    const params = email ? `?email=${encodeURIComponent(email.trim())}` : '';
+    dismiss();
+    window.location.href = `/free-tools/docs-debt-quiz${params}`;
+  };
+
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) dismiss();
+  };
+
+  return createPortal(
+    <div
+      className={styles.overlay}
+      role="dialog"
+      aria-modal="true"
+      onClick={handleOverlayClick}
+    >
+      <div className={styles.wrapper}>
+        <div className={styles.card}>
+          <button
+            className={styles.close}
+            onClick={dismiss}
+            aria-label="Close"
+          >
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+
+          <span className={styles.kicker}>Docs health check</span>
+          <h1 className={styles.heading}>
+            Your help center is out of date.
+          </h1>
+          <p className={styles.bodyText}>
+            You know it. Your support team knows it. Your customers definitely
+            know it.
+          </p>
+          <p className={styles.bodyText}>
+            Take a minute to find out how bad it is, and get a free checklist to
+            fix it.
+          </p>
+
+          <div className={styles.points}>
+            <div className={styles.point}>
+              <ClockIcon />
+              <span className={styles.pointText}>7 questions, 1 minute</span>
+            </div>
+            <div className={styles.point}>
+              <WarningIcon />
+              <span className={styles.pointText}>
+                See where you actually stand
+              </span>
+            </div>
+            <div className={styles.point}>
+              <EnvelopeIcon />
+              <span className={styles.pointText}>
+                Get a checklist to fix it this week
+              </span>
+            </div>
+          </div>
+
+          <form className={styles.form} onSubmit={handleSubmit}>
+            <input
+              type="email"
+              name="email"
+              placeholder="you@company.com"
+              required
+              className={styles.emailInput}
+              autoComplete="email"
+            />
+            <button type="submit" className={styles.cta}>
+              Take the Quiz
+            </button>
+          </form>
+
+          <p className={styles.disclaimer}>
+            No spam. Unsubscribe anytime.
+          </p>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/site/DocsDebtQuiz.tsx
+++ b/src/components/site/DocsDebtQuiz.tsx
@@ -1,0 +1,277 @@
+import { useState } from 'react';
+
+interface QuizOption {
+  label: string;
+  score: number;
+}
+
+interface QuizQuestion {
+  question: string;
+  options: QuizOption[];
+}
+
+interface QuizResult {
+  range: [number, number];
+  title: string;
+  summary: string;
+  tips: string[];
+}
+
+const questions: QuizQuestion[] = [
+  {
+    question: 'How many people work on your product?',
+    options: [
+      { label: 'Just me', score: 1 },
+      { label: '2\u20134 people', score: 2 },
+      { label: '5\u201310 people', score: 3 },
+      { label: '10+', score: 4 },
+    ],
+  },
+  {
+    question: 'How often do you ship product updates?',
+    options: [
+      { label: 'Weekly or more', score: 4 },
+      { label: 'Every 2 weeks', score: 3 },
+      { label: 'Monthly', score: 2 },
+      { label: 'Seldom', score: 1 },
+    ],
+  },
+  {
+    question: 'When was the last time someone reviewed your docs end-to-end?',
+    options: [
+      { label: 'This month', score: 1 },
+      { label: 'This quarter', score: 2 },
+      { label: 'This year', score: 3 },
+      { label: 'I honestly don\u2019t know', score: 4 },
+    ],
+  },
+  {
+    question: 'How do you find out about broken or outdated docs?',
+    options: [
+      { label: 'Automated tests or monitoring', score: 1 },
+      { label: 'Regular manual reviews', score: 2 },
+      { label: 'When a customer complains', score: 3 },
+      { label: 'Usually by accident', score: 4 },
+    ],
+  },
+  {
+    question: 'How confident are you that your docs match the current product?',
+    options: [
+      { label: 'Very confident', score: 1 },
+      { label: 'Mostly confident', score: 2 },
+      { label: 'Not very confident', score: 3 },
+      { label: 'I\u2019d rather not check', score: 4 },
+    ],
+  },
+  {
+    question: 'Who is responsible for keeping docs up to date?',
+    options: [
+      { label: 'A dedicated docs team or tech writer', score: 1 },
+      { label: 'Developers update docs alongside code', score: 2 },
+      { label: 'It\u2019s supposed to be everyone, but nobody really owns it', score: 3 },
+      { label: 'Nobody, specifically', score: 4 },
+    ],
+  },
+  {
+    question: 'How many pages of documentation do you have?',
+    options: [
+      { label: 'Under 20', score: 1 },
+      { label: '20\u2013100', score: 2 },
+      { label: '100\u2013500', score: 3 },
+      { label: '500+', score: 4 },
+    ],
+  },
+];
+
+const results: QuizResult[] = [
+  {
+    range: [7, 12],
+    title: 'Low docs debt',
+    summary:
+      'Your documentation seems to be in good shape. You have processes in place and a manageable scope. Keep it up!',
+    tips: [
+      'Set up automated broken link checks to catch issues early.',
+      'Schedule a quarterly docs review to stay ahead of drift.',
+    ],
+  },
+  {
+    range: [13, 18],
+    title: 'Moderate docs debt',
+    summary:
+      'There are some cracks starting to show. Things are mostly working, but a few gaps could snowball as your product grows.',
+    tips: [
+      'Audit your highest-traffic pages for accuracy first.',
+      'Add docs updates to your shipping checklist for each release.',
+      'Consider assigning an owner for docs quality.',
+    ],
+  },
+  {
+    range: [19, 23],
+    title: 'Significant docs debt',
+    summary:
+      'Your docs are falling behind your product. Customers are likely running into outdated or missing information regularly.',
+    tips: [
+      'Prioritize a docs audit on your top 20 most-visited pages.',
+      'Tie docs updates to your release process so new features ship with current docs.',
+      'Look into automation tools to detect docs drift before customers do.',
+    ],
+  },
+  {
+    range: [24, 28],
+    title: 'Critical docs debt',
+    summary:
+      'Your documentation needs urgent attention. At this level, outdated docs are likely causing support tickets, slowing onboarding, and hurting trust.',
+    tips: [
+      'Start with a broken link audit to find the worst offenders.',
+      'Assign a dedicated owner or team to tackle the backlog.',
+      'Invest in tooling that keeps docs in sync with your codebase automatically.',
+    ],
+  },
+];
+
+function getResult(score: number): QuizResult {
+  for (const r of results) {
+    if (score >= r.range[0] && score <= r.range[1]) return r;
+  }
+  return results[results.length - 1];
+}
+
+export default function DocsDebtQuiz() {
+  const [currentQuestion, setCurrentQuestion] = useState(0);
+  const [answers, setAnswers] = useState<(number | null)[]>(
+    () => new Array(questions.length).fill(null),
+  );
+  const [showResult, setShowResult] = useState(false);
+
+  const progress = showResult
+    ? 100
+    : ((currentQuestion + 1) / (questions.length + 1)) * 100;
+
+  const handleSelect = (score: number) => {
+    const next = [...answers];
+    next[currentQuestion] = score;
+    setAnswers(next);
+
+    // Auto-advance after short delay
+    setTimeout(() => {
+      if (currentQuestion < questions.length - 1) {
+        setCurrentQuestion(currentQuestion + 1);
+      } else {
+        setShowResult(true);
+      }
+    }, 200);
+  };
+
+  const handleBack = () => {
+    if (showResult) {
+      setShowResult(false);
+    } else if (currentQuestion > 0) {
+      setCurrentQuestion(currentQuestion - 1);
+    }
+  };
+
+  const handleRestart = () => {
+    setCurrentQuestion(0);
+    setAnswers(new Array(questions.length).fill(null));
+    setShowResult(false);
+  };
+
+  const totalScore = answers.reduce<number>((sum, a) => sum + (a ?? 0), 0);
+  const result = getResult(totalScore);
+
+  const q = questions[currentQuestion];
+
+  return (
+    <div className="pl-quiz-backdrop">
+      <div className="pl-quiz-container">
+        <div className="pl-quiz-card">
+          {/* Progress bar */}
+          <div className="pl-quiz-progress-track">
+            <div
+              className="pl-quiz-progress-bar"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+
+          {/* Header */}
+          <div className="pl-quiz-header">
+            <a href="/" className="pl-quiz-logo">
+              <img
+                alt=""
+                src="/favicon.ico"
+                className="pl-quiz-logo-img"
+                width={18}
+                height={18}
+              />
+              <span className="pl-quiz-logo-text">Promptless</span>
+            </a>
+            {!showResult && currentQuestion > 0 && (
+              <button
+                className="pl-quiz-back"
+                onClick={handleBack}
+                aria-label="Back"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.5"
+                >
+                  <path d="M15 6C15 6 9.00001 10.4189 9 12C8.99999 13.5812 15 18 15 18" />
+                </svg>
+                <span>Back</span>
+              </button>
+            )}
+          </div>
+
+          {/* Body */}
+          {!showResult ? (
+            <div className="pl-quiz-body">
+              <h2 className="pl-quiz-question">{q.question}</h2>
+              <div className="pl-quiz-options">
+                {q.options.map((opt) => (
+                  <button
+                    key={opt.label}
+                    className={`pl-quiz-option ${answers[currentQuestion] === opt.score ? 'is-selected' : ''}`}
+                    onClick={() => handleSelect(opt.score)}
+                  >
+                    <span>{opt.label}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="pl-quiz-body">
+              <div className="pl-quiz-result-badge" data-level={result.title}>
+                Score: {totalScore} / {questions.length * 4}
+              </div>
+              <h2 className="pl-quiz-question">{result.title}</h2>
+              <p className="pl-quiz-result-summary">{result.summary}</p>
+              <div className="pl-quiz-result-tips">
+                <h3>What to do next</h3>
+                <ul>
+                  {result.tips.map((tip) => (
+                    <li key={tip}>{tip}</li>
+                  ))}
+                </ul>
+              </div>
+              <div className="pl-quiz-result-actions">
+                <button className="pl-quiz-restart" onClick={handleRestart}>
+                  Retake quiz
+                </button>
+                <a className="pl-quiz-cta" href="/free-tools/broken-link-report">
+                  Run a free broken link report
+                </a>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/site/DocsDebtQuizWithDebug.tsx
+++ b/src/components/site/DocsDebtQuizWithDebug.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import DocsDebtQuiz from './DocsDebtQuiz';
+import DocsDebtModal from './DocsDebtModal';
+
+export default function DocsDebtQuizWithDebug() {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => {
+          sessionStorage.removeItem('pl_docs_debt_modal_dismissed');
+          setShowModal(true);
+        }}
+        style={{
+          marginBottom: '1rem',
+          padding: '0.5rem 0.85rem',
+          border: '1px dashed #d4d4d4',
+          borderRadius: '0.4rem',
+          background: '#fafafa',
+          color: '#737373',
+          fontSize: '0.8rem',
+          cursor: 'pointer',
+        }}
+      >
+        Debug: Show idle modal
+      </button>
+      <DocsDebtQuiz />
+      {showModal && <DocsDebtModal forceShow />}
+    </>
+  );
+}

--- a/src/content/website/docs-debt-quiz.mdx
+++ b/src/content/website/docs-debt-quiz.mdx
@@ -1,0 +1,12 @@
+---
+title: Docs Debt Quiz
+description: Find out how much documentation debt your team is carrying with this quick 7-question quiz.
+routePath: /free-tools/docs-debt-quiz
+order: 7
+hidden: false
+---
+import DocsDebtQuizWithDebug from '@components/site/DocsDebtQuizWithDebug.tsx';
+
+Answer 7 quick questions to find out how much documentation debt your team is carrying — and what to do about it.
+
+<DocsDebtQuizWithDebug client:load />

--- a/src/content/website/free-tools.mdx
+++ b/src/content/website/free-tools.mdx
@@ -17,4 +17,9 @@ import FreeToolCard from '@components/site/FreeToolCard.astro';
     description="Scan your site and get a broken-link report by email."
     href="/free-tools/broken-link-report"
   />
+  <FreeToolCard
+    title="Docs Debt Quiz"
+    description="Find out how much documentation debt your team is carrying."
+    href="/free-tools/docs-debt-quiz"
+  />
 </div>

--- a/src/lib/free-tools-navigation.ts
+++ b/src/lib/free-tools-navigation.ts
@@ -1,4 +1,4 @@
-export type FreeToolPageId = 'overview' | 'broken_link_report';
+export type FreeToolPageId = 'overview' | 'broken_link_report' | 'docs_debt_quiz';
 
 export interface FreeToolNavItem {
   id: FreeToolPageId;
@@ -14,6 +14,7 @@ interface FreeToolsSidebarLink {
 export const FREE_TOOLS_NAV_ITEMS: FreeToolNavItem[] = [
   { id: 'overview', href: '/free-tools', label: 'Overview' },
   { id: 'broken_link_report', href: '/free-tools/broken-link-report', label: 'Broken Link Report' },
+  { id: 'docs_debt_quiz', href: '/free-tools/docs-debt-quiz', label: 'Docs Debt Quiz' },
 ];
 
 export function getFreeToolsSidebarLinks(): FreeToolsSidebarLink[] {

--- a/src/pages/free-tools/docs-debt-quiz.astro
+++ b/src/pages/free-tools/docs-debt-quiz.astro
@@ -1,0 +1,29 @@
+---
+import { getEntry } from 'astro:content';
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import { getFreeToolsSidebarLinks } from '@lib/free-tools-navigation';
+
+const entry = await getEntry('website', 'docs-debt-quiz');
+
+if (!entry) {
+  throw new Error('Missing website content entry: docs-debt-quiz');
+}
+
+const { Content, headings } = await entry.render();
+---
+
+<StarlightPage
+  hasSidebar
+  sidebar={getFreeToolsSidebarLinks()}
+  headings={headings}
+  frontmatter={{
+    title: entry.data.title,
+    description: entry.data.description,
+    template: 'doc',
+    editUrl: false,
+  }}
+>
+  <div class="pl-site-page pl-site-page-compact pl-free-tools-page">
+    <Content />
+  </div>
+</StarlightPage>

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -1345,3 +1345,332 @@
     width: 100%;
   }
 }
+
+/* ── Docs Debt Quiz ── */
+
+.pl-quiz-backdrop {
+  margin-top: 1.15rem;
+  background-image: radial-gradient(rgba(186, 183, 195) 0.6px, transparent 0.5px);
+  background-size: 10px 10px;
+  background-color: #fafafa;
+  border-radius: 0.75rem;
+  padding: 2rem 1rem;
+  display: flex;
+  justify-content: center;
+}
+
+.pl-quiz-container {
+  width: 100%;
+  max-width: 32rem;
+}
+
+.pl-quiz-card {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 25px 50px -12px rgba(28, 25, 23, 0.1);
+}
+
+/* Reset Starlight markdown styles inside the quiz */
+.sl-markdown-content .pl-quiz-card {
+  all: unset;
+  position: relative;
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 25px 50px -12px rgba(28, 25, 23, 0.1);
+  box-sizing: border-box;
+}
+
+.sl-markdown-content .pl-quiz-card *,
+.sl-markdown-content .pl-quiz-card *::before,
+.sl-markdown-content .pl-quiz-card *::after {
+  box-sizing: border-box;
+}
+
+.sl-markdown-content .pl-quiz-card h2,
+.sl-markdown-content .pl-quiz-card h3 {
+  border: 0;
+  padding: 0;
+}
+
+.sl-markdown-content .pl-quiz-card a {
+  text-decoration: none;
+}
+
+.sl-markdown-content .pl-quiz-card ul {
+  padding-left: 1.15rem;
+}
+
+.sl-markdown-content .pl-quiz-card li + li {
+  margin-top: 0;
+}
+
+.pl-quiz-progress-track {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: #f5f5f4;
+  overflow: hidden;
+}
+
+.pl-quiz-progress-bar {
+  height: 100%;
+  background: #171717;
+  transition: width 0.3s ease;
+}
+
+.pl-quiz-header {
+  margin-top: 0.75rem;
+  margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.sl-markdown-content .pl-quiz-logo,
+.pl-quiz-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: #171717;
+}
+
+.sl-markdown-content .pl-quiz-logo:hover,
+.pl-quiz-logo:hover {
+  text-decoration: none;
+  color: #171717;
+}
+
+.pl-quiz-logo-img {
+  border-radius: 0.35rem;
+  width: 18px;
+  height: 18px;
+}
+
+.pl-quiz-logo-text {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #171717;
+}
+
+.pl-quiz-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 0;
+  border-radius: 0.5rem;
+  background: transparent;
+  padding: 0.375rem 0.625rem;
+  font: inherit;
+  font-size: 0.8125rem;
+  color: #737373;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.pl-quiz-back:hover {
+  background: #f5f5f4;
+  color: #171717;
+}
+
+.pl-quiz-body {
+  animation: pl-quiz-fade-in 0.2s ease;
+}
+
+@keyframes pl-quiz-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.sl-markdown-content .pl-quiz-question,
+.pl-quiz-question {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 500;
+  color: #171717;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  border: 0;
+  padding: 0;
+}
+
+.pl-quiz-options {
+  margin-top: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.pl-quiz-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  background: #fff;
+  padding: 0.75rem 1rem;
+  font: inherit;
+  font-size: 0.875rem;
+  color: #404040;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.pl-quiz-option:hover {
+  border-color: #d4d4d4;
+  background: #fafafa;
+}
+
+.pl-quiz-option.is-selected {
+  border-color: #171717;
+  background: #f5f5f4;
+  color: #171717;
+}
+
+.pl-quiz-result-badge {
+  display: inline-block;
+  margin-bottom: 0.75rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: #f5f5f4;
+  color: #525252;
+  border: 1px solid #e5e7eb;
+}
+
+.pl-quiz-result-summary {
+  margin: 0.75rem 0 0;
+  color: #525252;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.pl-quiz-result-tips {
+  margin-top: 1.25rem;
+  padding: 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  background: #fafafa;
+}
+
+.sl-markdown-content .pl-quiz-result-tips h3,
+.pl-quiz-result-tips h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #171717;
+  border: 0;
+  padding: 0;
+}
+
+.sl-markdown-content .pl-quiz-result-tips ul,
+.pl-quiz-result-tips ul {
+  margin: 0;
+  padding-left: 1.15rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.sl-markdown-content .pl-quiz-result-tips li,
+.pl-quiz-result-tips li {
+  color: #525252;
+  font-size: 0.84rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.pl-quiz-result-actions {
+  margin-top: 1.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pl-quiz-restart {
+  border: 1px solid #d4d4d4;
+  border-radius: 0.5rem;
+  background: #fff;
+  color: #171717;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  padding: 0.6rem 0.9rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.pl-quiz-restart:hover {
+  background: #fafafa;
+  border-color: #a3a3a3;
+}
+
+.sl-markdown-content .pl-quiz-cta,
+.sl-markdown-content .pl-quiz-cta:hover,
+.sl-markdown-content .pl-quiz-cta:visited,
+.pl-quiz-cta {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #0f172a;
+  border-radius: 0.5rem;
+  background: #0f172a;
+  color: #fff;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  padding: 0.6rem 0.9rem;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.sl-markdown-content .pl-quiz-cta:hover,
+.pl-quiz-cta:hover {
+  background: #1e293b;
+  border-color: #1e293b;
+  color: #fff;
+  text-decoration: none;
+}
+
+@media (max-width: 550px) {
+  .pl-quiz-backdrop {
+    padding: 1.25rem 0.5rem;
+  }
+
+  .pl-quiz-card,
+  .sl-markdown-content .pl-quiz-card {
+    padding: 1rem 1.15rem;
+  }
+
+  .sl-markdown-content .pl-quiz-question,
+  .pl-quiz-question {
+    font-size: 1.15rem;
+  }
+
+  .pl-quiz-result-actions {
+    flex-direction: column;
+  }
+
+  .pl-quiz-restart,
+  .pl-quiz-cta,
+  .sl-markdown-content .pl-quiz-cta {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a 7-question scored docs debt quiz at `/free-tools/docs-debt-quiz`
- Add an idle-triggered fullscreen modal (`DocsDebtModal`) that appears after 30s of inactivity, portaled to `document.body` for full viewport coverage
- Wire quiz into free tools navigation and index page
- Include a debug button on the quiz page to trigger the modal on demand

## Test plan
- [ ] Visit `/free-tools/docs-debt-quiz` and complete the quiz end-to-end
- [ ] Verify results page shows correct tier based on score
- [ ] Click "Debug: Show idle modal" and confirm modal covers full viewport with blur
- [ ] Close modal via X, Escape, and backdrop click
- [ ] Verify modal doesn't reappear after dismissal (sessionStorage)
- [ ] Check responsive behavior on mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)