### PR TITLE
content: How to Measure Developer Documentation ROI

### DIFF
--- a/src/content/blog/technical/how-to-measure-developer-documentation-roi.mdx
+++ b/src/content/blog/technical/how-to-measure-developer-documentation-roi.mdx
@@ -1,0 +1,74 @@
+---
+title: 'How to Measure Developer Documentation ROI'
+subtitle: Published April 2026
+description: >-
+  Most documentation teams track outputs, not outcomes. Here's how to measure
+  developer documentation ROI, and why that return decays if docs aren't maintained.
+date: '2026-04-17T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Most documentation teams can tell you how many pages they published this quarter. Fewer can tell you what those pages are worth.
+
+The instinct is to measure output: word count, pages published, time to publish. These numbers are easy to track and easy to report. They are also the wrong ones. Output metrics measure effort, not value. A CFO deciding whether to hire a second technical writer does not need to know how many words were written last quarter. She needs to know what the documentation is doing for the business.
+
+Documentation ROI is real and measurable. The challenge is that it flows through channels most teams don't instrument.
+
+## The Cost Side Is Already Visible
+
+Before getting to returns, the cost of poor documentation is concrete enough to build a case around.
+
+Stripe's research found that developers spend up to 17 hours per week dealing with technical debt, with poor documentation as a primary contributor. Across the software industry, that adds up to roughly $85 billion annually in lost productivity. A Stack Overflow survey found that 78% of developers name poor documentation as the biggest problem in their daily work. Sixty-two percent spend more than 30 minutes each day searching for answers that their documentation should have provided.
+
+The cost lands on a specific line: engineering time. Every hour a developer spends reading source code instead of docs, or asking Slack questions that docs should answer, is a productivity cost. It just rarely gets attributed to documentation quality.
+
+## The Metrics That Capture Return
+
+Documentation's return flows through a few measurable channels. These are the ones worth tracking.
+
+**Time to First API Call.** Stripe benchmarks TTFC under 90 seconds for developer onboarding. Postman's research treats TTFC as the single most predictive metric for developer activation: developers who complete a first successful call are significantly more likely to continue integrating. The documentation lever is direct. A clear, working quickstart drives TTFC down. A stale or incomplete one drives it up.
+
+Going from a 10-minute TTFC to a 5-minute TTFC can produce a 40-60% jump in developer conversion rates. For any company with a developer funnel, that is a large return on a relatively small documentation investment.
+
+**Developer activation rate.** TTFC captures the first call. Activation is about getting from "this might work" to "I shipped something with this." The gap between those two milestones is where documentation quality shows up most clearly: in tutorials, reference accuracy, SDK guides, and error message explanations.
+
+**Support ticket volume.** A well-maintained knowledge base can reduce inbound support ticket volume by 40-60%. For teams with engineering time in their support rotation, every deflected ticket translates directly to hours recovered. A single common question deflected 200 times per month is a meaningful saving, and it compounds as the developer base grows. [Support agent deflection](https://promptless.ai/blog/technical/support-agent-deflection) scales in proportion to how current your documentation actually is.
+
+**Developer churn.** Research from multiple sources consistently puts the abandonment rate at around 50%: when documentation fails a developer, roughly half of them leave without filing a ticket or sending an email. They just stop. This is why tracking drop-off rates in the developer funnel, and auditing documentation state at the points of highest churn, often reveals a clearer picture than support data alone.
+
+<BlogNewsletterCTA />
+
+## The Decay Problem
+
+Here is the part most documentation ROI frameworks leave out: the return decays.
+
+A team that invests in excellent documentation at launch earns real returns. But as the product evolves, code changes against the docs. Parameters get renamed. Endpoints get deprecated. Authentication flows get restructured. The documentation that drove strong TTFC and high activation at launch begins delivering the opposite: blocked onboarding and silent developer abandonment.
+
+[Documentation drift](https://promptless.ai/blog/technical/documentation-drift-detection-problem) is the mechanism. Changes ship faster than documentation updates. The gap accumulates. 75% of APIs don't conform to their own specifications, according to recent research on API drift. That figure reflects teams that invested in documentation and then watched the return erode as the product moved underneath it.
+
+The ROI math becomes unfavorable quickly. A quickstart that drove a 40-60% conversion improvement now causes developers to hit errors on step two. A reference doc that deflected 200 support tickets per month now generates them. The documentation investment is the same. The return has inverted.
+
+## Why This Changes the Measurement Question
+
+Most ROI analysis treats documentation as a one-time investment with a fixed return: write the docs, measure the improvement, report the number. That framing misses the decay dynamic.
+
+The more accurate question is: how is the return holding over time, and is the gap between the product and the documentation widening?
+
+[Developer onboarding documentation](https://promptless.ai/blog/technical/developer-onboarding-documentation-fails-after-launch) tends to have the steepest decay curve. It receives the most developer traffic, covers the most product-specific detail, and changes fastest as the product evolves. It is the highest-return documentation to get right, and the highest-cost documentation to let go stale.
+
+Teams that measure documentation ROI well track two things alongside each other: the current return (TTFC, activation rate, support volume) and the maintenance state (how far the docs have drifted from the actual product). Neither tells the full story alone. Both together distinguish documentation quality problems from documentation decay problems, which have different causes and different fixes.
+
+## The Budget Argument, Reframed
+
+Documentation teams often frame the investment question as justifying headcount. The more useful frame is: what is the decay rate of our documentation investment, and what does it take to hold the return steady?
+
+Framed that way, the case for documentation investment is not about word count or publication frequency. It is about developer conversion rates and support ticket volume, both directly linked to how current the documentation actually is. The teams that make the strongest case are not the ones with the best launch-day docs. They are the ones who can show that their documentation's return is stable because they have a system to keep it current.
+
+That system, whether it is a rigorous review process, automated drift detection, or a combination, is where the maintenance budget conversation belongs. The cost of maintaining documentation accuracy is smaller than the cost of recovering from the developer churn and support load that accumulates when you don't.
+
+<BlogRequestDemo />

--- a/src/content/blog/technical/how-to-measure-developer-documentation-roi.mdx
+++ b/src/content/blog/technical/how-to-measure-developer-documentation-roi.mdx
@@ -15,7 +15,7 @@ import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
 Most documentation teams can tell you how many pages they published this quarter. Fewer can tell you what those pages are worth.
 
-The instinct is to measure output: word count, pages published, time to publish. These numbers are easy to track and easy to report. They are also the wrong ones. Output metrics measure effort, not value. A CFO deciding whether to hire a second technical writer does not need to know how many words were written last quarter. She needs to know what the documentation is doing for the business.
+The instinct is to measure output like word count, pages published, and time to publish. These numbers are easy to track and easy to report. They are also the wrong ones. Output metrics measure effort, not value. A CFO deciding whether to hire a second technical writer does not need to know how many words were written last quarter. She needs to know what the documentation is doing for the business.
 
 Documentation ROI is real and measurable. The challenge is that it flows through channels most teams don't instrument.
 
@@ -25,21 +25,21 @@ Before getting to returns, the cost of poor documentation is concrete enough to 
 
 Stripe's research found that developers spend up to 17 hours per week dealing with technical debt, with poor documentation as a primary contributor. Across the software industry, that adds up to roughly $85 billion annually in lost productivity. A Stack Overflow survey found that 78% of developers name poor documentation as the biggest problem in their daily work. Sixty-two percent spend more than 30 minutes each day searching for answers that their documentation should have provided.
 
-The cost lands on a specific line: engineering time. Every hour a developer spends reading source code instead of docs, or asking Slack questions that docs should answer, is a productivity cost. It just rarely gets attributed to documentation quality.
+The cost lands squarely on engineering time. Every hour a developer spends reading source code instead of docs, or asking Slack questions that docs should answer, is a productivity cost. It just rarely gets attributed to documentation quality.
 
 ## The Metrics That Capture Return
 
 Documentation's return flows through a few measurable channels. These are the ones worth tracking.
 
-**Time to First API Call.** Stripe benchmarks TTFC under 90 seconds for developer onboarding. Postman's research treats TTFC as the single most predictive metric for developer activation: developers who complete a first successful call are significantly more likely to continue integrating. The documentation lever is direct. A clear, working quickstart drives TTFC down. A stale or incomplete one drives it up.
+**Time to First API Call.** Stripe benchmarks TTFC under 90 seconds for developer onboarding. Postman's research treats TTFC as the single most predictive metric for developer activation. Developers who complete a first successful call are significantly more likely to continue integrating. The documentation lever is direct. A clear, working quickstart drives TTFC down, while a stale or incomplete one drives it up.
 
 Going from a 10-minute TTFC to a 5-minute TTFC can produce a 40-60% jump in developer conversion rates. For any company with a developer funnel, that is a large return on a relatively small documentation investment.
 
-**Developer activation rate.** TTFC captures the first call. Activation is about getting from "this might work" to "I shipped something with this." The gap between those two milestones is where documentation quality shows up most clearly: in tutorials, reference accuracy, SDK guides, and error message explanations.
+**Developer activation rate.** TTFC captures the first call. Activation is about getting from "this might work" to "I shipped something with this." The gap between those two milestones is where documentation quality shows through most in tutorials, reference accuracy, SDK guides, and error message explanations.
 
 **Support ticket volume.** A well-maintained knowledge base can reduce inbound support ticket volume by 40-60%. For teams with engineering time in their support rotation, every deflected ticket translates directly to hours recovered. A single common question deflected 200 times per month is a meaningful saving, and it compounds as the developer base grows. [Support agent deflection](https://promptless.ai/blog/technical/support-agent-deflection) scales in proportion to how current your documentation actually is.
 
-**Developer churn.** Research from multiple sources consistently puts the abandonment rate at around 50%: when documentation fails a developer, roughly half of them leave without filing a ticket or sending an email. They just stop. This is why tracking drop-off rates in the developer funnel, and auditing documentation state at the points of highest churn, often reveals a clearer picture than support data alone.
+**Developer churn.** Research from multiple sources consistently puts the abandonment rate at around 50%. When documentation fails a developer, roughly half of them leave without filing a ticket or sending an email. They just stop. This is why tracking drop-off rates in the developer funnel, and auditing documentation state at the points of highest churn, often reveals a clearer picture than support data alone.
 
 <BlogNewsletterCTA />
 
@@ -47,25 +47,25 @@ Going from a 10-minute TTFC to a 5-minute TTFC can produce a 40-60% jump in deve
 
 Here is the part most documentation ROI frameworks leave out: the return decays.
 
-A team that invests in excellent documentation at launch earns real returns. But as the product evolves, code changes against the docs. Parameters get renamed. Endpoints get deprecated. Authentication flows get restructured. The documentation that drove strong TTFC and high activation at launch begins delivering the opposite: blocked onboarding and silent developer abandonment.
+A team that invests in excellent documentation at launch earns real returns. But as the product evolves, code changes against the docs. Parameters get renamed, endpoints get deprecated, authentication flows get restructured. The documentation that drove strong TTFC and high activation at launch begins producing the opposite. Onboarding gets blocked, and developers abandon the project.
 
-[Documentation drift](https://promptless.ai/blog/technical/documentation-drift-detection-problem) is the mechanism. Changes ship faster than documentation updates. The gap accumulates. 75% of APIs don't conform to their own specifications, according to recent research on API drift. That figure reflects teams that invested in documentation and then watched the return erode as the product moved underneath it.
+[Documentation drift](https://promptless.ai/blog/technical/documentation-drift-detection-problem) is the mechanism. Changes ship faster than documentation updates, and the gap accumulates. 75% of APIs don't conform to their own specifications, according to recent research on API drift. That figure reflects teams that invested in documentation and then watched the return erode as the product moved underneath it.
 
 The ROI math becomes unfavorable quickly. A quickstart that drove a 40-60% conversion improvement now causes developers to hit errors on step two. A reference doc that deflected 200 support tickets per month now generates them. The documentation investment is the same. The return has inverted.
 
 ## Why This Changes the Measurement Question
 
-Most ROI analysis treats documentation as a one-time investment with a fixed return: write the docs, measure the improvement, report the number. That framing misses the decay dynamic.
+Most ROI analysis treats documentation as a one-time investment with a fixed return. Write the docs, measure the improvement, report the number. That framing misses the decay dynamic.
 
-The more accurate question is: how is the return holding over time, and is the gap between the product and the documentation widening?
+The more accurate question is whether the return is holding over time, and whether the gap between the product and the documentation is widening.
 
 [Developer onboarding documentation](https://promptless.ai/blog/technical/developer-onboarding-documentation-fails-after-launch) tends to have the steepest decay curve. It receives the most developer traffic, covers the most product-specific detail, and changes fastest as the product evolves. It is the highest-return documentation to get right, and the highest-cost documentation to let go stale.
 
-Teams that measure documentation ROI well track two things alongside each other: the current return (TTFC, activation rate, support volume) and the maintenance state (how far the docs have drifted from the actual product). Neither tells the full story alone. Both together distinguish documentation quality problems from documentation decay problems, which have different causes and different fixes.
+Teams that measure documentation ROI well watch the current return and the maintenance state at the same time, tracking TTFC, activation rate, and support volume alongside how far the docs have drifted from the actual product. Neither tells the full story alone. Both together distinguish documentation quality problems from documentation decay problems, which have different causes and different fixes.
 
 ## The Budget Argument, Reframed
 
-Documentation teams often frame the investment question as justifying headcount. The more useful frame is: what is the decay rate of our documentation investment, and what does it take to hold the return steady?
+Documentation teams often frame the investment question as justifying headcount. A more useful frame asks what the decay rate of the documentation investment is, and what it takes to hold the return steady.
 
 Framed that way, the case for documentation investment is not about word count or publication frequency. It is about developer conversion rates and support ticket volume, both directly linked to how current the documentation actually is. The teams that make the strongest case are not the ones with the best launch-day docs. They are the ones who can show that their documentation's return is stable because they have a system to keep it current.
 


### PR DESCRIPTION
**Keyword:** `developer documentation ROI`

## Article plan

**Keywords targeted:** `developer documentation ROI`, `technical documentation metrics`

**Thesis:** Developer documentation has measurable ROI — but that ROI decays as the product evolves, making maintenance as financially important as the original investment.

**Key points:**
- Most teams track documentation outputs (word count, pages published) rather than outcomes (TTFC, activation, support deflection, developer churn)
- TTFC is the clearest direct ROI metric: halving TTFC can produce a 40-60% jump in developer conversion
- Support ticket deflection: a good knowledge base reduces ticket volume by 40-60%
- 50% of developers abandon an API silently when docs fail them
- Documentation ROI decays over time as product and docs diverge (75% of APIs don't conform to their own specs)
- Maintenance is a financial decision, not just a quality one

**Promptless connection:** Promptless monitors the gap between product and docs — precisely what causes ROI decay.

## File

`src/content/blog/technical/how-to-measure-developer-documentation-roi.mdx`

This is an AI-generated draft and needs human review before publishing.