### PR TITLE
content: Launch post — Connect Multiple GitHub Organizations to One Promptless Account

### DIFF
--- a/src/content/blog/product-updates/multi-org-github-connect.mdx
+++ b/src/content/blog/product-updates/multi-org-github-connect.mdx
@@ -1,0 +1,43 @@
+---
+title: 'Connect Multiple GitHub Organizations to One Promptless Account'
+subtitle: Published April 2026
+description: >-
+  Teams with multiple GitHub organizations can now connect them all to a single Promptless account, manage each integration independently, and see repos from every org in one project dropdown.
+date: '2026-04-27T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Promptless now supports connecting multiple GitHub organizations to a single account. If your engineering setup spans more than one GitHub org, you no longer need a separate Promptless account for each one.
+
+## The problem
+
+Most Promptless customers have one GitHub organization. But some teams have two or more: an internal product org and an open-source org, separate orgs for different product lines, or a company org alongside an acquired team's GitHub namespace. Until now, the only way to use Promptless across these was to create separate accounts and manage them separately. That meant duplicated trigger configuration, separate notification settings, and no unified view of documentation work across orgs.
+
+## What changed
+
+After you connect your first GitHub organization, a "Connect another GitHub Org" option appears in Settings. Connect as many additional orgs as you need using the same OAuth flow you used for the first.
+
+Once connected, all repos from all your orgs appear in project dropdowns. Repos are prefixed with the org name (for example, `acme/docs`) so you can tell them apart when multiple orgs have similarly named repositories. Each org's GitHub integration is managed independently: you can disconnect one org without affecting the others.
+
+<BlogNewsletterCTA />
+
+## Who benefits most
+
+This is most useful for teams that maintain documentation across multiple GitHub organizations for legitimate organizational reasons. Common cases: a company that ships both internal tooling and an open-source SDK through separate GitHub orgs, a team that acquired another company and now maintains their GitHub org separately, or an engineering org that separated infrastructure and product into distinct GitHub namespaces.
+
+If you currently manage multiple Promptless accounts to work around the single-org limit, consolidating them will give you a unified view of all your projects and triggers.
+
+## How to set it up
+
+Go to **Settings > Integrations > GitHub**. After your first org is connected, a **Connect another GitHub Org** button appears at the bottom of the GitHub section. Clicking it starts a standard GitHub OAuth flow. Once authorized, that org's repos are immediately available in project dropdowns.
+
+Each connected org appears as a separate entry in the integrations list. To remove one, click its disconnect button. Removing an org does not affect projects or triggers from your other orgs.
+
+If you're consolidating from multiple Promptless accounts and want to migrate existing project and trigger configuration, contact help@gopromptless.ai.
+
+<BlogRequestDemo />

--- a/src/content/blog/product-updates/multi-org-github-connect.mdx
+++ b/src/content/blog/product-updates/multi-org-github-connect.mdx
@@ -16,19 +16,19 @@ Promptless now supports connecting multiple GitHub organizations to a single acc
 
 ## The problem
 
-Most Promptless customers have one GitHub organization. But some teams have two or more: an internal product org and an open-source org, separate orgs for different product lines, or a company org alongside an acquired team's GitHub namespace. Until now, the only way to use Promptless across these was to create separate accounts and manage them separately. That meant duplicated trigger configuration, separate notification settings, and no unified view of documentation work across orgs.
+Most Promptless customers have one GitHub organization. But some teams have two or more, spanning combinations like an internal product org and an open-source org, separate orgs for different product lines, or a company org alongside an acquired team's GitHub namespace. Until now, the only way to use Promptless across these was to create separate accounts and manage them separately. That meant duplicated trigger configuration, separate notification settings, and no unified view of documentation work across orgs.
 
 ## What changed
 
 After you connect your first GitHub organization, a "Connect another GitHub Org" option appears in Settings. Connect as many additional orgs as you need using the same OAuth flow you used for the first.
 
-Once connected, all repos from all your orgs appear in project dropdowns. Repos are prefixed with the org name (for example, `acme/docs`) so you can tell them apart when multiple orgs have similarly named repositories. Each org's GitHub integration is managed independently: you can disconnect one org without affecting the others.
+Once connected, all repos from all your orgs appear in project dropdowns. Repos are prefixed with the org name (for example, `acme/docs`) so you can tell them apart when multiple orgs have similarly named repositories. Each org's GitHub integration is managed independently, so you can disconnect one org without affecting the others.
 
 <BlogNewsletterCTA />
 
 ## Who benefits most
 
-This is most useful for teams that maintain documentation across multiple GitHub organizations for legitimate organizational reasons. Common cases: a company that ships both internal tooling and an open-source SDK through separate GitHub orgs, a team that acquired another company and now maintains their GitHub org separately, or an engineering org that separated infrastructure and product into distinct GitHub namespaces.
+This is most useful for teams that maintain documentation across multiple GitHub organizations for legitimate organizational reasons. The most common examples are a company that ships both internal tooling and an open-source SDK through separate GitHub orgs, a team that acquired another company and now maintains their GitHub org separately, or an engineering org that separated infrastructure and product into distinct GitHub namespaces.
 
 If you currently manage multiple Promptless accounts to work around the single-org limit, consolidating them will give you a unified view of all your projects and triggers.
 


### PR DESCRIPTION
## Feature
Teams with multiple GitHub organizations can now connect them all to a single Promptless account and manage each integration independently.

## Entries considered this run

Window: 2026-04-20 → 2026-04-27 (last 7 days).

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **Agent Knowledge Base** (Jan 2026) — View and edit files that inform how Promptless writes documentation | SKIP | Meets the bar on capability, but feature shipped in January 2026 (3+ months ago). Stale for a launch post. |
| 2 | **Guided Onboarding Wizard** (Jan 2026) — 6-step wizard for new user setup with auto-saved progress | SKIP | Meets the bar on UX, but January 2026 feature. Stale. |
| 3 | **Automatic Support Channel** (Jan 2026) — Creates a Slack Connect channel when you connect Slack during onboarding | SKIP | Operational/support feature, not a core product capability improvement. |
| 4 | **Self-Service Signup** (Jan 2026) — Sign up without a sales call | SKIP | Meets the bar (fundamental PLG shift), but January 2026 feature. Stale. |
| 5 | **Deep Analysis** (Jan 2026) — Submit large documentation requests like section refactors or comprehensive docs from scratch | SKIP | Meets the bar on capability, but January 2026 feature. Stale. |
| 6 | **Triggers Page Search** (Jan 2026) — Search triggers by PR info, topic, or summary text across full history | SKIP | UI filter improvement; borderline, default NO. |
| 7 | **Read-Only GitHub App for Open Source Repos** (Jan 2026) — Connect repos where you can't install GitHub apps via fork-based PR creation | SKIP | Meets the bar (new user segment), but January 2026 feature. Stale. |
| 8 | **Faster Response Times** (Jan 2026) — 2x faster documentation processing | SKIP | Performance improvement with no workflow change. |
| 9 | **Request Documentation via PR Comments** (Apr 2026) — @mention Promptless on any PR to trigger documentation | SKIP | Duplicate of existing post `request-docs-via-pr-comments.mdx`. |
| 10 | **Starlight (Astro) Docs Platform Support** (Apr 2026) — First-class Starlight support with auto-detection | SKIP | Duplicate of existing post `starlight-support.mdx`. |
| 11 | **First-Approval GitHub PR Trigger Mode** (Apr 2026) — Trigger on first PR approval instead of PR open | SKIP | Already existed in April changelog prior to this week's commit; not a new addition. |
| 12 | **Process Recent Commits for GitHub Commit Triggers** (Apr 2026) — Enable "Process last 30 days of commits" when creating a commit trigger project | SKIP | Qualifies (new setup option unlocking commit history bootstrapping), but narrower audience than Multi-Org. One post per week. |
| 13 | **Multi-Org GitHub Connect** (Apr 2026) — Connect multiple GitHub organizations to a single Promptless account with independent per-org management | **QUALIFIES** | Adds substantial new capability: previously impossible to manage multiple GitHub orgs in one account. Relevant for enterprise teams with multi-org setups. |
| 14 | **GitHub Issue Trigger Feedback** (Apr 2026) — Emoji reaction, helpful comment, and result comments when tagging @Promptless in GitHub issues | SKIP | UX improvement on existing feature. |
| 15 | **Improved Comment Visibility in Suggestion Review** (Apr 2026) — Per-file "Show N Comment(s)" toggle | SKIP | UI polish. |
| 16 | **Self-Serve Doc Collection Editing** (Apr 2026) — Edit doc collection settings in dashboard without contacting support | SKIP | Qualifies (removes support dependency), but deprioritized in favor of Multi-Org this week. |
| 17 | **GitHub Enterprise Source PR Comments** (Apr 2026) — Source PR comments now posted on GitHub Enterprise pull requests | SKIP | Qualifies (parity feature for GHE users), but narrower audience. Deprioritized. |
| 18 | **Faster Diff Rendering** (Apr 2026) — GraphQL batching reduces file fetch round-trips | SKIP | Performance improvement, no UX change. |
| 19 | **Faster Agent Knowledge Base** (Apr 2026) — Settings tab loads faster via GitHub API instead of repo cloning | SKIP | Performance improvement. |
| 20 | **Notification Tips** (Apr 2026) — Tips in Slack notification footers and GitHub PR comments | SKIP | Minor discovery improvement. |
| 21 | **Assignee-Aware Weekly Digest** (Apr 2026) — Assigned suggestions sorted first with direct filtered view link | SKIP | Improvement to existing feature; default NO. |
| 22 | **XWiki Integration Removed** (Apr 2026) — XWiki integration discontinued | SKIP | Deprecation notice, not a new capability. |
| 23 | Bug fixes (multiple, Apr 2026) | SKIP | Bug fixes do not warrant launch posts. |

2 commits in window. 23 entries considered (including sub-entries), 1 qualified.

## Covered entry (full text)
> **Multi-Org GitHub Connect:** Connect multiple GitHub organizations to a single Promptless account. After linking your first org, a "Connect another GitHub Org" option appears in settings. Each org's integration can be managed and disconnected independently. Repos from all connected orgs appear in project dropdowns, prefixed with the org name (e.g., `acme/docs`) for easy disambiguation.

Source: commit [3f4eac1](https://github.com/Promptless/promptless.ai/commit/3f4eac1375934093e60968e9ba34ab12e6265113) — "docs: Add April 2026 changelog entries (#373)".

## PR(s) researched
No PR found — Promptless/promptless is not accessible via available tooling. Article written from changelog entry content.

## File
`src/content/blog/product-updates/multi-org-github-connect.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAQg4QUU1Jf4fihQYksSMe)_