### PR TITLE
Filter hidden routes from sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,11 +1,24 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import react from '@astrojs/react';
+import sitemap from '@astrojs/sitemap';
 
 import generatedSidebar from './src/lib/generated/sidebar.json' with { type: 'json' };
 import redirectsManifest from './src/lib/generated/redirects.json' with { type: 'json' };
+import routeManifest from './src/lib/generated/route-manifest.json' with { type: 'json' };
+import {
+  createSitemapPathFilter,
+  getHiddenDocsPaths,
+  getHiddenRouteManifestPaths,
+  getHiddenWebsitePaths,
+} from './src/lib/sitemap-filter.mjs';
 
 const redirectEntries = (redirectsManifest.redirects || []).map((rule) => [rule.source, rule.destination]);
+const hiddenSitemapPaths = new Set([
+  ...getHiddenRouteManifestPaths(routeManifest),
+  ...getHiddenDocsPaths(new URL('./src/content/docs/', import.meta.url)),
+  ...getHiddenWebsitePaths(new URL('./src/content/website/', import.meta.url)),
+]);
 
 const redirects = {
   '/home': '/',
@@ -32,6 +45,9 @@ export default defineConfig({
   redirects,
   integrations: [
     react(),
+    sitemap({
+      filter: createSitemapPathFilter(hiddenSitemapPaths),
+    }),
     starlight({
       title: 'Promptless | Automatic updates for your customer-facing docs',
       description: 'Automated docs that eliminate manual overhead and keep your docs current with your codebase',

--- a/src/lib/sitemap-filter.mjs
+++ b/src/lib/sitemap-filter.mjs
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import matter from 'gray-matter';
+
+export function normalizePathname(pathname) {
+  if (!pathname || pathname === '/') return '/';
+  return pathname.replace(/\/+$/, '') || '/';
+}
+
+export function getHiddenRouteManifestPaths(routeManifest) {
+  return new Set(
+    routeManifest
+      .filter((route) => route.hidden)
+      .map((route) => normalizePathname(route.routePath))
+  );
+}
+
+export function getHiddenWebsitePaths(contentDir) {
+  const directoryPath = contentDir instanceof URL ? fileURLToPath(contentDir) : contentDir;
+  const hiddenPaths = new Set();
+
+  for (const filePath of getMarkdownFiles(directoryPath)) {
+    const { data } = matter(fs.readFileSync(filePath, 'utf8'));
+
+    if (data.hidden && typeof data.routePath === 'string') {
+      hiddenPaths.add(normalizePathname(data.routePath));
+    }
+  }
+
+  return hiddenPaths;
+}
+
+export function getHiddenDocsPaths(contentDir) {
+  const directoryPath = contentDir instanceof URL ? fileURLToPath(contentDir) : contentDir;
+  const hiddenPaths = new Set();
+
+  for (const filePath of getMarkdownFiles(directoryPath)) {
+    const { data } = matter(fs.readFileSync(filePath, 'utf8'));
+
+    if (data?.sidebar?.hidden && typeof data.slug === 'string') {
+      hiddenPaths.add(normalizePathname(`/${data.slug}`));
+    }
+  }
+
+  return hiddenPaths;
+}
+
+export function createSitemapPathFilter(hiddenPaths) {
+  return (page) => {
+    const pathname = normalizePathname(new URL(page).pathname);
+    return !hiddenPaths.has(pathname);
+  };
+}
+
+function getMarkdownFiles(directoryPath) {
+  const files = [];
+
+  for (const entry of fs.readdirSync(directoryPath, { withFileTypes: true })) {
+    const entryPath = path.join(directoryPath, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...getMarkdownFiles(entryPath));
+      continue;
+    }
+
+    if (entry.isFile() && (entry.name.endsWith('.md') || entry.name.endsWith('.mdx'))) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}

--- a/tests/unit/sitemap-filter.spec.ts
+++ b/tests/unit/sitemap-filter.spec.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createSitemapPathFilter,
+  getHiddenDocsPaths,
+  getHiddenRouteManifestPaths,
+  getHiddenWebsitePaths,
+  normalizePathname,
+} from '../../src/lib/sitemap-filter.mjs';
+
+test('normalizes sitemap paths consistently', () => {
+  assert.equal(normalizePathname('/docs/core-concepts/'), '/docs/core-concepts');
+  assert.equal(normalizePathname('/'), '/');
+  assert.equal(normalizePathname(''), '/');
+});
+
+test('collects hidden route-manifest pages', () => {
+  const hiddenPaths = getHiddenRouteManifestPaths([
+    { routePath: '/docs/core-concepts', hidden: true },
+    { routePath: '/docs/self-hosting', hidden: true },
+    { routePath: '/docs/internal/component-fixtures', hidden: true },
+    { routePath: '/docs/getting-started/welcome', hidden: false },
+  ]);
+
+  assert(hiddenPaths.has('/docs/core-concepts'));
+  assert(hiddenPaths.has('/docs/self-hosting'));
+  assert(hiddenPaths.has('/docs/internal/component-fixtures'));
+  assert(!hiddenPaths.has('/docs/getting-started/welcome'));
+});
+
+test('collects hidden website pages', () => {
+  const hiddenPaths = getHiddenWebsitePaths(new URL('../../src/content/website/', import.meta.url));
+
+  assert(hiddenPaths.has('/jobs'));
+  assert(hiddenPaths.has('/wtd-portland-2026'));
+  assert(!hiddenPaths.has('/demo'));
+});
+
+test('collects hidden docs pages from source content', () => {
+  const hiddenPaths = getHiddenDocsPaths(new URL('../../src/content/docs/', import.meta.url));
+
+  assert(hiddenPaths.has('/docs/internal/component-fixtures'));
+  assert(hiddenPaths.has('/docs/core-concepts'));
+  assert(hiddenPaths.has('/docs/self-hosting'));
+  assert(!hiddenPaths.has('/docs/getting-started/welcome'));
+});
+
+test('filters hidden sitemap pages while preserving public ones', () => {
+  const hiddenPaths = new Set([
+    '/docs/core-concepts',
+    '/docs/internal/component-fixtures',
+    '/wtd-portland-2026',
+  ]);
+  const filter = createSitemapPathFilter(hiddenPaths);
+
+  assert.equal(filter('https://promptless.ai/docs/core-concepts/'), false);
+  assert.equal(filter('https://promptless.ai/docs/internal/component-fixtures/'), false);
+  assert.equal(filter('https://promptless.ai/wtd-portland-2026/'), false);
+  assert.equal(filter('https://promptless.ai/demo/'), true);
+});


### PR DESCRIPTION
## Problem or objective
- `afdocs` still warns on `llms-txt-freshness` because the sitemap exposes hidden pages that are intentionally omitted from `llms.txt`.
- Starlight auto-adds a default sitemap integration, so hidden docs and hidden website pages currently flow into the generated sitemap as long as they have a live route.
- That makes the public sitemap disagree with the content visibility rules the rest of the site uses.

## Solution
- Add an explicit `@astrojs/sitemap` integration in `astro.config.mjs` so we can control sitemap filtering.
- Build a hidden-path set from the generated route manifest plus hidden docs and website source files.
- Use the sitemap `filter(page)` hook to exclude hidden routes from the generated sitemap.
- Add unit coverage for normalization, hidden path collection, and the filter behavior.

## Design choices
- Filter at sitemap generation time instead of post-processing XML so the behavior stays close to the source of truth.
- Read hidden docs directly from source content because some hidden routes, like `component-fixtures`, are not represented in the generated route manifest.
- Keep the helper small and framework-agnostic so it can be validated without a full site build.
