### PR TITLE
content: Using Slack as a Knowledge Base? Here's What You're Missing out on

### DIFF
--- a/src/content/blog/technical/using-slack-as-a-knowledge-base.mdx
+++ b/src/content/blog/technical/using-slack-as-a-knowledge-base.mdx
@@ -5,8 +5,8 @@ description: >-
   Slack feels like a knowledge store because answers happen there. Its design actively destroys institutional knowledge. Here's why docs-as-code fixes it.
 date: '2026-04-08T00:00:00.000Z'
 author: Frances
-section: Technical
-hidden: true
+section: Use Cases
+hidden: false
 ---
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';

--- a/src/content/blog/technical/using-slack-as-a-knowledge-base.mdx
+++ b/src/content/blog/technical/using-slack-as-a-knowledge-base.mdx
@@ -1,0 +1,70 @@
+---
+title: 'Using Slack as a Knowledge Base? Here's What You're Losing'
+subtitle: Published April 2026
+description: >-
+  Slack feels like a knowledge store because answers happen there. Its design actively destroys institutional knowledge. Here's why docs-as-code fixes it.
+date: '2026-04-08T00:00:00.000Z'
+author: Frances
+section: Technical
+hidden: true
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A new engineer joins your team. They need to set up their dev environment. The official docs are 18 months old and reference a tool you deprecated last spring. So they ask in `#engineering`. Someone helpful walks them through the real steps in a thread.
+
+That thread disappears within a week. The next new engineer asks the same question.
+
+This is Slack working exactly as designed. The problem is that it has become your default knowledge store.
+
+## The half-life of a Slack message
+
+Slack is optimized for the conversation happening right now. That optimization actively works against retention.
+
+A decision made in a thread on Monday is effectively unfindable by Friday. The information technically exists, but Slack's search relies on exact keywords and ignores context. Teams spend more than 30 minutes per week searching for things they know exist somewhere in Slack. The problem is not that people are searching badly. Retrieval is structurally broken.
+
+The deeper loss is the "why." When a technical decision gets made in a Slack thread, the reasoning disappears within days: the tradeoffs considered, the approach tried and rejected, the edge case knowingly deferred. What survives downstream is an artifact: a line of code, a config choice, a pattern in the codebase. The reasoning that produced it has scrolled away.
+
+This is what "[ephemeral knowledge](https://doclandscape.com/the-living-knowledge-system/the-knowledge-tiers/ephemeral-knowledge/)" refers to: information generated in real-time, in the flow of work, in a tool not designed to preserve it. Gartner puts the number at 47% of knowledge workers struggling to find information they need to do their job. Slack is a significant contributor.
+
+## Why stale docs make Slack worse
+
+Slack fills the knowledge gap partly because formal documentation fails people first.
+
+Documentation decays. Products ship, processes change. When someone follows a Confluence page and the steps are wrong, something shifts in how they relate to written docs. They file it as "docs are unreliable" and route around the whole system. The next time they need information, they ask a colleague on Slack. They're optimizing for reliability, choosing a source they trust over one they can't.
+
+This is rational. It's also a compounding problem.
+
+The more questions get answered through people, the more certain individuals become informal knowledge hubs. Knowledge concentrates in 2–3 people per team. When those people leave, that knowledge leaves with them. The docs don't get better during this cycle. They get worse, because fewer people use them and even fewer update them. The [trust collapse](/blog/technical/documentation-drift-detection-problem) is hard to reverse once it sets in.
+
+<BlogNewsletterCTA />
+
+## What docs-as-code actually fixes
+
+Moving internal documentation into a docs-as-code system (markdown files in a Git repository) changes the structural problem, not just the tooling.
+
+When docs live in the same repo as the code they describe, they go through the same review process. A pull request that changes an API also updates the documentation for that API. Ownership is unambiguous: whoever merged the code owns the context around it. There's no question about which version of the docs corresponds to which version of the product.
+
+Decay happens more slowly because the feedback loop is shorter. Engineers don't have to context-switch to a separate tool to update documentation. The change and the explanation travel together.
+
+For internal documentation specifically (team processes, architectural decisions, onboarding guides), the case is more direct than it is for external docs. Internal docs rarely have a non-technical audience that needs a WYSIWYG editor. They're read by developers and written by developers. Docs-as-code is the natural format. The [help center vs. docs-as-code](/blog/technical/help-center-to-docs-as-code) question is more nuanced for external-facing content, but for internal knowledge the answer is usually clear.
+
+## The automation that docs-as-code unlocks
+
+The more significant benefit is what docs-as-code makes possible downstream.
+
+Structured, version-controlled documentation is the prerequisite for programmatic updates. When docs live in a wiki or Confluence, there's no clean interface for automated changes. In a Git repository, there is. This matters because keeping internal docs current is where most teams actually fail. Writing docs once is the easy part. Keeping them current as the codebase moves and decisions accumulate in Slack threads is where the process breaks down.
+
+Promptless addresses both sides of this. It watches code changes and flags when a PR affects something currently documented. It also listens to Slack. When a decision gets made in a thread or institutional knowledge surfaces in a channel, Promptless can turn that signal into a documentation update. The context that used to disappear with the thread now has a place to land: the repo.
+
+One team using Promptless, Basis, takes this further. They pipe customer call transcripts into a Git repository. Promptless monitors the repo and maintains internal documentation around product usage patterns, recurring questions, and what's actually happening in the field. The internal knowledge base builds itself from conversation. Because it lives in their own repo, they can build agents on top of it and do useful things with the data. That leverage only exists because the documentation is in a format they control, not locked in a third-party system.
+
+## Where to start
+
+The Slack habit is hard to break because it works in the moment. Someone gets an answer in 20 minutes. The long-term cost is invisible at the time of the interaction: institutional knowledge that evaporates, the same question asked repeatedly across a year.
+
+Moving internal docs to a Git-based format doesn't require a large migration. Start with the highest-traffic knowledge: onboarding, environment setup, architectural decision records. Put those in a `docs/` folder in the relevant repo. Get engineers reviewing doc changes in PRs alongside code changes.
+
+That foundation is what makes the rest possible. Detection becomes automatable. Updates can be drafted rather than written from scratch. The knowledge that currently lives and dies in Slack threads has somewhere permanent to go.
+
+<BlogRequestDemo />

--- a/src/content/blog/technical/using-slack-as-a-knowledge-base.mdx
+++ b/src/content/blog/technical/using-slack-as-a-knowledge-base.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Using Slack as a Knowledge Base? Here's What You're Losing'
+title: 'Using Slack as a "Knowledge Base"? Here''s What You''re Missing out on'
 subtitle: Published April 2026
 description: >-
   Slack feels like a knowledge store because answers happen there. Its design actively destroys institutional knowledge. Here's why docs-as-code fixes it.

--- a/src/content/blog/technical/using-slack-as-a-knowledge-base.mdx
+++ b/src/content/blog/technical/using-slack-as-a-knowledge-base.mdx
@@ -11,21 +11,19 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-A new engineer joins your team. They need to set up their dev environment. The official docs are 18 months old and reference a tool you deprecated last spring. So they ask in `#engineering`. Someone helpful walks them through the real steps in a thread.
+Most teams don't choose Slack as their knowledge base. It just ends up that way. Someone asks a question, someone else answers it, and over time the real answers to "how does this work" live in threads and DMs rather than in any official documentation. It makes sense: Slack is where your team already is, and getting an answer there is fast.
 
-That thread disappears within a week. The next new engineer asks the same question.
-
-This is Slack working exactly as designed. The problem is that it has become your default knowledge store.
+If you're reading this, you've probably already felt the cost. You've searched for a decision you know was made somewhere, scrolled through threads that almost had the answer, or watched a new hire re-ask the same onboarding question for the third time this quarter. You've decided that Slack shouldn't be where institutional knowledge lives. This article is about why that instinct is right and what actually works instead.
 
 ## The half-life of a Slack message
 
-Slack is optimized for the conversation happening right now. That optimization actively works against retention.
+Slack search relies on exact keywords and ignores context. If you're looking for "the decision about the auth migration," you need to already know which words someone used when they made it. Slack won't surface a thread where someone said "let's go with OAuth" in response to "what should we do about login" unless you search for exactly the right terms.
 
-A decision made in a thread on Monday is effectively unfindable by Friday. The information technically exists, but Slack's search relies on exact keywords and ignores context. Teams spend more than 30 minutes per week searching for things they know exist somewhere in Slack. The problem is not that people are searching badly. Retrieval is structurally broken.
+It gets worse over time. Nobody goes back and edits Slack messages. When someone corrects a previous answer or a process changes, the new information lands in a new message. But search doesn't know that. It will happily surface the original, outdated answer because it's a better keyword match for your query. You're effectively running last-write-wins, but the search engine doesn't respect the write order.
 
-The deeper loss is the "why." When a technical decision gets made in a Slack thread, the reasoning disappears within days: the tradeoffs considered, the approach tried and rejected, the edge case knowingly deferred. What survives downstream is an artifact: a line of code, a config choice, a pattern in the codebase. The reasoning that produced it has scrolled away.
+The deeper loss is the "why." When a technical decision gets made in a Slack thread, the reasoning lives there and only there: the tradeoffs considered, the approach tried and rejected, the edge case knowingly deferred. What survives downstream is an artifact — a line of code, a config choice, a pattern in the codebase. The reasoning that produced it has scrolled away.
 
-This is what "[ephemeral knowledge](https://doclandscape.com/the-living-knowledge-system/the-knowledge-tiers/ephemeral-knowledge/)" refers to: information generated in real-time, in the flow of work, in a tool not designed to preserve it. Gartner puts the number at 47% of knowledge workers struggling to find information they need to do their job. Slack is a significant contributor.
+This is what doclandscape.com calls "[ephemeral knowledge](https://doclandscape.com/the-living-knowledge-system/the-knowledge-tiers/ephemeral-knowledge/)": information generated in real-time, in the flow of work, in a tool not designed to preserve it. The volume of knowledge flowing through Slack channels every day is enormous, and none of it is being processed into anything durable. You need something that can watch this stream as it happens and pull the institutional knowledge out before it disappears.
 
 ## Why stale docs make Slack worse
 


### PR DESCRIPTION
**Keyword:** \`slack knowledge base\`

## Article plan

**Thesis:** Slack erodes institutional knowledge because it's optimized for conversation, not retention. The fix is moving internal docs to docs-as-code, which gives you version control, clear ownership, and the foundation for Promptless to keep docs updated automatically from both code changes and Slack activity.

**Target reader:** Engineering managers and tech leads at 10–50 person teams whose same questions keep appearing in Slack and whose Confluence docs nobody trusts.

**Key points:**
1. Slack's message half-life is hours — retrieval is structurally broken, and 47% of knowledge workers can't find info they need (Gartner)
2. Stale docs cause a trust collapse that makes Slack the permanent fallback
3. Docs-as-code fixes ownership and decay rate by co-locating docs with code
4. Docs-as-code is the prerequisite for automation — Promptless can then watch both code changes and Slack to keep docs current automatically

**Promptless connection:** Once internal docs are in a Git repo, Promptless can monitor both the codebase and Slack channels to surface doc updates automatically, closing the loop that Slack currently breaks.

## File

\`src/content/blog/technical/using-slack-as-a-knowledge-base.mdx\`

This is an AI-generated draft and needs human review before publishing.