### PR TITLE
content: Launch post -- @mention Promptless to request docs on any PR

### DIFF
--- a/src/content/blog/product-updates/request-docs-via-pr-comments.mdx
+++ b/src/content/blog/product-updates/request-docs-via-pr-comments.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Comment @promptless on Any PR to Request Documentation'
+title: 'Comment @promptless on a PR to Request Documentation'
 subtitle: Published April 2026
 description: >-
-  Promptless can now be triggered by commenting @promptless on any pull request, including merged or closed ones, for teams that want on-demand docs control.
+  Promptless can now be triggered by commenting @promptless on a pull request in any repo you've connected to Promptless, including merged or closed ones.
 date: '2026-04-14T00:00:00.000Z'
 author: Frances
 tag: Product Updates
@@ -12,7 +12,7 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-You can now comment `@promptless` on any source PR to request documentation updates. It works on PRs in any state: open, draft, merged, or closed.
+You can now comment `@promptless` on a pull request to request documentation updates. It works in any repo you've connected to Promptless, on PRs in any state: open, draft, merged, or closed.
 
 This is an addition, not a replacement. Your existing trigger rules keep running. `@promptless` comments give you an on-demand option for PRs your rules don't cover, or PRs where you want to give Promptless specific instructions.
 
@@ -30,11 +30,13 @@ Previously, the workaround was to edit configuration, re-run builds, or skip the
 
 ## How it works
 
-Leave a comment on any source PR that includes `@promptless`. Promptless picks up the comment, fetches the current state of the PR, and starts a doc run based on what's in the PR right now.
+Leave a comment that includes `@promptless` on any pull request in a connected repo. Promptless picks up the comment, fetches the current state of the PR, and starts a doc run based on what's in the PR right now.
 
 **Works on any PR state.** Open, draft, merged, or closed. Promptless fetches live PR details at the time of the comment, so PRs that shipped weeks or months ago are handled correctly.
 
-**Explicit only.** Promptless only runs if the comment includes `@promptless`. It doesn't watch every comment. No risk of accidental triggers from conversational PR comments.
+**Connected repos only.** The PR has to be in a repo you've added to a Promptless project. Installing the Promptless GitHub App on an additional repo isn't enough on its own. If you comment `@promptless` on a PR in a repo that isn't configured, nothing happens.
+
+**Explicit only.** Promptless runs only if the comment includes `@promptless`. It doesn't watch every comment. No risk of accidental triggers from conversational PR comments.
 
 You can add instructions in the comment. If you write `@promptless please focus on the new retries config`, that context is passed to the doc run. Useful when the PR is broad but only one slice matters for your docs.
 
@@ -50,11 +52,11 @@ You can add instructions in the comment. If you write `@promptless please focus 
 
 ## How to use it
 
-No configuration to change. If you're on GitHub, it's live.
+No new configuration for repos you've already connected. If you're on GitHub, it's live.
 
-Leave a comment on any source PR that includes `@promptless`. GitHub won't autocomplete `@promptless` because it isn't a GitHub user. The keyword still works. Add instructions if you want to. Promptless picks it up, runs the doc flow, and comments back with a draft.
+Leave a comment that includes `@promptless` on any pull request in a connected repo. GitHub won't autocomplete `@promptless` because it isn't a GitHub user. The keyword still works. Add instructions if you want to. Promptless picks it up, runs the doc flow, and comments back with a draft.
 
-GitHub Enterprise isn't supported for source PR comments yet. It's on the list.
+GitHub Enterprise isn't supported yet. It's on the list.
 
 ## What's next
 

--- a/src/content/blog/product-updates/request-docs-via-pr-comments.mdx
+++ b/src/content/blog/product-updates/request-docs-via-pr-comments.mdx
@@ -1,8 +1,8 @@
 ---
-title: '@mention Promptless to Request Documentation on Any PR'
+title: 'Comment @promptless on Any PR to Request Documentation'
 subtitle: Published April 2026
 description: >-
-  Promptless can now be triggered by @mentioning it in a comment on any pull request, including merged or closed ones, for teams that want on-demand docs control.
+  Promptless can now be triggered by commenting @promptless on any pull request, including merged or closed ones, for teams that want on-demand docs control.
 date: '2026-04-14T00:00:00.000Z'
 author: Frances
 tag: Product Updates
@@ -12,9 +12,9 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-You can now @mention Promptless in a comment on any source PR to request documentation updates. It works on PRs in any state: open, draft, merged, or closed.
+You can now comment `@promptless` on any source PR to request documentation updates. It works on PRs in any state: open, draft, merged, or closed.
 
-This is an addition, not a replacement. Your existing trigger rules keep running. @mentions give you an on-demand option for PRs your rules don't cover, or PRs where you want to give Promptless specific instructions.
+This is an addition, not a replacement. Your existing trigger rules keep running. `@promptless` comments give you an on-demand option for PRs your rules don't cover, or PRs where you want to give Promptless specific instructions.
 
 ## The problem
 
@@ -30,19 +30,19 @@ Previously, the workaround was to edit configuration, re-run builds, or skip the
 
 ## How it works
 
-@mention `promptless` in a comment on any source PR. Promptless picks up the comment, fetches the current state of the PR, and starts a doc run based on what's actually in that PR right now.
+Leave a comment on any source PR that includes `@promptless`. Promptless picks up the comment, fetches the current state of the PR, and starts a doc run based on what's in the PR right now.
 
-**Works on any PR state.** Open, draft, merged, or closed. Promptless fetches live PR details at the time of the @mention, so PRs that shipped weeks or months ago are handled correctly.
+**Works on any PR state.** Open, draft, merged, or closed. Promptless fetches live PR details at the time of the comment, so PRs that shipped weeks or months ago are handled correctly.
 
-**Explicit-mention only.** Promptless only runs if you @mention it. It doesn't silently watch every comment. No risk of accidental triggers from conversational PR comments.
+**Explicit only.** Promptless only runs if the comment includes `@promptless`. It doesn't watch every comment. No risk of accidental triggers from conversational PR comments.
 
-You can add instructions in the comment. If you write "@promptless please focus on the new retries config," that context is passed to the doc run. Useful when the PR is broad but only one slice matters for your docs.
+You can add instructions in the comment. If you write `@promptless please focus on the new retries config`, that context is passed to the doc run. Useful when the PR is broad but only one slice matters for your docs.
 
 ## Who benefits most
 
 **Teams filling in docs gaps retroactively.** If you set up Promptless recently, most of your historical PRs were never processed. Pick the significant ones and document them one at a time.
 
-**Teams that want explicit control over specific PRs.** Some PRs want the standard flow. Others are irregular: a big refactor with one user-visible slice, a config PR that changes defaults, a 40-file rewrite that needs three lines of docs. @mentions let you guide Promptless on the ones that need judgment.
+**Teams that want explicit control over specific PRs.** Some PRs want the standard flow. Others are irregular: a big refactor with one user-visible slice, a config PR that changes defaults, a 40-file rewrite that needs three lines of docs. `@promptless` comments let you guide Promptless on the ones that need judgment.
 
 **Launch-week triage.** Point at the exact PRs that shipped a release and queue docs for each in a comment, instead of waiting for automatic triggers.
 
@@ -52,7 +52,7 @@ You can add instructions in the comment. If you write "@promptless please focus 
 
 No configuration to change. If you're on GitHub, it's live.
 
-Leave a comment on any source PR that includes `@promptless`. Add instructions if you want to. Promptless picks it up, runs the doc flow, and comments back with a draft.
+Leave a comment on any source PR that includes `@promptless`. GitHub won't autocomplete `@promptless` because it isn't a GitHub user. The keyword still works. Add instructions if you want to. Promptless picks it up, runs the doc flow, and comments back with a draft.
 
 GitHub Enterprise isn't supported for source PR comments yet. It's on the list.
 

--- a/src/content/blog/product-updates/request-docs-via-pr-comments.mdx
+++ b/src/content/blog/product-updates/request-docs-via-pr-comments.mdx
@@ -12,13 +12,13 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-You can now comment `@promptless` on a pull request to request documentation updates. It works in any repo you've connected to Promptless, on PRs in any state: open, draft, merged, or closed.
+You can now comment `@promptless` on a pull request to request documentation updates. It works in any repo you've connected to Promptless, whether the PR is open, draft, merged, or closed.
 
 This is an addition, not a replacement. Your existing trigger rules keep running. `@promptless` comments give you an on-demand option for PRs your rules don't cover, or PRs where you want to give Promptless specific instructions.
 
 ## The problem
 
-Promptless triggers are rules. You configure when to run (on PR open, on first approval, on merge, when a glob matches) and it runs on every PR that matches.
+Promptless triggers are rules. You configure when to run, and it runs on every PR that matches. Rules can fire on PR open, on first approval, on merge, or when a glob matches.
 
 Rules don't cover every case. Three common gaps:
 
@@ -32,11 +32,11 @@ Previously, the workaround was to edit configuration, re-run builds, or skip the
 
 Leave a comment that includes `@promptless` on any pull request in a connected repo. Promptless picks up the comment, fetches the current state of the PR, and starts a doc run based on what's in the PR right now.
 
-**Works on any PR state.** Open, draft, merged, or closed. Promptless fetches live PR details at the time of the comment, so PRs that shipped weeks or months ago are handled correctly.
+A few things to know:
 
-**Connected repos only.** The PR has to be in a repo you've added to a Promptless project. Installing the Promptless GitHub App on an additional repo isn't enough on its own. If you comment `@promptless` on a PR in a repo that isn't configured, nothing happens.
-
-**Explicit only.** Promptless runs only if the comment includes `@promptless`. It doesn't watch every comment. No risk of accidental triggers from conversational PR comments.
+- Any PR state works, whether the PR is open, draft, merged, or closed. Promptless fetches live details at the time of the comment, so PRs that shipped weeks or months ago are handled correctly.
+- The repo has to be connected to a Promptless project. Installing the Promptless GitHub App on an additional repo isn't enough on its own. If you comment `@promptless` on a PR in a repo that isn't configured, nothing happens.
+- Only comments that include `@promptless` trigger a run, so conversational PR comments won't accidentally start one.
 
 You can add instructions in the comment. If you write `@promptless please focus on the new retries config`, that context is passed to the doc run. Useful when the PR is broad but only one slice matters for your docs.
 
@@ -60,6 +60,6 @@ GitHub Enterprise isn't supported yet. It's on the list.
 
 ## What's next
 
-Next up: thread-aware follow-ons so you can iterate on a draft inside the PR, and parity for GitHub Enterprise.
+We're building thread-aware follow-ons so you can iterate on a draft inside the PR. We're also working toward parity for GitHub Enterprise.
 
 <BlogRequestDemo />

--- a/src/content/blog/product-updates/request-docs-via-pr-comments.mdx
+++ b/src/content/blog/product-updates/request-docs-via-pr-comments.mdx
@@ -12,54 +12,52 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-You can now @mention Promptless in a comment on any pull request to request documentation updates. It works on PRs that are open, drafted, merged, or even closed. If you've ever wished you could point at a specific PR and say "document this one," that's now a single comment away.
+You can now @mention Promptless in a comment on any source PR to request documentation updates. It works on PRs in any state: open, draft, merged, or closed.
 
-This ships alongside your existing trigger configuration. Whatever rules you've already set up still run. @mentions are an additional, on-demand way to ask Promptless for work.
+This is an addition, not a replacement. Your existing trigger rules keep running. @mentions give you an on-demand option for PRs your rules don't cover, or PRs where you want to give Promptless specific instructions.
 
 ## The problem
 
-Most Promptless triggers are rules. You tell Promptless when to run (on PR open, on first approval, on merge, when a glob matches) and it runs on every PR that matches.
+Promptless triggers are rules. You configure when to run (on PR open, on first approval, on merge, when a glob matches) and it runs on every PR that matches.
 
-That's the right default for most of the work. But rules don't cover every case. Teams kept running into the same kinds of gaps:
+Rules don't cover every case. Three common gaps:
 
-- A PR merged months ago introduced behavior that users keep asking about, but it predates your trigger setup
-- A draft PR has a feature worth documenting early, before it hits your usual trigger
-- You want to give Promptless specific instructions about what to focus on for this one PR, not every PR
+- A PR merged months ago introduced behavior users keep asking about, but it predates your trigger setup.
+- A draft PR has a feature worth documenting early, before it hits your usual trigger.
+- You want to focus Promptless on one slice of a broad PR, not the whole thing.
 
-For any of these, the workaround was to edit configuration, re-run builds, or ignore the PR entirely.
+Previously, the workaround was to edit configuration, re-run builds, or skip the PR.
 
 ## How it works
 
-@mention `promptless` in a comment on any source PR. That's it. Promptless picks up the comment, fetches the current state of the PR, and kicks off a docs dispatch based on what's actually in that PR right now.
+@mention `promptless` in a comment on any source PR. Promptless picks up the comment, fetches the current state of the PR, and starts a doc run based on what's actually in that PR right now.
 
-Two details worth knowing.
+**Works on any PR state.** Open, draft, merged, or closed. Promptless fetches live PR details at the time of the @mention, so PRs that shipped weeks or months ago are handled correctly.
 
-**It works on any PR state.** Open, draft, merged, or closed. Promptless fetches live PR details at the time of the @mention, so whatever shape the PR is in, including PRs that shipped weeks or months ago, it handles correctly.
+**Explicit-mention only.** Promptless only runs if you @mention it. It doesn't silently watch every comment. No risk of accidental triggers from conversational PR comments.
 
-**It's explicit-mention only.** Promptless only runs if you actually @mention it. It does not silently watch every comment on every PR, so there's no risk of accidental triggers from conversational comments about the PR.
-
-You can include instructions in the comment too. If you write "@promptless please focus on the new retries config," the dispatch receives that context. Use this when the PR is broad but only one slice matters for your docs.
+You can add instructions in the comment. If you write "@promptless please focus on the new retries config," that context is passed to the doc run. Useful when the PR is broad but only one slice matters for your docs.
 
 ## Who benefits most
 
-**Teams retroactively filling in docs gaps.** If you set up Promptless recently, most of your historical PRs were never processed. You can now pick the significant ones and ask Promptless to document them, one at a time, without re-running every merged PR through your triggers.
+**Teams filling in docs gaps retroactively.** If you set up Promptless recently, most of your historical PRs were never processed. Pick the significant ones and document them one at a time.
 
-**Teams that want explicit control over some PRs.** Some PRs want the standard flow. Others are weird. A big refactor with one user-visible slice. A config PR that changes defaults. A rewrite that touches 40 files but only needs three lines of docs. @mentions let you guide Promptless on the ones that need judgment, instead of relying on broader rules to catch every shape.
+**Teams that want explicit control over specific PRs.** Some PRs want the standard flow. Others are irregular: a big refactor with one user-visible slice, a config PR that changes defaults, a 40-file rewrite that needs three lines of docs. @mentions let you guide Promptless on the ones that need judgment.
 
-**Anyone triaging feature releases.** During a launch week, rather than wait for the automatic trigger to fire, you can point at the exact PRs that shipped the release and queue documentation for each one in a comment.
+**Launch-week triage.** Point at the exact PRs that shipped a release and queue docs for each in a comment, instead of waiting for automatic triggers.
 
 <BlogNewsletterCTA />
 
 ## How to use it
 
-There's no configuration to change. If you're on GitHub, it's already live.
+No configuration to change. If you're on GitHub, it's live.
 
-Leave a comment on any source PR that includes `@promptless`. Optionally add specific instructions about what you want documented. Promptless will pick it up, dispatch a doc run, and comment back with a draft.
+Leave a comment on any source PR that includes `@promptless`. Add instructions if you want to. Promptless picks it up, runs the doc flow, and comments back with a draft.
 
-GitHub Enterprise is not yet supported for source PR comments. That's coming.
+GitHub Enterprise isn't supported for source PR comments yet. It's on the list.
 
 ## What's next
 
-We're looking at a few follow-ups: thread-aware follow-ons so you can iterate on a draft inside the PR, and parity for GitHub Enterprise. If this is useful and you'd like to see one of those sooner, let us know.
+Next up: thread-aware follow-ons so you can iterate on a draft inside the PR, and parity for GitHub Enterprise.
 
 <BlogRequestDemo />

--- a/src/content/blog/product-updates/request-docs-via-pr-comments.mdx
+++ b/src/content/blog/product-updates/request-docs-via-pr-comments.mdx
@@ -1,0 +1,65 @@
+---
+title: '@mention Promptless to Request Documentation on Any PR'
+subtitle: Published April 2026
+description: >-
+  Promptless can now be triggered by @mentioning it in a comment on any pull request, including merged or closed ones, for teams that want on-demand docs control.
+date: '2026-04-14T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+You can now @mention Promptless in a comment on any pull request to request documentation updates. It works on PRs that are open, drafted, merged, or even closed. If you've ever wished you could point at a specific PR and say "document this one," that's now a single comment away.
+
+This ships alongside your existing trigger configuration. Whatever rules you've already set up still run. @mentions are an additional, on-demand way to ask Promptless for work.
+
+## The problem
+
+Most Promptless triggers are rules. You tell Promptless when to run (on PR open, on first approval, on merge, when a glob matches) and it runs on every PR that matches.
+
+That's the right default for most of the work. But rules don't cover every case. Teams kept running into the same kinds of gaps:
+
+- A PR merged months ago introduced behavior that users keep asking about, but it predates your trigger setup
+- A draft PR has a feature worth documenting early, before it hits your usual trigger
+- You want to give Promptless specific instructions about what to focus on for this one PR, not every PR
+
+For any of these, the workaround was to edit configuration, re-run builds, or ignore the PR entirely.
+
+## How it works
+
+@mention `promptless` in a comment on any source PR. That's it. Promptless picks up the comment, fetches the current state of the PR, and kicks off a docs dispatch based on what's actually in that PR right now.
+
+Two details worth knowing.
+
+**It works on any PR state.** Open, draft, merged, or closed. Promptless fetches live PR details at the time of the @mention, so whatever shape the PR is in, including PRs that shipped weeks or months ago, it handles correctly.
+
+**It's explicit-mention only.** Promptless only runs if you actually @mention it. It does not silently watch every comment on every PR, so there's no risk of accidental triggers from conversational comments about the PR.
+
+You can include instructions in the comment too. If you write "@promptless please focus on the new retries config," the dispatch receives that context. Use this when the PR is broad but only one slice matters for your docs.
+
+## Who benefits most
+
+**Teams retroactively filling in docs gaps.** If you set up Promptless recently, most of your historical PRs were never processed. You can now pick the significant ones and ask Promptless to document them, one at a time, without re-running every merged PR through your triggers.
+
+**Teams that want explicit control over some PRs.** Some PRs want the standard flow. Others are weird. A big refactor with one user-visible slice. A config PR that changes defaults. A rewrite that touches 40 files but only needs three lines of docs. @mentions let you guide Promptless on the ones that need judgment, instead of relying on broader rules to catch every shape.
+
+**Anyone triaging feature releases.** During a launch week, rather than wait for the automatic trigger to fire, you can point at the exact PRs that shipped the release and queue documentation for each one in a comment.
+
+<BlogNewsletterCTA />
+
+## How to use it
+
+There's no configuration to change. If you're on GitHub, it's already live.
+
+Leave a comment on any source PR that includes `@promptless`. Optionally add specific instructions about what you want documented. Promptless will pick it up, dispatch a doc run, and comment back with a draft.
+
+GitHub Enterprise is not yet supported for source PR comments. That's coming.
+
+## What's next
+
+We're looking at a few follow-ups: thread-aware follow-ons so you can iterate on a draft inside the PR, and parity for GitHub Enterprise. If this is useful and you'd like to see one of those sooner, let us know.
+
+<BlogRequestDemo />


### PR DESCRIPTION
## Feature
Request documentation on any source PR by @mentioning `promptless` in a comment. Works on open, draft, merged, and closed PRs.

## Entries considered this run

Window: 2026-04-13 → 2026-04-21 (simulating a Monday-morning scheduled run).

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **Request Documentation via PR Comments** — @mention Promptless in a comment on any source PR to request documentation updates. Works on open, draft, merged, and closed PRs. | QUALIFIES | Adds a new trigger type (substantial new capability). |

One commit in window ([9bed246](https://github.com/Promptless/docs/commit/9bed24626729d9e0e9e519ad18da2d9221b895f0)) adding one entry. No skipped entries this week.

## Covered entry (full text)
> **Request Documentation via PR Comments:** @mention Promptless in a comment on any source PR to request documentation updates. Works on open, draft, merged, and closed PRs—useful when you want to document a PR that predates your trigger setup or provide specific instructions about what to document.

## PR(s) researched
- [Promptless/promptless#2951](https://github.com/Promptless/promptless/pull/2951) — runtime: dispatch tagged source PR comments (merged 2026-04-09)

## File
\`src/content/blog/product-updates/request-docs-via-pr-comments.mdx\`

AI-generated draft — needs human review before publishing.