### PR TITLE
fix: hoist YouTube preconnect links to document head

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -98,6 +98,14 @@ export default defineConfig({
           attrs: { name: 'twitter:image', content: 'https://promptless.ai/assets/social-card.png' },
         },
         {
+          tag: 'link',
+          attrs: { rel: 'preconnect', href: 'https://www.youtube-nocookie.com' },
+        },
+        {
+          tag: 'link',
+          attrs: { rel: 'preconnect', href: 'https://i.ytimg.com' },
+        },
+        {
           tag: 'script',
           attrs: { type: 'text/partytown', src: 'https://www.googletagmanager.com/gtag/js?id=G-NHEW11ZR9F' },
         },

--- a/src/components/site/LiteYouTube.astro
+++ b/src/components/site/LiteYouTube.astro
@@ -27,9 +27,6 @@ const remotePosterUrl =
   typeof poster === 'string' ? `https://i.ytimg.com/vi/${id}/${poster}.jpg` : null;
 ---
 
-<link rel="preconnect" href="https://www.youtube-nocookie.com" />
-{remotePosterUrl && <link rel="preconnect" href="https://i.ytimg.com" />}
-
 <div
   class="lite-youtube"
   data-video-id={id}


### PR DESCRIPTION
## Problem

Follow-up to #419. The LiteYouTube component placed its \`<link rel=\"preconnect\">\` tags inline in the template:

\`\`\`astro
<link rel=\"preconnect\" href=\"https://www.youtube-nocookie.com\" />
<div class=\"lite-youtube\">...</div>
\`\`\`

This produced a visible ~16 px black strip above the video poster on the homepage and the technical-writer use-case page. The \`<link>\` element itself is \`display: none\` via user-agent styles, but the whitespace text node surrounding it rendered as a block-level line inside \`.pl-site-video-embed\`, pushing the absolutely positioned \`.lite-youtube\` down by the line-height.

Measured before the fix:
- \`.pl-site-video-embed\` = 1080 × 607.5 (correct 16:9)
- \`.lite-youtube\` = 1080 × **591.5** (16 px short)

## Fix

Moved the preconnect hints from the component into the Starlight \`head\` config in \`astro.config.mjs\`, so they emit once in \`<head>\` per page regardless of whether the component is used. No layout impact; preconnect still fires at page load.

After:
- \`.lite-youtube\` = 1080 × **607.5** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)