### PR TITLE
Implement glossary marketing events

### DIFF
--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -12,18 +12,22 @@
     })
 
     // Track homepage section views (50%+ visible, once per section per page load).
+    // Uses IntersectionObserver to fire 'section_viewed' when a user scrolls each
+    // section into view. The 0.5 threshold means the event fires once 50% of the
+    // section is visible. viewedSections prevents duplicate events for the same
+    // section if the user scrolls back and forth.
     if (location.pathname === '/') {
       var sectionIds = ['overview', 'testimonials', 'how-promptless-works', 'capabilities'];
-      var viewedSections = {};
+      var viewedSections = {}; // Tracks which sections already fired to avoid duplicates
       var sectionObs = new IntersectionObserver(function (entries) {
         entries.forEach(function (entry) {
-          if (!entry.isIntersecting) return;
+          if (!entry.isIntersecting) return; // Ignore when section leaves viewport
           var id = entry.target.id;
-          if (viewedSections[id]) return;
+          if (viewedSections[id]) return; // Skip if already tracked
           viewedSections[id] = true;
           posthog.capture('section_viewed', { section: id, page: location.pathname });
         });
-      }, { threshold: 0.5 });
+      }, { threshold: 0.5 }); // Fire when 50% of section is visible
       sectionIds.forEach(function (id) {
         var el = document.getElementById(id);
         if (el) sectionObs.observe(el);
@@ -31,12 +35,17 @@
     }
 
     // Track scroll depth on blog posts (25/50/75/100%, once per milestone per page load).
+    // Fires 'scroll_depth' at each milestone as the user scrolls through an article.
+    // Excludes the blog index (/blog/) and all-posts page (/blog/all) since those
+    // aren't article content. Uses passive listener for better scroll performance.
     if (location.pathname.indexOf('/blog/') === 0 && location.pathname !== '/blog/' && location.pathname !== '/blog/all') {
       var scrollMilestones = [25, 50, 75, 100];
-      var firedMilestones = {};
+      var firedMilestones = {}; // Tracks which milestones already fired to avoid duplicates
       var scrollHandler = function () {
+        // Calculate scrollable height (total doc height minus viewport)
         var docHeight = document.documentElement.scrollHeight - window.innerHeight;
-        if (docHeight <= 0) return;
+        if (docHeight <= 0) return; // Page fits in viewport, no scroll tracking needed
+        // Calculate current scroll percentage
         var pct = Math.round((window.scrollY / docHeight) * 100);
         scrollMilestones.forEach(function (m) {
           if (pct >= m && !firedMilestones[m]) {
@@ -45,7 +54,7 @@
           }
         });
       };
-      window.addEventListener('scroll', scrollHandler, { passive: true });
+      window.addEventListener('scroll', scrollHandler, { passive: true }); // passive for perf
     }
 
     // Unmask the Pagefind search input and track search queries.

--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -11,6 +11,43 @@
       debug: location.hostname === 'localhost' || location.hostname === '127.0.0.1'
     })
 
+    // Track homepage section views (50%+ visible, once per section per page load).
+    if (location.pathname === '/') {
+      var sectionIds = ['overview', 'testimonials', 'how-promptless-works', 'capabilities'];
+      var viewedSections = {};
+      var sectionObs = new IntersectionObserver(function (entries) {
+        entries.forEach(function (entry) {
+          if (!entry.isIntersecting) return;
+          var id = entry.target.id;
+          if (viewedSections[id]) return;
+          viewedSections[id] = true;
+          posthog.capture('section_viewed', { section: id, page: location.pathname });
+        });
+      }, { threshold: 0.5 });
+      sectionIds.forEach(function (id) {
+        var el = document.getElementById(id);
+        if (el) sectionObs.observe(el);
+      });
+    }
+
+    // Track scroll depth on blog posts (25/50/75/100%, once per milestone per page load).
+    if (location.pathname.indexOf('/blog/') === 0 && location.pathname !== '/blog/' && location.pathname !== '/blog/all') {
+      var scrollMilestones = [25, 50, 75, 100];
+      var firedMilestones = {};
+      var scrollHandler = function () {
+        var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        if (docHeight <= 0) return;
+        var pct = Math.round((window.scrollY / docHeight) * 100);
+        scrollMilestones.forEach(function (m) {
+          if (pct >= m && !firedMilestones[m]) {
+            firedMilestones[m] = true;
+            posthog.capture('scroll_depth', { percent: m, page: location.pathname });
+          }
+        });
+      };
+      window.addEventListener('scroll', scrollHandler, { passive: true });
+    }
+
     // Unmask the Pagefind search input and track search queries.
     new MutationObserver(function(_, obs) {
       var input = document.querySelector('site-search input, .pagefind-ui__search-input');

--- a/src/components/shared/AnnouncementBanner.astro
+++ b/src/components/shared/AnnouncementBanner.astro
@@ -58,6 +58,11 @@ const storageKey = `pl_banner_dismissed_${campaign}`;
         banner.setAttribute('hidden', '');
         localStorage.setItem(storageKey, '1');
         root.style.removeProperty('--sl-nav-height');
+
+        var campaign = storageKey.replace('pl_banner_dismissed_', '');
+        if (window.posthog) {
+          window.posthog.capture('banner_dismissed', { campaign: campaign });
+        }
       });
     }
   }

--- a/src/components/shared/AnnouncementBanner.astro
+++ b/src/components/shared/AnnouncementBanner.astro
@@ -59,6 +59,8 @@ const storageKey = `pl_banner_dismissed_${campaign}`;
         localStorage.setItem(storageKey, '1');
         root.style.removeProperty('--sl-nav-height');
 
+        // Track banner dismissal with the campaign name extracted from the storage key.
+        // This helps measure how many users dismiss vs. engage with each campaign.
         var campaign = storageKey.replace('pl_banner_dismissed_', '');
         if (window.posthog) {
           window.posthog.capture('banner_dismissed', { campaign: campaign });

--- a/src/components/site/BlogNewsletterCTA.astro
+++ b/src/components/site/BlogNewsletterCTA.astro
@@ -65,8 +65,10 @@
 
         if (!res.ok) throw new Error('Submission failed');
 
-        window.posthog?.capture('blog_newsletter_subscribed', {
+        window.posthog?.capture('email_captured', {
+          intent: 'newsletter',
           location: 'blog',
+          campaign: '',
           $set: { email },
         });
 

--- a/src/components/site/BlogRequestDemo.astro
+++ b/src/components/site/BlogRequestDemo.astro
@@ -65,8 +65,10 @@
 
         try { sessionStorage.setItem('pl_demo_email', email); } catch {}
 
-        window.posthog?.capture('blog_demo_requested', {
+        window.posthog?.capture('email_captured', {
+          intent: 'demo',
           location: 'blog',
+          campaign: '',
           $set: { email },
         });
 

--- a/src/components/site/BrokenLinkReportForm.astro
+++ b/src/components/site/BrokenLinkReportForm.astro
@@ -202,6 +202,13 @@ const apiBaseUrl = (rawApiBaseUrl || fallbackApiBaseUrl).replace(/\/+$/, '');
           $set: { email },
         });
 
+        window.posthog?.capture('email_captured', {
+          intent: 'free_tool',
+          location: 'free_tools',
+          campaign: '',
+          $set: { email },
+        });
+
         form.reset();
         const anchorsToggle = form.querySelector('#broken-link-check-anchors');
         if (anchorsToggle instanceof HTMLInputElement) anchorsToggle.checked = true;

--- a/src/components/site/DemoBooking.astro
+++ b/src/components/site/DemoBooking.astro
@@ -157,8 +157,10 @@
       } catch (_) {}
 
       if (window.posthog) {
-        window.posthog.capture('demo_requested', {
+        window.posthog.capture('email_captured', {
+          intent: 'demo',
           location: 'demo_page',
+          campaign: '',
           $set: { email: email },
         });
       }

--- a/src/components/site/Hero.astro
+++ b/src/components/site/Hero.astro
@@ -78,8 +78,10 @@ const {
       if (email) {
         try { sessionStorage.setItem('pl_demo_email', email); } catch {}
       }
-      (window as any).posthog?.capture('demo_requested', {
+      (window as any).posthog?.capture('email_captured', {
+        intent: 'demo',
         location: 'hero',
+        campaign: '',
         ...(email ? { $set: { email } } : {}),
       });
 

--- a/src/components/site/pricing/GrowthBundleSelector.astro
+++ b/src/components/site/pricing/GrowthBundleSelector.astro
@@ -63,7 +63,17 @@ const selectId = 'growth-pages';
         }
       };
 
-      select.addEventListener('change', update);
+      select.addEventListener('change', function () {
+        update();
+        var opt = select.options[select.selectedIndex];
+        if (opt && window.posthog) {
+          window.posthog.capture('pricing_bundle_changed', {
+            bundle_id: opt.value,
+            bundle_label: opt.textContent.trim(),
+            price_label: (opt.dataset.priceLabel || '').trim(),
+          });
+        }
+      });
       update();
     };
 

--- a/src/components/site/pricing/GrowthBundleSelector.astro
+++ b/src/components/site/pricing/GrowthBundleSelector.astro
@@ -65,12 +65,14 @@ const selectId = 'growth-pages';
 
       select.addEventListener('change', function () {
         update();
+        // Track when users change the Growth plan bundle selection on the pricing page.
+        // Captures the selected bundle details to understand which tiers users explore.
         var opt = select.options[select.selectedIndex];
         if (opt && window.posthog) {
           window.posthog.capture('pricing_bundle_changed', {
-            bundle_id: opt.value,
-            bundle_label: opt.textContent.trim(),
-            price_label: (opt.dataset.priceLabel || '').trim(),
+            bundle_id: opt.value,              // e.g., 'growth_50', 'growth_100'
+            bundle_label: opt.textContent.trim(),  // e.g., '50 articles', '100 articles'
+            price_label: (opt.dataset.priceLabel || '').trim(),  // e.g., '$199/mo'
           });
         }
       });


### PR DESCRIPTION
## Summary
- **`email_captured`**: Consolidates `demo_requested`, `blog_demo_requested`, and `blog_newsletter_subscribed` into a single event with `intent`/`location` properties across Hero, DemoBooking, BlogRequestDemo, BlogNewsletterCTA, and BrokenLinkReportForm
- **`section_viewed`**: IntersectionObserver (50% threshold) on homepage sections (`overview`, `testimonials`, `how-promptless-works`, `capabilities`), once per section per page load
- **`scroll_depth`**: Fires at 25/50/75/100% scroll milestones on blog posts
- **`pricing_bundle_changed`**: Fires on Growth plan dropdown change with `bundle_id`, `bundle_label`, `price_label`
- **`banner_dismissed`**: Fires on announcement banner close with `campaign`

`video_played` and `video_progress` are not included — blocked on YouTube migration per the glossary.

## Test plan
- [ ] Verify `email_captured` fires with correct `intent`/`location` on each form submission (hero, demo page, blog demo CTA, blog newsletter, broken link tool)
- [ ] Verify old events (`demo_requested`, `blog_demo_requested`, `blog_newsletter_subscribed`) no longer fire
- [ ] Verify `section_viewed` fires once per section when scrolling the homepage
- [ ] Verify `scroll_depth` fires at each milestone on a blog post
- [ ] Verify `pricing_bundle_changed` fires when changing the Growth dropdown on /pricing
- [ ] Verify `banner_dismissed` fires when closing the announcement banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)