### PR TITLE
content: What Documentation Debt Actually Costs Engineering Teams

### DIFF
--- a/src/content/blog/technical/documentation-debt.mdx
+++ b/src/content/blog/technical/documentation-debt.mdx
@@ -1,0 +1,79 @@
+---
+title: 'What Documentation Debt Actually Costs Engineering Teams'
+subtitle: Published April 2026
+description: >-
+  Documentation debt generates no automated alerts. Here's how to measure what you can't see and stop paying the hidden cost in onboarding and engineering time.
+date: '2026-04-22T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Your CI pipeline doesn't fail when a README goes out of date. Your error monitoring doesn't alert when an API guide starts describing a parameter that no longer exists. No ticket gets filed when a setup guide quietly stops working because the product changed.
+
+This is the core problem with documentation debt: it accumulates without any automated signal.
+
+Code debt has detectors. Tests fail. Dependency scanners alert. Documentation has neither of these signals. It builds up, page by page, until the cost surfaces somewhere far downstream.
+
+## Why documentation debt is harder to see than code debt
+
+Code debt eventually fails loudly. A messy codebase still runs, but broken code stops working and forces action. A misleading doc gets acted on and produces damage before anyone notices.
+
+When documentation says one thing and your product does another, users trust the doc and then file a support ticket or give up. The gap between cause (outdated content) and symptom (a churned customer, a slow-ramping hire) is wide enough that most teams never connect them.
+
+The [State of Docs Report 2025](https://www.stateofdocs.com/2025/) found that 39% of teams track no documentation metrics at all. Most of the rest measure page views or time-on-page, which tells you nothing about accuracy. The result: most teams have no visibility into how much of their documentation has drifted from reality.
+
+There is also a compounding factor that code debt doesn't have: knowledge leaves with engineers.
+
+A poorly documented system might still have a senior engineer holding the full mental model. When that engineer leaves, the gap between "undocumented" and "unknown" closes permanently. What was once "we should write this down" becomes "nobody knows how this works anymore." Exit interviews recover a fraction of it. Most is gone.
+
+## Where the cost shows up
+
+Documentation debt concentrates in three areas.
+
+**Onboarding.** Missing or outdated docs extend new hire ramp-up significantly. Research from developer experience teams puts typical onboarding at around four weeks with good documentation. Poor documentation stretches that to twelve weeks or more. New hires don't onboard slowly because they're unprepared. They spend their first weeks asking questions, hitting dead ends in stale content, and reverse-engineering systems that should have documented answers.
+
+**Support volume.** Outdated API references and incorrect setup guides generate support tickets at scale. Each ticket consumes the customer's time, the support engineer's time, and often the context-switch overhead of a developer pulled in for escalation.
+
+**Engineering interruptions.** Every time a developer answers a question that should be in the docs, they lose 15-20 minutes recovering their working context. Research consistently estimates this compounds to [15-25% of total engineering capacity](https://promptless.ai/blog/technical/documentation-drift-detection-problem) in teams with significant documentation debt. That's 15-25 engineers per 100-person team spending their time compensating for missing documentation instead of building.
+
+<BlogNewsletterCTA />
+
+## Measuring what you can't see
+
+Before you can reduce documentation debt, you need to know where it lives.
+
+A documentation audit maps what you actually have: every doc, its last-updated date, its owner, and a pass/fail on whether the content still reflects reality. That last column matters most. A doc updated six months ago might still be accurate. A doc updated last week might describe a flow that changed in yesterday's deploy.
+
+The goal is visibility, not a perfect inventory. Teams that run this audit consistently find that more of their documentation is inaccurate than they expected, and that the inaccuracy clusters around the same areas: authentication flows, setup guides, API references, and anything that touches configuration.
+
+Once you have the map, you can prioritize. Start with the documentation users encounter first (onboarding, getting-started guides) and the docs that correspond to your highest-volume support tickets. Fix those first, then work outward.
+
+For a leading indicator rather than a lagging one, look at developer behavior. Count how many questions in your internal Slack or Discord should have been answered by docs. Tag support tickets by whether the root cause was outdated or missing documentation. These signals surface where debt is actively generating cost before it appears in churned accounts or onboarding failures.
+
+## Building prevention into the process
+
+Audits address existing debt. Preventing new debt requires changing how documentation is treated during development.
+
+The most effective change is making documentation part of the definition of done. If a feature ships without updated docs, it's not done. This creates a direct link between code changes and documentation changes without requiring a separate process or a dedicated sprint.
+
+Ownership matters just as much. Documentation without a named owner gets updated by nobody. When a specific team owns specific docs, those docs get updated when the team's code changes, because they feel the pain directly when their docs are wrong.
+
+Some teams embed documentation review into the PR process itself. When a PR touches a public API endpoint, it triggers a review of the corresponding reference doc. When a config file changes, the setup guide gets flagged. This is the same mechanic that makes code debt visible: automated checks at the point of change.
+
+The [teams that keep docs current](https://promptless.ai/blog/technical/how-teams-keep-docs-up-to-date-with-promptless) build systems that surface what needs updating before it becomes a problem. Understanding [why onboarding docs break after launch](https://promptless.ai/blog/technical/developer-onboarding-documentation-fails-after-launch) gives you the specific failure modes to build prevention around.
+
+## The measurement gap is the starting point
+
+Documentation debt is manageable. What makes it expensive is how long it accumulates undetected.
+
+The State of Docs Report 2025 found that 90% of documentation leaders believe their docs influence purchasing decisions. Only 35% think their own docs are actually effective. That gap between belief and reality is documentation debt, made visible.
+
+You don't need sophisticated tooling to start. A spreadsheet tracking every doc's last-updated date and owner, combined with support ticket tagging for doc-related issues, gives you enough of a baseline to prioritize. Once you can see where the debt is concentrated, you can pay it down systematically.
+
+What generates no signal stays invisible. Documentation debt that goes unmeasured will keep compounding until the cost forces your hand.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `documentation debt`

## Article plan

**Target keywords:** documentation debt (primary), documentation coverage (secondary)

**Thesis:** Documentation debt costs engineering teams more than they realize because it generates no automated signal, and closing that monitoring gap is the necessary first step.

**Target reader:** Engineering managers and DevEx leads at API/developer-tool companies feeling friction from slow onboarding and high support volume.

**Key points:**
1. Code debt fails loudly; docs debt fails silently and the damage happens downstream
2. 39% of teams track no documentation metrics at all (State of Docs Report 2025)
3. Costs concentrate in onboarding (4 weeks → 12 weeks), support tickets, and context-switch interruptions (15-25% of engineering capacity)
4. Interest compounds when engineers leave: undocumented becomes unknown
5. A documentation audit is the starting point for visibility
6. Prevention requires docs in the definition of done plus named ownership

**Promptless connection:** Promptless is the monitoring layer that makes documentation debt visible automatically — the equivalent of error monitoring for docs.

## File

`src/content/blog/technical/documentation-debt.mdx`

This is an AI-generated draft and needs human review before publishing.