### PR TITLE
content: Add keyword-targeted blog article drafts

### DIFF
--- a/src/content/blog/technical/automated-docs-review.mdx
+++ b/src/content/blog/technical/automated-docs-review.mdx
@@ -1,0 +1,10 @@
+---
+title: Automated Docs Review
+subtitle: Published March 2026
+description: >-
+  How to automate documentation review so every code change that affects docs
+  gets caught before it ships.
+date: '2026-03-30T00:00:00.000Z'
+section: Technical
+hidden: true
+---

--- a/src/content/blog/technical/automated-documentation-updates.mdx
+++ b/src/content/blog/technical/automated-documentation-updates.mdx
@@ -1,0 +1,10 @@
+---
+title: Automated Documentation Updates
+subtitle: Published March 2026
+description: >-
+  How to automate documentation updates so your docs stay accurate without
+  manual effort every release cycle.
+date: '2026-03-30T00:00:00.000Z'
+section: Technical
+hidden: true
+---

--- a/src/content/blog/technical/docs-as-code.mdx
+++ b/src/content/blog/technical/docs-as-code.mdx
@@ -1,0 +1,15 @@
+---
+title: "Why Docs as Code Is the Only Documentation Approach That Scales"
+subtitle: Published March 2026
+description: >-
+  Why treating documentation like code with version control, pull requests, and
+  CI pipelines is essential for keeping docs accurate. Especially now that AI agents
+  are blundering all over the place trying to figure out how to use your product.
+date: '2026-03-26T00:00:00.000Z'
+author: Frances
+section: Technical
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+

--- a/src/content/blog/technical/docs-out-of-sync-with-code.mdx
+++ b/src/content/blog/technical/docs-out-of-sync-with-code.mdx
@@ -1,0 +1,10 @@
+---
+title: Docs Out of Sync with Code
+subtitle: Published March 2026
+description: >-
+  Why docs fall out of sync with code and how to close the gap with
+  automated detection and CI/CD workflows.
+date: '2026-03-30T00:00:00.000Z'
+section: Technical
+hidden: true
+---

--- a/src/content/blog/technical/documentation-ci-cd.mdx
+++ b/src/content/blog/technical/documentation-ci-cd.mdx
@@ -1,0 +1,10 @@
+---
+title: Documentation CI/CD
+subtitle: Published March 2026
+description: >-
+  How to build a CI/CD pipeline for documentation that catches staleness,
+  validates accuracy, and keeps docs shipping with your code.
+date: '2026-03-30T00:00:00.000Z'
+section: Technical
+hidden: true
+---

--- a/src/content/blog/technical/documentation-drift.mdx
+++ b/src/content/blog/technical/documentation-drift.mdx
@@ -1,0 +1,10 @@
+---
+title: Documentation Drift
+subtitle: Published March 2026
+description: >-
+  What documentation drift is, why it happens, and how to detect and fix it
+  before your users notice.
+date: '2026-03-30T00:00:00.000Z'
+section: Technical
+hidden: true
+---

--- a/src/content/blog/technical/documentation-maintenance.mdx
+++ b/src/content/blog/technical/documentation-maintenance.mdx
@@ -1,0 +1,10 @@
+---
+title: Documentation Maintenance
+subtitle: Published March 2026
+description: >-
+  A practical guide to documentation maintenance — processes, tools, and
+  workflows that keep your docs accurate over time.
+date: '2026-03-30T00:00:00.000Z'
+section: Technical
+hidden: true
+---

--- a/src/content/blog/technical/how-to-keep-documentation-up-to-date.mdx
+++ b/src/content/blog/technical/how-to-keep-documentation-up-to-date.mdx
@@ -1,0 +1,10 @@
+---
+title: How to Keep Documentation Up to Date
+subtitle: Published March 2026
+description: >-
+  How to keep documentation up to date as your product and codebase evolve,
+  without burning out your team.
+date: '2026-03-30T00:00:00.000Z'
+section: Technical
+hidden: true
+---

--- a/src/content/blog/technical/outdated-documentation.mdx
+++ b/src/content/blog/technical/outdated-documentation.mdx
@@ -1,0 +1,10 @@
+---
+title: Outdated Documentation
+subtitle: Published March 2026
+description: >-
+  Why documentation goes out of date, the real cost of outdated docs, and
+  what to do about it.
+date: '2026-03-30T00:00:00.000Z'
+section: Technical
+hidden: true
+---


### PR DESCRIPTION
## Summary
- Add 9 SEO-focused technical blog article drafts under `src/content/blog/technical/`:
  - Automated Docs Review
  - Automated Documentation Updates
  - Docs as Code
  - Docs Out of Sync with Code
  - Documentation CI/CD
  - Documentation Drift
  - Documentation Maintenance
  - How to Keep Documentation Up to Date
  - Outdated Documentation

## Test plan
- [ ] Verify all articles render correctly at their blog URLs
- [ ] Review content for accuracy and tone
- [ ] Check that frontmatter (title, description, date) is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)