### PR TITLE
fix: restore section_viewed tracking and align CTAs with new nav

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,194 @@
+# Marketing Event Glossary
+
+Canonical reference for every PostHog event on promptless.ai.
+Add new events here first, then implement.
+
+## Conventions
+
+- Snake_case, past tense: `email_captured`, `section_viewed`
+- `location` — where on the site: `hero`, `nav`, `demo_page`, `blog`, `pricing_growth`, etc.
+- `$set: { email }` — always identify when we capture an email
+- `transport: 'sendBeacon'` — for events that fire on navigation/unload
+
+---
+
+## `email_captured`
+
+Fires every time a visitor gives us their email, regardless of context.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `intent` | string | Why they gave it: `demo`, `newsletter`, `free_tool` |
+| `location` | string | Where: `hero`, `demo_page`, `blog`, `free_tools` |
+| `campaign` | string | Campaign slug or empty |
+| `$set: { email }` | string | Always set to identify the person |
+
+**Sources**: HeroV2.astro, DemoBooking.astro, BlogRequestDemo.astro,
+BlogNewsletterCTA.astro, BrokenLinkReportForm.astro
+
+Replaces the old `demo_requested`, `blog_demo_requested`, and
+`blog_newsletter_subscribed` events. The `broken_link_report_submitted` event
+still fires separately with tool-specific properties — but `email_captured`
+fires alongside it.
+
+---
+
+## `cta_clicked`
+
+Fires on click of any element with `data-track-action`. Already implemented in
+`AnalyticsClickTracker.astro`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `action` | string | What the CTA does (see values below) |
+| `funnel_stage` | string | `conversion` or `evaluation` |
+| `location` | string | Where the CTA lives |
+| `campaign` | string | Campaign slug or empty |
+| `link_url` | string | href of the element |
+
+Current `action` values:
+
+| action | locations |
+|--------|-----------|
+| `book_demo` | `hero`, `nav`, `mobile_menu`, `pricing_growth`, `pricing_enterprise`, `docs_welcome` |
+| `sign_up` | `nav`, `mobile_menu`, `pricing_startup` |
+| `sign_in` | `nav`, `mobile_menu` |
+| `watch_demo` | `jobs_page` |
+| `use_free_tool` | `free_tools` |
+| `view_commits` | `demo_social_proof` |
+| `wtd_sign_up` | `hero_callout` |
+| `banner_cta` | `announcement_banner` |
+
+The `nav` row is the highest-traffic CTA location — after the Apr 2026 redesign
+it holds three buttons: Sign in (`sign_in`), Get a demo (`book_demo`), and
+Start for free (`sign_up`).
+
+Also fires `gtag('event', 'cta_click', ...)` for Google Analytics.
+
+---
+
+## `section_viewed`
+
+Fires when a homepage section enters the viewport (50%+ visible). Once per
+section per page load.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities` |
+| `page` | string | Pathname (always `/` for homepage) |
+
+**Component**: Inline IntersectionObserver in `posthog.astro`. Elements opt in
+with `data-section-tracked="<name>"` — a data attribute (not id) so the desktop
+and mobile testimonials variants can share a name without duplicate ids.
+
+---
+
+## `scroll_depth`
+
+Fires at 25%, 50%, 75%, 100% scroll milestones on blog posts. Once per
+milestone per page load.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `percent` | number | `25`, `50`, `75`, `100` |
+| `page` | string | Blog post pathname |
+
+**Component**: Inline script scoped to blog post pages, measuring scroll
+relative to the article content area.
+
+---
+
+## `video_played`
+
+Fires when a visitor starts playing an embedded video.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `video_id` | string | Video identifier (YouTube video ID or slug) |
+| `video_title` | string | Human-readable title |
+| `location` | string | Page where the video appears: `demo`, `homepage` |
+
+**Component**: `VideoEmbed.astro`. The homepage demo now uses YouTube
+(`AONpRsZJkTY`), which exposes the IFrame Player API — `video_played` and
+`video_progress` are unblocked but not yet implemented.
+
+---
+
+## `video_progress`
+
+Fires at 25%, 50%, 75%, 100% watch milestones.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `video_id` | string | Same as `video_played` |
+| `percent` | number | `25`, `50`, `75`, `100` |
+| `seconds_watched` | number | Elapsed watch time |
+
+**Component**: `VideoEmbed.astro`. Requires YouTube IFrame Player API.
+Homepage demo switched to YouTube on 2026-04-16, so this is unblocked.
+
+---
+
+## `banner_dismissed`
+
+Fires when a visitor closes an announcement banner.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `campaign` | string | Banner campaign slug (e.g. `wtd_pre_conference`) |
+
+**Component**: `AnnouncementBanner.astro`
+
+---
+
+## `pricing_bundle_changed`
+
+Fires when a visitor changes the Growth plan page-range dropdown on /pricing.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `bundle_id` | string | e.g. `growth-200-500` |
+| `bundle_label` | string | e.g. `200-500 Pages` |
+| `price_label` | string | e.g. `$500-$1,000/mo` |
+
+**Component**: `GrowthBundleSelector.astro`
+
+---
+
+## `site_searched`
+
+Fires when a visitor types 2+ characters in the Pagefind search input
+(debounced 1s). Already implemented in `posthog.astro`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `query` | string | Search text |
+| `page_url` | string | Pathname where the search happened |
+
+---
+
+## `broken_link_report_submitted`
+
+Fires when a visitor submits the broken link checker tool. Already implemented
+in `BrokenLinkReportForm.astro`. Note: `email_captured` also fires alongside
+this event.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `target_url` | string | URL to scan |
+| `check_external` | boolean | Include external links |
+| `check_anchors` | boolean | Include anchor links |
+| `max_pages` | number \| null | Page limit |
+| `$set: { email }` | string | Identifies the visitor |
+
+---
+
+## Implementation Priority
+
+1. `email_captured` — consolidate all email capture, highest analytical value
+2. `section_viewed` — understand homepage engagement depth
+3. `pricing_bundle_changed` — understand pricing interest signals
+4. `banner_dismissed` — measure banner effectiveness
+5. `scroll_depth` — blog content engagement
+6. `video_played` — homepage is on YouTube as of 2026-04-16, ready to implement
+7. `video_progress` — homepage is on YouTube as of 2026-04-16, ready to implement

--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -12,26 +12,32 @@
     })
 
     // Track homepage section views (50%+ visible, once per section per page load).
-    // Uses IntersectionObserver to fire 'section_viewed' when a user scrolls each
-    // section into view. The 0.5 threshold means the event fires once 50% of the
-    // section is visible. viewedSections prevents duplicate events for the same
-    // section if the user scrolls back and forth.
+    // Elements opt in with data-section-tracked="<name>" — section_viewed fires
+    // once per name per page load when a matching element reaches 50% visibility.
+    // Uses a data attribute (not id) so display:none variants (e.g. mobile vs
+    // desktop testimonials) can share a name without duplicate ids.
+    // Runs on DOMContentLoaded since this script lives in <head>/top-of-body
+    // and the sections it observes render later in the document.
     if (location.pathname === '/') {
-      var sectionIds = ['overview', 'testimonials', 'how-promptless-works', 'capabilities'];
-      var viewedSections = {}; // Tracks which sections already fired to avoid duplicates
-      var sectionObs = new IntersectionObserver(function (entries) {
-        entries.forEach(function (entry) {
-          if (!entry.isIntersecting) return; // Ignore when section leaves viewport
-          var id = entry.target.id;
-          if (viewedSections[id]) return; // Skip if already tracked
-          viewedSections[id] = true;
-          posthog.capture('section_viewed', { section: id, page: location.pathname });
-        });
-      }, { threshold: 0.5 }); // Fire when 50% of section is visible
-      sectionIds.forEach(function (id) {
-        var el = document.getElementById(id);
-        if (el) sectionObs.observe(el);
-      });
+      var startSectionObserver = function () {
+        var viewedSections = {}; // Dedupe across multiple elements with the same name
+        var sectionObs = new IntersectionObserver(function (entries) {
+          entries.forEach(function (entry) {
+            if (!entry.isIntersecting) return;
+            var name = entry.target.getAttribute('data-section-tracked');
+            if (!name || viewedSections[name]) return;
+            viewedSections[name] = true;
+            posthog.capture('section_viewed', { section: name, page: location.pathname });
+          });
+        }, { threshold: 0.5 });
+        var els = document.querySelectorAll('[data-section-tracked]');
+        for (var i = 0; i < els.length; i++) sectionObs.observe(els[i]);
+      };
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', startSectionObserver);
+      } else {
+        startSectionObserver();
+      }
     }
 
     // Track scroll depth on blog posts (25/50/75/100%, once per milestone per page load).

--- a/src/components/shared/TopHeader.astro
+++ b/src/components/shared/TopHeader.astro
@@ -19,7 +19,7 @@ const { activeSection = getActiveSection(Astro.url.pathname), showNavTools = fal
     </slot>
     {showNavTools ? <div class="pl-site-search sl-flex print:hidden"><slot name="nav-tools" /></div> : null}
     <div class="pl-site-cta-row">
-      <a class="pl-site-cta pl-site-cta-login" href="https://app.gopromptless.ai" target="_blank" rel="noopener noreferrer" data-track-action="login" data-track-location="nav">Sign in</a>
+      <a class="pl-site-cta pl-site-cta-login" href="https://app.gopromptless.ai" target="_blank" rel="noopener noreferrer" data-track-action="sign_in" data-track-location="nav">Sign in</a>
       <a class="pl-site-cta pl-site-cta-secondary" href="/meet" data-track-action="book_demo" data-track-funnel="conversion" data-track-location="nav">Get a demo</a>
       <a class="pl-site-cta" href="https://accounts.gopromptless.ai/sign-up" data-track-action="sign_up" data-track-funnel="conversion" data-track-location="nav">Start for free</a>
     </div>

--- a/src/components/site/HeroV2.astro
+++ b/src/components/site/HeroV2.astro
@@ -1,7 +1,7 @@
 ---
 ---
 
-<section id="overview" class="pl-hero-v2">
+<section id="overview" class="pl-hero-v2" data-section-tracked="overview">
   <h1 class="pl-hero-v2-title">
     Ship world-class docs.
   </h1>

--- a/src/components/site/HowItWorks.astro
+++ b/src/components/site/HowItWorks.astro
@@ -68,7 +68,7 @@ const {
 } = Astro.props;
 ---
 
-<section class:list={['pl-site-steps', { 'is-compact': compact }]} id={id} data-sticky-heading={showHeading ? 'true' : 'false'}>
+<section class:list={['pl-site-steps', { 'is-compact': compact }]} id={id} data-sticky-heading={showHeading ? 'true' : 'false'} data-section-tracked="how-promptless-works">
   {showHeading && <h2 class="pl-site-steps-heading">{heading}</h2>}
 
   <div class="pl-site-step-list">

--- a/src/components/site/Testimonials.astro
+++ b/src/components/site/Testimonials.astro
@@ -81,7 +81,7 @@ const defaultItems: Testimonial[] = [
 const { items = defaultItems } = Astro.props;
 ---
 
-<section id="testimonials" class="pl-site-testimonials" aria-label="Testimonials">
+<section id="testimonials" class="pl-site-testimonials" aria-label="Testimonials" data-section-tracked="testimonials">
   <h2>Writers, developers, and founders all love Promptless</h2>
   <div class="pl-site-testimonials-grid">
     {

--- a/src/components/site/TestimonialsVertical.astro
+++ b/src/components/site/TestimonialsVertical.astro
@@ -74,7 +74,7 @@ const testimonials: Testimonial[] = [
 ];
 ---
 
-<div class="pl-testimonials-vertical">
+<div class="pl-testimonials-vertical" data-section-tracked="testimonials">
   <div class="pl-testimonials-vertical-track">
     {
       [...testimonials, ...testimonials].map((item) => (

--- a/src/components/site/VideoEmbed.astro
+++ b/src/components/site/VideoEmbed.astro
@@ -12,7 +12,7 @@ const {
 } = Astro.props;
 ---
 
-<section id={id}>
+<section id={id} data-section-tracked={id}>
   <div class="pl-site-video-embed">
     <iframe
       src={src}

--- a/src/components/site/WhyPromptless.astro
+++ b/src/components/site/WhyPromptless.astro
@@ -53,7 +53,7 @@ const defaultCapabilities: Capability[] = [
 const { capabilities = defaultCapabilities } = Astro.props;
 ---
 
-<section id="capabilities" class="pl-site-why" aria-label="Capabilities">
+<section id="capabilities" class="pl-site-why" aria-label="Capabilities" data-section-tracked="capabilities">
   <p class="pl-site-kicker">Why Promptless?</p>
   <h2>Built to fit into your workflows, not to make you a prompt engineer</h2>
   <div class="pl-site-why-grid">

--- a/src/components/starlight/MobileMenuFooter.astro
+++ b/src/components/starlight/MobileMenuFooter.astro
@@ -1,6 +1,6 @@
 <div class="pl-mobile-menu-footer">
   <a class="pl-mobile-menu-primary" href="/meet" data-track-action="book_demo" data-track-funnel="conversion" data-track-location="mobile_menu">Book demo</a>
-  <a class="pl-mobile-menu-secondary" href="https://app.gopromptless.ai" data-track-action="sign_in" data-track-funnel="conversion" data-track-location="mobile_menu">Sign in</a>
+  <a class="pl-mobile-menu-secondary" href="https://app.gopromptless.ai" data-track-action="login" data-track-location="mobile_menu">Sign in</a>
 </div>
 
 <style>

--- a/src/components/starlight/MobileMenuFooter.astro
+++ b/src/components/starlight/MobileMenuFooter.astro
@@ -1,6 +1,6 @@
 <div class="pl-mobile-menu-footer">
   <a class="pl-mobile-menu-primary" href="/meet" data-track-action="book_demo" data-track-funnel="conversion" data-track-location="mobile_menu">Book demo</a>
-  <a class="pl-mobile-menu-secondary" href="https://app.gopromptless.ai" data-track-action="login" data-track-location="mobile_menu">Sign in</a>
+  <a class="pl-mobile-menu-secondary" href="https://app.gopromptless.ai" data-track-action="sign_in" data-track-location="mobile_menu">Sign in</a>
 </div>
 
 <style>


### PR DESCRIPTION
## Summary

- **Fixes a silent analytics regression**: `section_viewed` has been firing **0 times for 14+ days**. The inline IntersectionObserver in `posthog.astro` runs inside the `<head>`-mounted PostHog component, before the observed sections exist in the DOM — so `document.getElementById(...)` always returned `null`. Now deferred to `DOMContentLoaded` and queried via `document.querySelectorAll`.
- **Makes section tracking robust to the new design**: switch from `id` lookup to a `data-section-tracked="<name>"` attribute. The Apr 16 landing page refactor (#401) replaced the testimonials grid with two variants (desktop `TestimonialsVertical`, mobile `Testimonials`) — duplicate ids would be invalid, but a shared data attribute is fine and lets whichever variant is visible fire the event. Annotates the five homepage sections: `overview`, `testimonials`, `how-promptless-works`, `capabilities`, and the new `demo` (YouTube video) section.
- **Keeps the "Sign in" action labeled `sign_in`**: the landing refactor had switched the top nav's "Sign in" link to `data-track-action="login"`. Changed it back to `sign_in` so the action name stays consistent across nav and mobile menu and preserves continuity with historical `cta_clicked` data.
- **Commits the marketing event glossary** (`docs/events.md`) that was previously only a local working doc. Updates it to reflect the new `demo` section, the `data-section-tracked` mechanism, the `sign_in`/`sign_up` nav CTAs, the move from Hero.astro to HeroV2.astro, and YouTube unblocking `video_played` / `video_progress`.

## PostHog activity last 14 days (test accounts filtered)

| event | count | note |
|-------|------:|------|
| Homepage `$pageview` | 778 | Steady ~55/day, no shift at the Apr 16 redesign |
| `cta_clicked` | 39 | `nav` dominates (19), `hero` only 1 |
| `email_captured` | 1 | First-ever HeroV2 form capture on Apr 16 |
| `section_viewed` | **0** | Broken — this PR fixes it |
| `banner_dismissed` | 0 | Banner not currently shown |

Top CTA actions: `book_demo` (11), `sign_up` (10), `view_commits` (8), `use_free_tool` (7), `watch_demo` (3).

## Not included

- The still-orphaned `HeroV1.astro` / `Hero.astro` components (no longer used on `/`, used on `/use-cases/technical-writer-power-tool`).

## Test plan

- [ ] Load `/` and verify 5 `section_viewed` events fire as you scroll through the page (one per: overview, testimonials, demo, how-promptless-works, capabilities)
- [ ] Confirm no duplicates when scrolling back up
- [ ] Confirm no `section_viewed` on non-`/` pages
- [ ] Click the top nav "Sign in" link and verify `cta_clicked` fires with `action: sign_in`, `location: nav`
- [ ] Click the mobile menu "Sign in" button and verify `cta_clicked` fires with `action: sign_in`, `location: mobile_menu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)