### PR TITLE
content: Tighten copy in documentation debt article

### DIFF
--- a/src/content/blog/technical/documentation-debt.mdx
+++ b/src/content/blog/technical/documentation-debt.mdx
@@ -12,21 +12,21 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-Your CI pipeline doesn't fail when a README goes out of date. Your error monitoring doesn't alert when an API guide starts describing a parameter that no longer exists. No ticket gets filed when a setup guide quietly stops working because the product changed.
+Your CI pipeline doesn't fail when a README goes out of date. Your error monitoring doesn't alert when an API guide starts describing a parameter that no longer exists. No ticket gets filed when a setup guide stops working because the product changed.
 
-This is the core problem with documentation debt: it accumulates without any automated signal.
+The core problem with documentation debt is that it accumulates without any automated signal.
 
-Code debt has detectors. Tests fail. Dependency scanners alert. Documentation has neither of these signals. It builds up, page by page, until the cost surfaces somewhere far downstream.
+Failing tests and dependency scanners serve as detectors for code debt. Documentation has neither of these signals. It builds up, page by page, until the cost surfaces somewhere far downstream.
 
 ## Why documentation debt is harder to see than code debt
 
 Code debt eventually fails loudly. A messy codebase still runs, but broken code stops working and forces action. A misleading doc gets acted on and produces damage before anyone notices.
 
-When documentation says one thing and your product does another, users trust the doc and then file a support ticket or give up. The gap between cause (outdated content) and symptom (a churned customer, a slow-ramping hire) is wide enough that most teams never connect them.
+When documentation says one thing and your product does another, users trust the doc and then file a support ticket or give up. The cause is outdated content, the symptom is a churned customer or a slow-ramping hire, and the gap between them is wide enough that most teams never connect the two.
 
-The [State of Docs Report 2025](https://www.stateofdocs.com/2025/) found that 39% of teams track no documentation metrics at all. Most of the rest measure page views or time-on-page, which tells you nothing about accuracy. The result: most teams have no visibility into how much of their documentation has drifted from reality.
+The [State of Docs Report 2025](https://www.stateofdocs.com/2025/) found that 39% of teams track no documentation metrics at all. Most of the rest measure page views or time-on-page, which tells you nothing about accuracy. Most teams have no visibility into how much of their documentation has drifted from reality.
 
-There is also a compounding factor that code debt doesn't have: knowledge leaves with engineers.
+Documentation debt compounds in a way code debt doesn't, because knowledge leaves with engineers.
 
 A poorly documented system might still have a senior engineer holding the full mental model. When that engineer leaves, the gap between "undocumented" and "unknown" closes permanently. What was once "we should write this down" becomes "nobody knows how this works anymore." Exit interviews recover a fraction of it. Most is gone.
 
@@ -46,13 +46,13 @@ Documentation debt concentrates in three areas.
 
 Before you can reduce documentation debt, you need to know where it lives.
 
-A documentation audit maps what you actually have: every doc, its last-updated date, its owner, and a pass/fail on whether the content still reflects reality. That last column matters most. A doc updated six months ago might still be accurate. A doc updated last week might describe a flow that changed in yesterday's deploy.
+A documentation audit maps every doc, its last-updated date, its owner, and a pass/fail on whether the content still reflects reality. That last column matters most. A doc updated six months ago might still be accurate. A doc updated last week might describe a flow that changed in yesterday's deploy.
 
-The goal is visibility, not a perfect inventory. Teams that run this audit consistently find that more of their documentation is inaccurate than they expected, and that the inaccuracy clusters around the same areas: authentication flows, setup guides, API references, and anything that touches configuration.
+The goal is visibility, not a perfect inventory. Teams that run this audit consistently find that more of their documentation is inaccurate than they expected, and that the inaccuracy clusters around authentication flows, setup guides, API references, and anything that touches configuration.
 
-Once you have the map, you can prioritize. Start with the documentation users encounter first (onboarding, getting-started guides) and the docs that correspond to your highest-volume support tickets. Fix those first, then work outward.
+Once you have the map, you can prioritize. Start with the onboarding and getting-started guides users encounter first, then the docs that correspond to your highest-volume support tickets. Fix those first, then work outward.
 
-For a leading indicator rather than a lagging one, look at developer behavior. Count how many questions in your internal Slack or Discord should have been answered by docs. Tag support tickets by whether the root cause was outdated or missing documentation. These signals surface where debt is actively generating cost before it appears in churned accounts or onboarding failures.
+For a leading indicator, look at developer behavior. Count how many questions in your internal Slack or Discord should have been answered by docs. Tag support tickets by whether the root cause was outdated or missing documentation. These signals surface where debt is actively generating cost before it appears in churned accounts or onboarding failures.
 
 ## Building prevention into the process
 
@@ -62,7 +62,7 @@ The most effective change is making documentation part of the definition of done
 
 Ownership matters just as much. Documentation without a named owner gets updated by nobody. When a specific team owns specific docs, those docs get updated when the team's code changes, because they feel the pain directly when their docs are wrong.
 
-Some teams embed documentation review into the PR process itself. When a PR touches a public API endpoint, it triggers a review of the corresponding reference doc. When a config file changes, the setup guide gets flagged. This is the same mechanic that makes code debt visible: automated checks at the point of change.
+Some teams embed documentation review into the PR process itself. When a PR touches a public API endpoint, it triggers a review of the corresponding reference doc. When a config file changes, the setup guide gets flagged. Automated checks at the point of change are the same mechanic that makes code debt visible.
 
 The [teams that keep docs current](https://promptless.ai/blog/technical/how-teams-keep-docs-up-to-date-with-promptless) build systems that surface what needs updating before it becomes a problem. Understanding [why onboarding docs break after launch](https://promptless.ai/blog/technical/developer-onboarding-documentation-fails-after-launch) gives you the specific failure modes to build prevention around.
 


### PR DESCRIPTION
## Summary
- Editorial pass on `src/content/blog/technical/documentation-debt.mdx` — follow-up to #413
- Condenses wordy phrasing, restructures a few sentences for directness, and switches some passive constructions to active voice

## Test plan
- [ ] Confirm article still renders correctly in preview
- [ ] Verify no broken links or formatting regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)