### PR TITLE
content: Developer Documentation ROI: The Metrics That Actually Matter

### DIFF
--- a/src/content/blog/technical/developer-documentation-roi.mdx
+++ b/src/content/blog/technical/developer-documentation-roi.mdx
@@ -1,0 +1,83 @@
+---
+title: 'Developer Documentation ROI: The Metrics That Actually Matter'
+subtitle: Published April 2026
+description: >-
+  Most teams make the documentation ROI case with support tickets. That understates it by 10x. Here's how to measure what leadership actually cares about.
+date: '2026-04-14T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+When a technical writer asks leadership for more budget, the conversation usually ends up in the same place: "how many support tickets will this deflect?" The team runs the math (tickets per month, cost per ticket, expected deflection rate) and lands on a number that sounds reasonable. Leadership approves a modest investment. The ticket count drops slightly. No one revisits the projection.
+
+This is the wrong metric. Support ticket deflection is real, but it captures a small fraction of what documentation costs and returns. The bigger number is engineering time, and most of it goes unmeasured.
+
+## The Cost Nobody Is Tracking
+
+Stack Overflow's developer survey found that developers spend more than 30 minutes per day searching for solutions to technical problems. Separate research puts it higher: half of developers lose roughly 10 hours per week sourcing basic information they need to do their jobs. They are senior-engineer hours paid at full rate, spent compensating for an information system that should have made the answer obvious.
+
+Research on developer experience makes this concrete. The DXI framework from DX (formerly DX Data) measures documentation quality as its own dimension of developer experience. Their data finds that each 1-point improvement in documentation quality saves 13 minutes per developer per week. For a 100-person engineering team, a 5-point improvement translates to 5,000 hours per year, roughly $500,000 in recovered capacity at a $150k average salary.
+
+The inverse calculation is equally useful. A team where documentation problems consume 15–25% of engineering capacity (a figure [documented in our post on documentation drift](/blog/technical/documentation-drift-detection-problem), drawn from engineering surveys) is effectively paying 15–25 engineers to compensate: reading source code instead of docs and asking Slack questions that a functioning information system would already answer. That is the cost denominator that almost never appears in a documentation business case.
+
+Support ticket deflection matters for customer-facing documentation. For internal and developer-facing docs, the engineering time lever is at minimum 10x larger.
+
+## Documentation as a Quality Input
+
+There is a second ROI lever that rarely appears in documentation business cases: defect prevention.
+
+An analysis of 101 production bugs presented at ICSE 2024 found that missing or outdated documentation caused nearly 50% of the defects, with erroneous code examples topping the list. The causal chain is direct: developer reads the wrong thing, writes the wrong code, ships a bug. Documentation accuracy is a measurable quality input, traceable through defect data.
+
+IBM research on software defect costs adds the multiplier: fixing a bug discovered late in the development cycle costs roughly 10x what it costs to fix the same bug at the writing stage. If outdated documentation contributes to half of production bugs, and late-stage bugs cost 10x more, then documentation accuracy is worth a meaningful share of your QA and incident-response budget.
+
+Few documentation teams make this argument, because the causal chain is harder to trace than a deflected ticket. But the data supports it, and it is the kind of argument that lands with an engineering organization rather than just a support operations team.
+
+<BlogNewsletterCTA />
+
+## Three Metrics Teams Can Track Today
+
+### 1. Developer experience surveys
+
+A single survey question asking developers to rate documentation quality on a scale of 1–10, tracked quarterly, is enough to build a trend line. Each point of improvement carries the 13-min/developer/week value above. For your specific team size and salary band, the dollar value is calculable and defensible.
+
+This is the most actionable metric for leadership conversations, because it is a number that moves and can be traced to investments. When you ship a documentation sprint, the DXI score should move. When it does not, that is also useful information.
+
+### 2. Support ticket categorization
+
+Pull 50–100 escalated tickets from the past quarter and categorize each one: true knowledge gap (answer did not exist anywhere), stale answer (doc existed but was wrong or outdated), retrieval miss (doc was correct but user could not find it), or genuinely hard question requiring human judgment.
+
+Most teams expect the "genuinely hard" bucket to dominate. In practice it is usually the smallest. True gaps and stale answers together account for 60–70% of escalations, and both are documentation problems with a cost per ticket. This turns a qualitative complaint ("our docs need work") into a number finance can act on.
+
+The approach is covered in more detail in [our post on support agent deflection](/blog/technical/support-agent-deflection), where the same categorization exercise applies to AI-handled tickets.
+
+### 3. Documentation coverage
+
+Coverage measures what percentage of your product surface (features, API endpoints, error codes, configuration options) has corresponding documentation that is verified as current. Gaps are a leading indicator of both support escalations and engineering friction.
+
+Most teams do not track this systematically. Treating it as a metric alongside code coverage or test coverage changes the conversation: docs drift becomes a risk number rather than an abstract quality concern, and coverage targets create accountability for keeping it current.
+
+## Why Documentation ROI Erodes
+
+Here is the dynamic that makes documentation investment difficult to sustain: accuracy degrades silently.
+
+Documentation delivers strong returns when it is accurate. Six months after a launch, product has shipped, APIs have changed, and a fraction of the docs are now wrong. That fraction grows with each release, accelerating as the engineering team ships faster with AI tooling.
+
+The ROI does not simply stop accruing when docs go stale. It reverses. A developer reading wrong documentation is worse off than a developer who found nothing, because they have false confidence. They write code against the wrong spec. They configure a deprecated parameter. [As covered in the context engineering post](/blog/technical/agent-context-engineering), when an AI agent reads the same stale documentation, it surfaces the wrong answer at scale, to every user who triggers that retrieval path.
+
+This is why quarterly documentation audits consistently underperform as a maintenance strategy. By the time a quarterly audit runs, stale content has been accumulating for weeks and has already generated bugs and support escalations. The cost has already been paid.
+
+The documentation ROI argument is strong, but it is only sustained by accuracy maintenance alongside initial authorship. Writing new content and allowing it to decay produces diminishing returns that eventually go negative. Writing accurate content and maintaining a system that keeps it accurate as the product evolves produces returns that compound over time.
+
+## Making the Case
+
+The engineering time calculation is what closes most leadership conversations.
+
+Take your team size. Multiply by average salary. Multiply by 15% (the low end of engineering capacity lost to documentation problems). That is your annual cost denominator. Then estimate what a 5-point DXI improvement is worth at your team size, using the 13-min/week/developer figure. The gap between those two numbers is the available ROI and the investment case.
+
+Start with two tracking practices: run a quarterly developer survey with a single documentation quality question, and pull 50 escalated tickets to categorize by root cause. Add a coverage metric against your product surface once those baselines exist. Together they convert "our docs need to be better" into a business case with a dollar value and a trend line.
+
+<BlogRequestDemo />

--- a/src/content/blog/technical/developer-documentation-roi.mdx
+++ b/src/content/blog/technical/developer-documentation-roi.mdx
@@ -12,17 +12,17 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-When a technical writer asks leadership for more budget, the conversation usually ends up in the same place: "how many support tickets will this deflect?" The team runs the math (tickets per month, cost per ticket, expected deflection rate) and lands on a number that sounds reasonable. Leadership approves a modest investment. The ticket count drops slightly. No one revisits the projection.
+When a technical writer asks leadership for more budget, the conversation usually ends up with someone asking "how many support tickets will this deflect?" The team runs the math on tickets per month, cost per ticket, and expected deflection rate, then lands on a number that sounds reasonable. Leadership approves a modest investment, the ticket count drops slightly, and no one revisits the projection.
 
 This is the wrong metric. Support ticket deflection is real, but it captures a small fraction of what documentation costs and returns. The bigger number is engineering time, and most of it goes unmeasured.
 
 ## The Cost Nobody Is Tracking
 
-Stack Overflow's developer survey found that developers spend more than 30 minutes per day searching for solutions to technical problems. Separate research puts it higher: half of developers lose roughly 10 hours per week sourcing basic information they need to do their jobs. They are senior-engineer hours paid at full rate, spent compensating for an information system that should have made the answer obvious.
+Stack Overflow's developer survey found that developers spend more than 30 minutes per day searching for solutions to technical problems. Separate research puts the figure higher, with half of developers losing roughly 10 hours per week sourcing basic information they need to do their jobs. They are senior-engineer hours paid at full rate, spent compensating for an information system that should have made the answer obvious.
 
 Research on developer experience makes this concrete. The DXI framework from DX (formerly DX Data) measures documentation quality as its own dimension of developer experience. Their data finds that each 1-point improvement in documentation quality saves 13 minutes per developer per week. For a 100-person engineering team, a 5-point improvement translates to 5,000 hours per year, roughly $500,000 in recovered capacity at a $150k average salary.
 
-The inverse calculation is equally useful. A team where documentation problems consume 15–25% of engineering capacity (a figure [documented in our post on documentation drift](/blog/technical/documentation-drift-detection-problem), drawn from engineering surveys) is effectively paying 15–25 engineers to compensate: reading source code instead of docs and asking Slack questions that a functioning information system would already answer. That is the cost denominator that almost never appears in a documentation business case.
+The inverse calculation is equally useful. A team where documentation problems consume 15 to 25% of engineering capacity, a figure drawn from engineering surveys and [documented in our post on documentation drift](/blog/technical/documentation-drift-detection-problem), is effectively paying 15 to 25 engineers to compensate. Those engineers read source code instead of docs and ask Slack questions that a functioning information system would already answer. That is the cost denominator that rarely appears in a documentation business case.
 
 Support ticket deflection matters for customer-facing documentation. For internal and developer-facing docs, the engineering time lever is at minimum 10x larger.
 
@@ -30,11 +30,11 @@ Support ticket deflection matters for customer-facing documentation. For interna
 
 There is a second ROI lever that rarely appears in documentation business cases: defect prevention.
 
-An analysis of 101 production bugs presented at ICSE 2024 found that missing or outdated documentation caused nearly 50% of the defects, with erroneous code examples topping the list. The causal chain is direct: developer reads the wrong thing, writes the wrong code, ships a bug. Documentation accuracy is a measurable quality input, traceable through defect data.
+An analysis of 101 production bugs presented at ICSE 2024 found that missing or outdated documentation caused nearly 50% of the defects, with erroneous code examples topping the list. The causal chain is direct. A developer reads the wrong thing, writes the wrong code, and ships a bug. Documentation accuracy is a measurable quality input, traceable through defect data.
 
-IBM research on software defect costs adds the multiplier: fixing a bug discovered late in the development cycle costs roughly 10x what it costs to fix the same bug at the writing stage. If outdated documentation contributes to half of production bugs, and late-stage bugs cost 10x more, then documentation accuracy is worth a meaningful share of your QA and incident-response budget.
+IBM research on software defect costs adds a multiplier. Fixing a bug discovered late in the development cycle costs roughly 10x what it costs to fix the same bug at the writing stage. If outdated documentation contributes to half of production bugs, and late-stage bugs cost 10x more, then documentation accuracy is worth a meaningful share of your QA and incident-response budget.
 
-Few documentation teams make this argument, because the causal chain is harder to trace than a deflected ticket. But the data supports it, and it is the kind of argument that lands with an engineering organization rather than just a support operations team.
+Few documentation teams make this argument, because the causal chain is harder to trace than a deflected ticket. But the data supports it, and it is the kind of argument that lands with an engineering organization, not a support operations team.
 
 <BlogNewsletterCTA />
 
@@ -42,31 +42,31 @@ Few documentation teams make this argument, because the causal chain is harder t
 
 ### 1. Developer experience surveys
 
-A single survey question asking developers to rate documentation quality on a scale of 1–10, tracked quarterly, is enough to build a trend line. Each point of improvement carries the 13-min/developer/week value above. For your specific team size and salary band, the dollar value is calculable and defensible.
+A single survey question asking developers to rate documentation quality on a scale of 1 to 10, tracked quarterly, is enough to build a trend line. Each point of improvement carries the 13-min/developer/week value above. For your specific team size and salary band, the dollar value is calculable and defensible.
 
 This is the most actionable metric for leadership conversations, because it is a number that moves and can be traced to investments. When you ship a documentation sprint, the DXI score should move. When it does not, that is also useful information.
 
 ### 2. Support ticket categorization
 
-Pull 50–100 escalated tickets from the past quarter and categorize each one: true knowledge gap (answer did not exist anywhere), stale answer (doc existed but was wrong or outdated), retrieval miss (doc was correct but user could not find it), or genuinely hard question requiring human judgment.
+Pull 50 to 100 escalated tickets from the past quarter and categorize each as a true knowledge gap where no answer existed anywhere, a stale answer where the doc existed but was wrong or outdated, a retrieval miss where the doc was correct but the user failed to find it, or a hard question requiring human judgment.
 
-Most teams expect the "genuinely hard" bucket to dominate. In practice it is usually the smallest. True gaps and stale answers together account for 60–70% of escalations, and both are documentation problems with a cost per ticket. This turns a qualitative complaint ("our docs need work") into a number finance can act on.
+Most teams expect the "hard question" bucket to dominate. In practice it is the smallest. True gaps and stale answers together account for 60 to 70% of escalations, and both are documentation problems with a cost per ticket. This turns a qualitative complaint about doc quality into a number finance can act on.
 
 The approach is covered in more detail in [our post on support agent deflection](/blog/technical/support-agent-deflection), where the same categorization exercise applies to AI-handled tickets.
 
 ### 3. Documentation coverage
 
-Coverage measures what percentage of your product surface (features, API endpoints, error codes, configuration options) has corresponding documentation that is verified as current. Gaps are a leading indicator of both support escalations and engineering friction.
+Coverage measures what percentage of your product surface, including features, API endpoints, error codes, and configuration options, has corresponding documentation that is verified as current. Gaps are a leading indicator of both support escalations and engineering friction.
 
-Most teams do not track this systematically. Treating it as a metric alongside code coverage or test coverage changes the conversation: docs drift becomes a risk number rather than an abstract quality concern, and coverage targets create accountability for keeping it current.
+Most teams do not track this systematically. Treating it as a metric alongside code coverage or test coverage changes the conversation. Docs drift becomes a risk number, not an abstract quality concern, and coverage targets create accountability for keeping it current.
 
 ## Why Documentation ROI Erodes
 
-Here is the dynamic that makes documentation investment difficult to sustain: accuracy degrades silently.
+Most investments get sized against the return they generate. Documentation is difficult to sustain because accuracy degrades silently, erasing the return signal that would justify the next round of investment.
 
 Documentation delivers strong returns when it is accurate. Six months after a launch, product has shipped, APIs have changed, and a fraction of the docs are now wrong. That fraction grows with each release, accelerating as the engineering team ships faster with AI tooling.
 
-The ROI does not simply stop accruing when docs go stale. It reverses. A developer reading wrong documentation is worse off than a developer who found nothing, because they have false confidence. They write code against the wrong spec. They configure a deprecated parameter. [As covered in the context engineering post](/blog/technical/agent-context-engineering), when an AI agent reads the same stale documentation, it surfaces the wrong answer at scale, to every user who triggers that retrieval path.
+The returns from documentation are gradual and ongoing. A doc pays off slowly, across every developer who reads it and every support ticket it resolves. That stream only continues if the doc stays accurate. Without maintenance, the returns shrink and eventually go negative. A developer who finds the wrong answer follows it confidently, writes code against the wrong spec, and configures deprecated parameters. [As covered in the context engineering post](/blog/technical/agent-context-engineering), when an AI agent reads the same stale documentation, it surfaces the wrong answer at scale, to every user who triggers that retrieval path.
 
 This is why quarterly documentation audits consistently underperform as a maintenance strategy. By the time a quarterly audit runs, stale content has been accumulating for weeks and has already generated bugs and support escalations. The cost has already been paid.
 
@@ -76,8 +76,8 @@ The documentation ROI argument is strong, but it is only sustained by accuracy m
 
 The engineering time calculation is what closes most leadership conversations.
 
-Take your team size. Multiply by average salary. Multiply by 15% (the low end of engineering capacity lost to documentation problems). That is your annual cost denominator. Then estimate what a 5-point DXI improvement is worth at your team size, using the 13-min/week/developer figure. The gap between those two numbers is the available ROI and the investment case.
+Take your team size. Multiply by average salary. Multiply by 15%, which is the low end of engineering capacity lost to documentation problems. That is your annual cost denominator. Then estimate what a 5-point DXI improvement is worth at your team size, using the 13-min/week/developer figure. The gap between those two numbers is the available ROI and the investment case.
 
-Start with two tracking practices: run a quarterly developer survey with a single documentation quality question, and pull 50 escalated tickets to categorize by root cause. Add a coverage metric against your product surface once those baselines exist. Together they convert "our docs need to be better" into a business case with a dollar value and a trend line.
+Start with two tracking practices. First, run a quarterly developer survey with a single documentation quality question. Second, pull 50 escalated tickets and categorize them by root cause. Add a coverage metric against your product surface once those baselines exist. Together they convert "our docs need to be better" into a business case with a dollar value and a trend line.
 
 <BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer documentation ROI`

## Article plan

- **Target keyword:** developer documentation ROI (related: documentation debt, developer experience)
- **Thesis:** Most documentation ROI arguments focus on support ticket deflection, which understates the real return by 10x. The bigger levers are engineering time recovery and defect prevention, and both can be measured.
- **Target reader:** Engineering managers and technical writers making the business case for documentation investment
- **Key points:**
  1. Support ticket deflection is the most-cited metric but the smallest lever
  2. Engineering time loss is 10–20x larger: 30+ min/day searching, 15–25% of capacity
  3. DXI framework gives a dollar formula: 1-point improvement = 13 min/developer/week; 5-point for 100 engineers ≈ $500K/year
  4. Stale docs cause bugs: ICSE 2024 analysis found ~50% of 101 production defects traced to missing/outdated docs
  5. Three metrics to track: DXI surveys, ticket categorization, coverage
  6. Documentation ROI erodes through staleness — sustained ROI requires accuracy maintenance
- **Promptless connection:** Staleness is what erodes documentation ROI over time. Promptless monitors docs against the actual product to prevent that erosion.
- **Internal links:** documentation-drift-detection-problem, support-agent-deflection, agent-context-engineering

## File

`src/content/blog/technical/developer-documentation-roi.mdx`

This is an AI-generated draft and needs human review before publishing.