### PR TITLE
Track hero clicks and forward PostHog identity to Cal.com

### DIFF
--- a/src/components/site/DemoBooking.astro
+++ b/src/components/site/DemoBooking.astro
@@ -108,9 +108,22 @@
 
     var calLink = 'team/promptless/15m-discovery-call';
     var storedEmail = getStoredEmail();
-    if (storedEmail) {
-      calLink += '?email=' + encodeURIComponent(storedEmail);
-    }
+    var ph = window.posthog;
+    var distinctId = null;
+    var sessionId = null;
+    try { distinctId = sessionStorage.getItem('pl_ph_distinct_id'); } catch (_) {}
+    try { sessionId = sessionStorage.getItem('pl_ph_session_id'); } catch (_) {}
+    try {
+      if (!distinctId && ph && typeof ph.get_distinct_id === 'function') distinctId = ph.get_distinct_id();
+      if (!sessionId && ph && typeof ph.get_session_id === 'function') sessionId = ph.get_session_id();
+    } catch (_) {}
+
+    var params = new URLSearchParams();
+    if (storedEmail) params.set('email', storedEmail);
+    if (distinctId) params.set('metadata[posthog_distinct_id]', distinctId);
+    if (sessionId) params.set('metadata[posthog_session_id]', sessionId);
+    var qs = params.toString();
+    if (qs) calLink += '?' + qs;
 
     window.Cal('init', namespace, { origin: 'https://app.cal.com' });
     window.Cal.ns[namespace]('inline', {
@@ -172,6 +185,14 @@
           $set: { email: email },
         });
       }
+
+      try {
+        var phNow = window.posthog;
+        var did = phNow && phNow.get_distinct_id && phNow.get_distinct_id();
+        var sid = phNow && phNow.get_session_id && phNow.get_session_id();
+        if (did) sessionStorage.setItem('pl_ph_distinct_id', did);
+        if (sid) sessionStorage.setItem('pl_ph_session_id', sid);
+      } catch (_) {}
 
       if (statusEl) {
         statusEl.textContent = 'Thanks! We\u2019ll be in touch.';

--- a/src/components/site/HeroV2.astro
+++ b/src/components/site/HeroV2.astro
@@ -55,6 +55,10 @@ const toolchainLogos = [
       <a
         class="pl-hero-v2-feature-text"
         href="https://promptless.ai/docs/configuring-promptless/doc-collections/how-promptless-learns-your-docs/#voice-and-style-learning"
+        data-track-action="hero_feature"
+        data-track-funnel="education"
+        data-track-location="hero"
+        data-track-campaign="style_guide"
       >
         Follows your style guide
       </a>
@@ -81,6 +85,10 @@ const toolchainLogos = [
       <a
         class="pl-hero-v2-feature-text"
         href="https://promptless.ai/blog/product-updates/launch-week-december-2025/#day-5-promptless-capture"
+        data-track-action="hero_feature"
+        data-track-funnel="education"
+        data-track-location="hero"
+        data-track-campaign="screenshots"
       >
         Auto-updated screenshots
       </a>
@@ -108,7 +116,14 @@ const toolchainLogos = [
         <rect x="14" y="2" width="8" height="8" rx="1" fill="currentColor" fill-opacity="0.18" />
       </svg>
       <div class="pl-hero-v2-feature-content">
-        <a class="pl-hero-v2-feature-text" href="https://promptless.ai/docs/integrations/">
+        <a
+          class="pl-hero-v2-feature-text"
+          href="https://promptless.ai/docs/integrations/"
+          data-track-action="hero_feature"
+          data-track-funnel="education"
+          data-track-location="hero"
+          data-track-campaign="toolchain"
+        >
           Very flexible, fits into any toolchain:
         </a>
         <ul class="pl-hero-v2-toolchain">
@@ -120,6 +135,10 @@ const toolchainLogos = [
                 rel="noopener"
                 aria-label={`${logo.name} integration docs`}
                 title={logo.name}
+                data-track-action="hero_toolchain"
+                data-track-funnel="education"
+                data-track-location="hero"
+                data-track-campaign={logo.slug}
               >
                 <img
                   src={`/site/logos/toolchain/${logo.slug}.svg`}
@@ -186,6 +205,17 @@ const toolchainLogos = [
         campaign: '',
         ...(email ? { $set: { email } } : {}),
       });
+
+      // Stash PostHog identifiers so /meet can forward them to Cal.com
+      // as booking metadata, letting the webhook stitch demo_booked onto
+      // the same session/person timeline.
+      try {
+        const ph = (window as any).posthog;
+        const distinctId = ph?.get_distinct_id?.();
+        const sessionId = ph?.get_session_id?.();
+        if (distinctId) sessionStorage.setItem('pl_ph_distinct_id', distinctId);
+        if (sessionId) sessionStorage.setItem('pl_ph_session_id', sessionId);
+      } catch {}
 
       if (submitButton instanceof HTMLButtonElement) {
         submitButton.disabled = true;

--- a/src/components/site/MeetCalendarInline.astro
+++ b/src/components/site/MeetCalendarInline.astro
@@ -47,11 +47,27 @@
           };
       })(window, 'https://app.cal.com/embed/embed.js', 'init');
 
+      let resolvedCalLink = calLink;
+      try {
+        const ph = window.posthog;
+        let distinctId = null;
+        let sessionId = null;
+        try { distinctId = sessionStorage.getItem('pl_ph_distinct_id'); } catch (_) {}
+        try { sessionId = sessionStorage.getItem('pl_ph_session_id'); } catch (_) {}
+        if (!distinctId && ph && typeof ph.get_distinct_id === 'function') distinctId = ph.get_distinct_id();
+        if (!sessionId && ph && typeof ph.get_session_id === 'function') sessionId = ph.get_session_id();
+        const params = new URLSearchParams();
+        if (distinctId) params.set('metadata[posthog_distinct_id]', distinctId);
+        if (sessionId) params.set('metadata[posthog_session_id]', sessionId);
+        const qs = params.toString();
+        if (qs) resolvedCalLink += '?' + qs;
+      } catch (_) {}
+
       window.Cal('init', namespace, { origin: 'https://app.cal.com' });
       window.Cal.ns[namespace]('inline', {
         elementOrSelector: elementSelector,
         config: { layout: 'month_view', useSlotsViewOnSmallScreen: 'true' },
-        calLink,
+        calLink: resolvedCalLink,
       });
       window.Cal.ns[namespace]('ui', { hideEventTypeDetails: false, layout: 'month_view' });
 


### PR DESCRIPTION
## Summary

- Adds `data-track-action` attributes to the three hero feature bullets and the twelve toolchain logos, so they fire `cta_clicked` with `campaign=<slug>`.
- Forwards `posthog.get_distinct_id()` and `get_session_id()` through Cal.com as booking metadata, so the gtme slackbot's new `/webhooks/calcom` receiver can fire `demo_booked` attributed to the same person/session as the original landing visit. End-to-end funnel in PostHog: `$pageview → cta_clicked → email_captured → demo_booked`.

Paired with [gtme#35](https://github.com/Promptless/gtme/pull/35), which adds the Cal.com webhook receiver.

## Tracking additions

| Element | action | campaign |
|---|---|---|
| Feature "Follows your style guide" | `hero_feature` | `style_guide` |
| Feature "Auto-updated screenshots" | `hero_feature` | `screenshots` |
| Feature "Very flexible…" | `hero_feature` | `toolchain` |
| Toolchain logos (×12) | `hero_toolchain` | `{slug}` (github, slack, jira, linear, notion, confluence, gitbook, readme, mintlify, docusaurus, zendesk, gitlab) |

All share `location=hero`, `funnel=education`. In PostHog, filter `cta_clicked` on `action` and break down by `campaign` to see which integrations and features drive interest.

## Identity forwarding

- `HeroV2.astro` — on form submit, stashes `posthog.get_distinct_id()` and `get_session_id()` in sessionStorage (alongside the already-stashed email).
- `DemoBooking.astro` (`/meet`) — reads those IDs (sessionStorage → posthog fallback) and appends `metadata[posthog_distinct_id]` + `metadata[posthog_session_id]` to the Cal.com `calLink`. Also stashes IDs on the page's own "not ready to book" email form submit.
- `MeetCalendarInline.astro` (`/` inline calendar) — same metadata forwarding so an inline booking without going via the hero form is still attributed.

Cal.com passes URL `metadata[...]` params through to the `BOOKING_CREATED` webhook payload. The gtme receiver extracts those IDs and posts `demo_booked` to PostHog's capture API with matching `distinct_id` + `$session_id`, which stitches the event onto the existing timeline. If metadata is missing, the receiver falls back to attendee email for attribution and records `attributed_via` so we can tell the two paths apart.

## Test plan

- [ ] Smoke-build the site locally and confirm the hero form still redirects to `/meet#book` and the inline Cal embed renders.
- [ ] Click a feature link in the hero, confirm `cta_clicked` fires in PostHog with `action=hero_feature` and the expected `campaign`.
- [ ] Click a toolchain logo, confirm `cta_clicked` fires with `action=hero_toolchain` and the correct `campaign` slug.
- [ ] Submit the hero form, then on `/meet` open devtools → Network → look at the Cal.com iframe URL and verify `metadata[posthog_distinct_id]` + `metadata[posthog_session_id]` are present.
- [ ] Once gtme#35 is deployed, book a real demo end-to-end and confirm a `demo_booked` event appears in PostHog tied to the same person as the original `$pageview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)