### PR TITLE
content: Documentation Debt Accrues Where Your Team Can't See It

### DIFF
--- a/src/content/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it.mdx
+++ b/src/content/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it.mdx
@@ -1,0 +1,79 @@
+---
+title: 'Documentation Debt Accrues Where Your Team Can''t See It'
+subtitle: Published April 2026
+description: >-
+  Documentation debt quietly costs mid-sized engineering teams $500K–$2M annually. The people bearing that cost aren't in your standups. Here's how to prioritize what to fix.
+date: '2026-04-20T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer opens your quickstart guide, follows step three, and hits an error. The API parameter was renamed four months ago. They search your public Slack, find nothing helpful, and close the tab. No support ticket. No email. Your dashboards look clean.
+
+That is documentation debt collecting interest.
+
+Documentation debt is the accumulated gap between what your docs say and what your product actually does, plus the sections where docs don't exist at all. Teams accumulate it passively: shipping without updating reference pages and releasing new features before the quickstart catches up.
+
+The productivity cost inside your organization is real. Research consistently estimates that documentation problems consume 15–25% of total engineering capacity (developers reading source code instead of docs and asking Slack questions that accurate documentation would prevent). For a 100-person engineering team, that's the equivalent of 15–25 engineers whose time disappears into compensating for missing or inaccurate documentation. Annually, that translates to somewhere between $500,000 and $2 million in a mid-sized company.
+
+But those numbers capture only what happens inside your organization. The higher cost sits outside it.
+
+## The externalized cost problem
+
+When code debt slows your engineers down, they show up to sprint planning and say so. The slowdown is legible. It gets tracked and scheduled.
+
+Documentation debt slows down the people trying to use your product. They don't show up in your standups. A developer who hits a broken quickstart doesn't file a support ticket and wait. Research consistently finds that [around 50% of developers abandon an API](https://userguiding.com/blog/user-onboarding-statistics) when documentation fails them. They move on quietly. The broken page stays up for the next developer who hits the same wall.
+
+The scale of this is not subtle. [Postman's 2024 State of the API report](https://www.postman.com/state-of-api/2024) found that 68% of developers cite outdated documentation as their top frustration when working with APIs. 78% of development teams report challenges with outdated or insufficient documentation. 64% of developers spend four or more hours per week searching for project information that should already be accessible.
+
+What makes documentation debt durable is the gap between how much pain it causes and how visible that pain is to the teams responsible for it. The people most affected (new developers and external integration partners) have no seat at the table when backlog priorities get set.
+
+AI coding agents have made this more acute. A developer can often work around a stale code sample: recognize a deprecated method and adapt. An AI agent follows your documentation literally and produces broken code. The developer then debugs the AI's output, traces the error back to your docs, and hits the same wall faster than they would have without the AI. This is [a pattern that shows up clearly in onboarding data](https://promptless.ai/blog/technical/developer-onboarding-documentation-fails-after-launch): stale documentation is less forgiving when agents amplify whatever they read.
+
+<BlogNewsletterCTA />
+
+## Why auditing by age gives you the wrong priority list
+
+When teams do address documentation debt, the default method is age. Flag pages that haven't been updated in twelve months. Run a documentation sprint. Work through the oldest sections first.
+
+The problem: age is a rough proxy for staleness. A two-year-old API reference page for a stable feature that hasn't changed is low priority. A six-month-old quickstart for an auth flow that's been updated twice since then is a live problem. Age doesn't tell you which pages are actually wrong or which pages actually matter.
+
+A more useful prioritization metric is blast radius: traffic volume multiplied by change frequency.
+
+**Traffic volume** tells you how many developers are reading a page. A page with 5,000 monthly views has 50 times the blast radius of one with 100 monthly views.
+
+**Change frequency** tells you how likely that page is to have drifted from what the product actually does. Pages covering authentication, onboarding flows, and core API endpoints change more often than reference pages for stable, rarely-touched features.
+
+High traffic combined with high change frequency identifies the documentation debt that is actively costing you users right now. Most teams have the data to run this calculation (analytics from their docs site and change history from their repository) but have never connected the two. Documentation sprints end up targeting the oldest pages and missing the ones with the most blast radius.
+
+## Where documentation debt concentrates
+
+In practice, debt accumulates in predictable places.
+
+**Quickstart guides.** These get written carefully at launch, then update inconsistently as the product evolves. A minor authentication change that gets three lines in a changelog can break an onboarding guide in ways that aren't obvious until a developer hits step five and gets an error they can't interpret.
+
+**API reference pages for active endpoints.** Teams that ship frequently accumulate parameter-level debt quickly. An endpoint updated four times may have a reference page reflecting two of those updates.
+
+**Code samples.** Samples break silently. A deprecated function doesn't visibly error until someone runs it. Most teams have no systematic check that their code samples remain executable.
+
+**Multi-step tutorials.** These have the highest failure surface: every step is a potential breakage point, and the full path requires multiple features to work simultaneously and accurately.
+
+These surfaces share a common characteristic: they're the ones developers rely on first, and the ones where failure sends developers away rather than toward your support queue.
+
+## The organizational fix
+
+[Docs-as-code workflows](https://promptless.ai/blog/technical/help-center-to-docs-as-code) (version-controlled documentation, PR templates that ask "did you update the docs?") create good habits and reduce future debt. They don't address the existing pile.
+
+A PR template asking "did you update the docs?" only helps if the engineer remembered which docs were affected. Quarterly documentation audits catch drift that already happened. Neither approach closes the loop between a code change and a documentation update in real time.
+
+The higher-leverage fix is connecting documentation review to code change signals upstream. When an engineer changes an authentication endpoint, the documentation pages covering that endpoint should surface for review automatically, flagged by the change that introduced the problem rather than discovered by a writer scanning PRs after the fact. This is the shift [from reactive audits to continuous detection](https://promptless.ai/blog/technical/documentation-drift-detection-problem) that teams with serious documentation coverage problems need.
+
+Teams that solve detection find their writing capacity goes further. Writers spend less time on surveillance (scanning PRs and triaging support tickets for documentation-related patterns) and more time on work that raises documentation quality.
+
+For teams working through an existing backlog, the practical starting point is the blast-radius calculation: pull traffic data from your docs analytics and cross-reference it against pages covering surfaces that have changed frequently. The priority list that emerges will not be the oldest pages. It will be the most dangerous ones.
+
+<BlogRequestDemo />

--- a/src/content/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it.mdx
+++ b/src/content/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it.mdx
@@ -12,13 +12,13 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-A developer opens your quickstart guide, follows step three, and hits an error. The API parameter was renamed four months ago. They search your public Slack, find nothing helpful, and close the tab. No support ticket. No email. Your dashboards look clean.
+A developer opens your quickstart guide, follows step three, and hits an error. The API parameter was renamed four months ago. They search your public Slack, find nothing helpful, and close the tab. They don't file a support ticket or send an email, so your dashboards look clean.
 
 That is documentation debt collecting interest.
 
-Documentation debt is the accumulated gap between what your docs say and what your product actually does, plus the sections where docs don't exist at all. Teams accumulate it passively: shipping without updating reference pages and releasing new features before the quickstart catches up.
+Documentation debt is the accumulated gap between what your docs say and what your product actually does, plus the sections where docs don't exist at all. Teams accumulate it passively by shipping without updating reference pages and releasing new features before the quickstart catches up.
 
-The productivity cost inside your organization is real. Research consistently estimates that documentation problems consume 15–25% of total engineering capacity (developers reading source code instead of docs and asking Slack questions that accurate documentation would prevent). For a 100-person engineering team, that's the equivalent of 15–25 engineers whose time disappears into compensating for missing or inaccurate documentation. Annually, that translates to somewhere between $500,000 and $2 million in a mid-sized company.
+The productivity cost inside your organization is real. Research consistently estimates that documentation problems consume 15 to 25% of total engineering capacity, as developers read source code instead of docs and ask Slack questions that accurate documentation would prevent. For a 100-person engineering team, that's the equivalent of 15 to 25 engineers whose time disappears into compensating for missing or inaccurate documentation. Annually, that translates to somewhere between $500,000 and $2 million in a mid-sized company.
 
 But those numbers capture only what happens inside your organization. The higher cost sits outside it.
 
@@ -26,13 +26,13 @@ But those numbers capture only what happens inside your organization. The higher
 
 When code debt slows your engineers down, they show up to sprint planning and say so. The slowdown is legible. It gets tracked and scheduled.
 
-Documentation debt slows down the people trying to use your product. They don't show up in your standups. A developer who hits a broken quickstart doesn't file a support ticket and wait. Research consistently finds that [around 50% of developers abandon an API](https://userguiding.com/blog/user-onboarding-statistics) when documentation fails them. They move on quietly. The broken page stays up for the next developer who hits the same wall.
+Documentation debt slows down the people trying to use your product. They don't show up in your standups. A developer who hits a broken quickstart doesn't file a support ticket and wait. Research consistently finds that [around 50% of developers abandon an API](https://userguiding.com/blog/user-onboarding-statistics) when documentation fails them, and the broken page stays up for the next developer who hits the same wall.
 
 The scale of this is not subtle. [Postman's 2024 State of the API report](https://www.postman.com/state-of-api/2024) found that 68% of developers cite outdated documentation as their top frustration when working with APIs. 78% of development teams report challenges with outdated or insufficient documentation. 64% of developers spend four or more hours per week searching for project information that should already be accessible.
 
-What makes documentation debt durable is the gap between how much pain it causes and how visible that pain is to the teams responsible for it. The people most affected (new developers and external integration partners) have no seat at the table when backlog priorities get set.
+What makes documentation debt durable is the gap between how much pain it causes and how visible that pain is to the teams responsible for it. The people most affected are new developers and external integration partners, and they have no seat at the table when backlog priorities get set.
 
-AI coding agents have made this more acute. A developer can often work around a stale code sample: recognize a deprecated method and adapt. An AI agent follows your documentation literally and produces broken code. The developer then debugs the AI's output, traces the error back to your docs, and hits the same wall faster than they would have without the AI. This is [a pattern that shows up clearly in onboarding data](https://promptless.ai/blog/technical/developer-onboarding-documentation-fails-after-launch): stale documentation is less forgiving when agents amplify whatever they read.
+AI coding agents have made this more acute. A developer can often work around a stale code sample by recognizing a deprecated method and adapting. An AI agent follows your documentation literally and produces broken code. The developer then debugs the AI's output, traces the error back to your docs, and hits the same wall faster than they would have without the AI. Stale documentation is less forgiving when agents amplify whatever they read, [a pattern that shows up in onboarding data](https://promptless.ai/blog/technical/developer-onboarding-documentation-fails-after-launch).
 
 <BlogNewsletterCTA />
 
@@ -40,15 +40,15 @@ AI coding agents have made this more acute. A developer can often work around a 
 
 When teams do address documentation debt, the default method is age. Flag pages that haven't been updated in twelve months. Run a documentation sprint. Work through the oldest sections first.
 
-The problem: age is a rough proxy for staleness. A two-year-old API reference page for a stable feature that hasn't changed is low priority. A six-month-old quickstart for an auth flow that's been updated twice since then is a live problem. Age doesn't tell you which pages are actually wrong or which pages actually matter.
+The problem is that age is a rough proxy for staleness. A two-year-old API reference page for a stable feature that hasn't changed is low priority. A six-month-old quickstart for an auth flow that's been updated twice since then is a live problem. Age doesn't tell you which pages are actually wrong or which pages actually matter.
 
-A more useful prioritization metric is blast radius: traffic volume multiplied by change frequency.
+A more useful prioritization metric is blast radius, calculated as traffic volume multiplied by change frequency.
 
 **Traffic volume** tells you how many developers are reading a page. A page with 5,000 monthly views has 50 times the blast radius of one with 100 monthly views.
 
 **Change frequency** tells you how likely that page is to have drifted from what the product actually does. Pages covering authentication, onboarding flows, and core API endpoints change more often than reference pages for stable, rarely-touched features.
 
-High traffic combined with high change frequency identifies the documentation debt that is actively costing you users right now. Most teams have the data to run this calculation (analytics from their docs site and change history from their repository) but have never connected the two. Documentation sprints end up targeting the oldest pages and missing the ones with the most blast radius.
+High traffic combined with high change frequency identifies the documentation debt that is actively costing you users right now. Most teams already have analytics from their docs site and change history from their repository, but have never connected the two. Documentation sprints end up targeting the oldest pages and missing the ones with the most blast radius.
 
 ## Where documentation debt concentrates
 
@@ -60,20 +60,20 @@ In practice, debt accumulates in predictable places.
 
 **Code samples.** Samples break silently. A deprecated function doesn't visibly error until someone runs it. Most teams have no systematic check that their code samples remain executable.
 
-**Multi-step tutorials.** These have the highest failure surface: every step is a potential breakage point, and the full path requires multiple features to work simultaneously and accurately.
+**Multi-step tutorials.** These have the highest failure surface. Every step is a potential breakage point, and the full path requires multiple features to work simultaneously and accurately.
 
-These surfaces share a common characteristic: they're the ones developers rely on first, and the ones where failure sends developers away rather than toward your support queue.
+These surfaces share a common characteristic. They're the ones developers rely on first, and the ones where failure sends developers away instead of toward your support queue.
 
 ## The organizational fix
 
-[Docs-as-code workflows](https://promptless.ai/blog/technical/help-center-to-docs-as-code) (version-controlled documentation, PR templates that ask "did you update the docs?") create good habits and reduce future debt. They don't address the existing pile.
+[Docs-as-code workflows](https://promptless.ai/blog/technical/help-center-to-docs-as-code), including version-controlled documentation and PR templates that prompt engineers to update the docs, create good habits and reduce future debt. They don't address the existing pile.
 
-A PR template asking "did you update the docs?" only helps if the engineer remembered which docs were affected. Quarterly documentation audits catch drift that already happened. Neither approach closes the loop between a code change and a documentation update in real time.
+A PR template reminding engineers to update the docs only helps if the engineer remembered which docs were affected. Quarterly documentation audits catch drift that already happened. Neither approach closes the loop between a code change and a documentation update in real time.
 
-The higher-leverage fix is connecting documentation review to code change signals upstream. When an engineer changes an authentication endpoint, the documentation pages covering that endpoint should surface for review automatically, flagged by the change that introduced the problem rather than discovered by a writer scanning PRs after the fact. This is the shift [from reactive audits to continuous detection](https://promptless.ai/blog/technical/documentation-drift-detection-problem) that teams with serious documentation coverage problems need.
+The higher-leverage fix is connecting documentation review to code change signals upstream. When an engineer changes an authentication endpoint, the documentation pages covering that endpoint should surface for review automatically, flagged by the change that introduced the problem instead of discovered by a writer scanning PRs after the fact. This is the shift [from reactive audits to continuous detection](https://promptless.ai/blog/technical/documentation-drift-detection-problem) that teams with serious documentation coverage problems need.
 
-Teams that solve detection find their writing capacity goes further. Writers spend less time on surveillance (scanning PRs and triaging support tickets for documentation-related patterns) and more time on work that raises documentation quality.
+Teams that solve detection find their writing capacity goes further. Writers spend less time scanning PRs and triaging support tickets for documentation-related patterns, and more time on work that raises documentation quality.
 
-For teams working through an existing backlog, the practical starting point is the blast-radius calculation: pull traffic data from your docs analytics and cross-reference it against pages covering surfaces that have changed frequently. The priority list that emerges will not be the oldest pages. It will be the most dangerous ones.
+For teams working through an existing backlog, the practical starting point is the blast-radius calculation. Pull traffic data from your docs analytics and cross-reference it against pages covering surfaces that have changed frequently. The priority list that emerges will not be the oldest pages. It will be the most dangerous ones.
 
 <BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `documentation debt`

## Article plan

**Thesis:** Documentation debt is underestimated because its cost is externalized to the people reading your docs (new developers, API consumers), and most teams make it worse by prioritizing debt paydown using the wrong signal — page age instead of blast radius (traffic × change frequency).

**Target reader:** Technical writers and DevRel engineers at developer-facing companies who know they have doc debt but are overwhelmed by where to start.

**Key points:**
1. Doc debt's cost is externalized — the affected parties (new developers, integration partners) don't show up in standups, they abandon silently
2. The standard audit method (age of page) is the wrong signal — a stable two-year-old page is less dangerous than a recently-broken quickstart
3. Blast radius = traffic × change frequency — the right prioritization metric
4. Docs-as-code prevents future debt but doesn't solve the existing pile
5. The fix is connecting doc review to code change signals upstream, not reactive quarterly audits

**Internal links:** documentation-drift-detection-problem, developer-onboarding-documentation-fails-after-launch, help-center-to-docs-as-code

## File

`src/content/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it.mdx`

This is an AI-generated draft and needs human review before publishing.