### PR TITLE
Remove sidebars from homepage

### DIFF
--- a/src/components/shared/NavIcon.astro
+++ b/src/components/shared/NavIcon.astro
@@ -1,6 +1,6 @@
 ---
 import type { TopNavIcon } from '@lib/site-navigation';
-import { House, BookText, Newspaper, Clock3, Sparkles } from '@lucide/astro';
+import { House, Tag, BookText, Newspaper, Clock3, Sparkles } from '@lucide/astro';
 
 interface Props {
   name: TopNavIcon;
@@ -11,6 +11,7 @@ const { name, class: className } = Astro.props;
 ---
 
 {name === 'website' ? <House class:list={['pl-site-tab-icon', className]} size={18} stroke-width={2} aria-hidden="true" /> : null}
+{name === 'pricing' ? <Tag class:list={['pl-site-tab-icon', className]} size={18} stroke-width={2} aria-hidden="true" /> : null}
 {name === 'docs' ? <BookText class:list={['pl-site-tab-icon', className]} size={18} stroke-width={2} aria-hidden="true" /> : null}
 {name === 'blog' ? <Newspaper class:list={['pl-site-tab-icon', className]} size={18} stroke-width={2} aria-hidden="true" /> : null}
 {name === 'changelog' ? <Clock3 class:list={['pl-site-tab-icon', className]} size={18} stroke-width={2} aria-hidden="true" /> : null}

--- a/src/components/shared/NavIcon.astro
+++ b/src/components/shared/NavIcon.astro
@@ -1,6 +1,6 @@
 ---
 import type { TopNavIcon } from '@lib/site-navigation';
-import { House, Tag, BookText, Newspaper, Clock3, Sparkles } from '@lucide/astro';
+import { House, BadgeDollarSign, BookText, Newspaper, Clock3, Sparkles } from '@lucide/astro';
 
 interface Props {
   name: TopNavIcon;
@@ -11,7 +11,7 @@ const { name, class: className } = Astro.props;
 ---
 
 {name === 'website' ? <House class:list={['pl-site-tab-icon', className]} size={18} stroke-width={2} aria-hidden="true" /> : null}
-{name === 'pricing' ? <Tag class:list={['pl-site-tab-icon', className]} size={18} stroke-width={2} aria-hidden="true" /> : null}
+{name === 'pricing' ? <BadgeDollarSign class:list={['pl-site-tab-icon', className]} size={18} stroke-width={2} aria-hidden="true" /> : null}
 {name === 'docs' ? <BookText class:list={['pl-site-tab-icon', className]} size={18} stroke-width={2} aria-hidden="true" /> : null}
 {name === 'blog' ? <Newspaper class:list={['pl-site-tab-icon', className]} size={18} stroke-width={2} aria-hidden="true" /> : null}
 {name === 'changelog' ? <Clock3 class:list={['pl-site-tab-icon', className]} size={18} stroke-width={2} aria-hidden="true" /> : null}

--- a/src/lib/site-navigation.ts
+++ b/src/lib/site-navigation.ts
@@ -1,5 +1,5 @@
-export type SiteSection = 'website' | 'docs' | 'blog' | 'changelog' | 'free_tools' | 'signin';
-export type TopNavIcon = 'website' | 'docs' | 'blog' | 'changelog' | 'free_tools';
+export type SiteSection = 'website' | 'pricing' | 'docs' | 'blog' | 'changelog' | 'free_tools' | 'signin';
+export type TopNavIcon = 'website' | 'pricing' | 'docs' | 'blog' | 'changelog' | 'free_tools';
 
 interface TopNavBaseItem {
   section: SiteSection;
@@ -16,6 +16,7 @@ export type TopNavItem = TopNavLinkItem;
 
 export const TOP_NAV_ITEMS: TopNavItem[] = [
   { section: 'website', href: '/', label: 'Home', icon: 'website' },
+  { section: 'pricing', href: '/pricing', label: 'Pricing', icon: 'pricing' },
   { section: 'docs', href: '/docs', label: 'Docs', icon: 'docs' },
   { section: 'blog', href: '/blog', label: 'Blog', icon: 'blog' },
   { section: 'changelog', href: '/changelog', label: 'Changelog', icon: 'changelog' },
@@ -39,7 +40,6 @@ export function getActiveSection(pathname: string): SiteSection {
     normalized === '/' ||
     normalized === '/home' ||
     normalized === '/demo' ||
-    normalized === '/pricing' ||
     normalized === '/meet' ||
     normalized === '/jobs' ||
     normalized === '/wtd-portland-2026' ||
@@ -47,6 +47,7 @@ export function getActiveSection(pathname: string): SiteSection {
   ) {
     return 'website';
   }
+  if (normalized === '/pricing') return 'pricing';
   if (normalized.startsWith('/docs')) return 'docs';
   if (normalized.startsWith('/blog')) return 'blog';
   if (normalized.startsWith('/changelog')) return 'changelog';

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
 import { getEntry } from 'astro:content';
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
-import { getWebsiteSidebarLinks } from '@lib/website-navigation';
 
 const entry = await getEntry('website', 'home');
 
@@ -13,18 +12,12 @@ const { Content } = await entry.render();
 ---
 
 <StarlightPage
-  hasSidebar
-  sidebar={getWebsiteSidebarLinks()}
-  headings={[
-    { depth: 2, slug: 'book-a-demo', text: 'Book a demo' },
-    { depth: 2, slug: 'testimonials', text: 'Testimonials' },
-    { depth: 2, slug: 'how-promptless-works', text: 'How Promptless works' },
-    { depth: 2, slug: 'capabilities', text: 'Why Promptless?' },
-  ]}
+  hasSidebar={false}
   frontmatter={{
     title: entry.data.title,
     description: entry.data.description,
     template: 'doc',
+    tableOfContents: false,
     editUrl: false,
   }}
 >

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -172,7 +172,7 @@
   display: grid;
   grid-template-rows: 1fr;
   grid-auto-flow: column;
-  grid-auto-columns: calc((100% - 2 * 1.05rem) / 3 + 0.5rem);
+  grid-auto-columns: calc((100% - 2 * 1.05rem) / 3 - 1rem);
   gap: 1.05rem;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
@@ -279,7 +279,7 @@
 
 @media (max-width: 1180px) {
   .pl-site-testimonials-grid {
-    grid-auto-columns: calc((100% - 1.05rem) / 2 + 0.5rem);
+    grid-auto-columns: calc((100% - 1.05rem) / 2 - 1rem);
   }
 }
 

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -172,7 +172,7 @@
   display: grid;
   grid-template-rows: 1fr;
   grid-auto-flow: column;
-  grid-auto-columns: min(22rem, calc(100% - 3rem));
+  grid-auto-columns: calc((100% - 2 * 1.05rem) / 3 + 0.5rem);
   gap: 1.05rem;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
@@ -275,6 +275,18 @@
   width: auto;
   display: block;
   object-fit: contain;
+}
+
+@media (max-width: 1180px) {
+  .pl-site-testimonials-grid {
+    grid-auto-columns: calc((100% - 1.05rem) / 2 + 0.5rem);
+  }
+}
+
+@media (max-width: 550px) {
+  .pl-site-testimonials-grid {
+    grid-auto-columns: calc(100% - 3rem);
+  }
 }
 
 .pl-site-testimonials::after {

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -170,11 +170,22 @@
 .pl-site-testimonials-grid {
   margin-top: 1.15rem;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-rows: 1fr;
+  grid-auto-flow: column;
+  grid-auto-columns: min(22rem, calc(100% - 3rem));
   gap: 1.05rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.pl-site-testimonials-grid::-webkit-scrollbar {
+  display: none;
 }
 
 .pl-site-testimonial {
+  scroll-snap-align: start;
   margin: 0;
   border: 1px solid #e5e7eb;
   border-radius: 0.75rem;
@@ -266,41 +277,14 @@
   object-fit: contain;
 }
 
-@media (max-width: 1180px) {
-  .pl-site-testimonials-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 550px) {
-  .pl-site-testimonials-grid {
-    grid-template-columns: unset;
-    grid-template-rows: 1fr;
-    grid-auto-flow: column;
-    grid-auto-columns: calc(100% - 3rem);
-    overflow-x: auto;
-    scroll-snap-type: x mandatory;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-  }
-
-  .pl-site-testimonials-grid::-webkit-scrollbar {
-    display: none;
-  }
-
-  .pl-site-testimonial {
-    scroll-snap-align: start;
-  }
-
-  .pl-site-testimonials::after {
-    content: '•  •  •';
-    display: block;
-    text-align: center;
-    color: #d1d5db;
-    font-size: 1.1rem;
-    letter-spacing: 0.1em;
-    margin-top: 0.75rem;
-  }
+.pl-site-testimonials::after {
+  content: '•  •  •';
+  display: block;
+  text-align: center;
+  color: #d1d5db;
+  font-size: 1.1rem;
+  letter-spacing: 0.1em;
+  margin-top: 0.75rem;
 }
 
 /* Shared CTA reset */

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -275,7 +275,7 @@
 @media (max-width: 550px) {
   .pl-site-testimonials-grid {
     grid-template-columns: unset;
-    grid-template-rows: repeat(2, 1fr);
+    grid-template-rows: 1fr;
     grid-auto-flow: column;
     grid-auto-columns: calc(100% - 3rem);
     overflow-x: auto;


### PR DESCRIPTION
## Summary
- Removes the left navigation sidebar and right "ON THIS PAGE" table of contents from the homepage
- Drops `hasSidebar`, `sidebar`, and `headings` props from the `StarlightPage` component in `index.astro`
- Removes unused `getWebsiteSidebarLinks` import

## Test plan
- [ ] Verify homepage renders without left or right sidebars
- [ ] Verify other website pages (pricing, demo, jobs) still have their sidebars

<img width="1643" height="887" alt="image" src="https://github.com/user-attachments/assets/1691656e-53c3-474a-81a1-dc69a6caf6a4" /> 
<img width="417" height="826" alt="image" src="https://github.com/user-attachments/assets/4de2c1a2-7fff-44b7-a24a-522b27242690" />

