### PR TITLE
content: Launch post — Edit Doc Collection Settings Without Contacting Support

### DIFF
--- a/src/content/blog/product-updates/self-serve-doc-collection-editing.mdx
+++ b/src/content/blog/product-updates/self-serve-doc-collection-editing.mdx
@@ -16,7 +16,7 @@ Doc collection settings can now be edited directly from the Promptless dashboard
 
 ## The problem
 
-Setting up a Promptless doc collection involves a set of configuration choices: which documentation framework you're using, where the framework config lives in your repo, what URL your published docs are served from, whether you're using Vale for linting, and whether Doc Detective is enabled.
+Setting up a Promptless doc collection involves choosing which documentation framework you're using, where the framework config lives in your repo, what URL your published docs are served from, whether you're using Vale for linting, and whether Doc Detective is enabled.
 
 Most teams get this right during onboarding. But documentation setups change. A team might reorganize their repo and move the config file. They might migrate from one docs framework to another. They might enable Vale or Doc Detective after the initial integration. Their published URL might change after a domain migration.
 
@@ -44,7 +44,7 @@ Changes take effect immediately for new suggestions.
 
 ## Who benefits most
 
-Teams that set up Promptless early and have since changed their docs infrastructure. The common cases: framework migrations, repo reorganizations, adding Vale or Doc Detective after the initial integration, and domain changes.
+Teams that set up Promptless early and have since changed their docs infrastructure benefit most. Common scenarios include framework migrations, repo reorganizations, adding Vale or Doc Detective after the initial integration, and domain changes.
 
 It also helps teams that caught a mistake in their initial setup. If the config path was wrong from the start, suggestions might have been targeting the wrong location. That's now a one-minute fix.
 

--- a/src/content/blog/product-updates/self-serve-doc-collection-editing.mdx
+++ b/src/content/blog/product-updates/self-serve-doc-collection-editing.mdx
@@ -1,0 +1,59 @@
+---
+title: 'Edit Doc Collection Settings Without Contacting Support'
+subtitle: Published April 2026
+description: >-
+  Doc collection settings can now be edited directly in the Promptless dashboard. Update your docs framework, config path, published URL, Vale config, or Doc Detective settings without a support request.
+date: '2026-04-27T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Doc collection settings can now be edited directly from the Promptless dashboard. If you need to update your docs framework, config path, published URL, Vale config, or Doc Detective settings, you can do it yourself. No support request, no waiting.
+
+## The problem
+
+Setting up a Promptless doc collection involves a set of configuration choices: which documentation framework you're using, where the framework config lives in your repo, what URL your published docs are served from, whether you're using Vale for linting, and whether Doc Detective is enabled.
+
+Most teams get this right during onboarding. But documentation setups change. A team might reorganize their repo and move the config file. They might migrate from one docs framework to another. They might enable Vale or Doc Detective after the initial integration. Their published URL might change after a domain migration.
+
+Until now, every one of those changes required a support request. You'd open a ticket, describe what needed to change, and wait for someone on our team to update it. Depending on timing, that could mean days before Promptless could generate accurate suggestions again. For teams running multiple doc collections, a single infrastructure change could mean several tickets, handled in sequence.
+
+The friction was out of proportion to the task.
+
+## What changed
+
+There's now an edit button on each doc collection card in the dashboard. Clicking it opens the collection configuration form with your current settings pre-filled. You can update:
+
+**Docs framework.** If you've migrated from Docusaurus to Starlight, or from GitBook to Mintlify, update the framework setting so Promptless knows how to parse and write to your docs.
+
+**Config path.** Promptless uses your framework's config file to understand your doc structure. If you've reorganized your repo and the config file moved, update the path here.
+
+**Published URL.** Promptless uses your published URL when generating links and references in documentation. Update this if your domain changed or you moved to a subdomain.
+
+**Vale config.** If you added Vale linting after initial setup, or if your Vale config location changed, update it here so Promptless respects your style rules.
+
+**Doc Detective settings.** Doc Detective support can be enabled or adjusted on existing collections without starting over.
+
+Changes take effect immediately for new suggestions.
+
+<BlogNewsletterCTA />
+
+## Who benefits most
+
+Teams that set up Promptless early and have since changed their docs infrastructure. The common cases: framework migrations, repo reorganizations, adding Vale or Doc Detective after the initial integration, and domain changes.
+
+It also helps teams that caught a mistake in their initial setup. If the config path was wrong from the start, suggestions might have been targeting the wrong location. That's now a one-minute fix.
+
+For teams running multiple doc collections across several repositories, this is more significant. Any infrastructure change that previously required several sequential support requests can now be handled in a single session.
+
+## How to use it
+
+Open the Promptless dashboard and go to your project settings. Find the doc collection you want to update and click the edit button on the collection card. Update the fields and save.
+
+The form uses the same fields as initial setup. If you have an open support request to update a collection setting, you can close it and make the change yourself.
+
+<BlogRequestDemo />


### PR DESCRIPTION
## Feature
Doc collection settings (docs framework, config path, published URL, Vale config, Doc Detective) can now be edited directly from the dashboard without filing a support request.

## Entries considered this run

Window: 2026-04-20 → 2026-04-27 (last 7 days).

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **Agent Knowledge Base** (Jan 2026) — View and edit files that inform how Promptless writes documentation | SKIP | Meets bar on capability, but feature shipped ~3 months ago. Stale for a launch post. |
| 2 | **Guided Onboarding Wizard** (Jan 2026) — 6-step wizard for new user setup with auto-saved progress | SKIP | Meets bar on UX, but January 2026 feature. Stale. |
| 3 | **Automatic Support Channel** (Jan 2026) — Creates a Slack Connect channel when you connect Slack during onboarding | SKIP | Operational/support convenience, not a core workflow unlock. |
| 4 | **Self-Service Signup** (Jan 2026) — Sign up at accounts.gopromptless.ai without a sales call | SKIP | Meets bar (fundamental PLG shift), but January 2026 feature. Stale. |
| 5 | **Deep Analysis** (Jan 2026) — Submit large documentation requests like section refactors or comprehensive docs from scratch | SKIP | Meets bar on capability, but January 2026 feature. Stale. |
| 6 | **Triggers Page Search** (Jan 2026) — Search triggers by PR info, topic, or summary text across full history | SKIP | UI filter improvement; borderline, default NO. |
| 7 | **Read-Only GitHub App for Open Source Repos** (Jan 2026) — Connect repos where you can't install GitHub apps via fork-based PR creation | SKIP | Meets bar (new user segment), but January 2026 feature. Stale. |
| 8 | **Faster Response Times** (Jan 2026) — ~2x faster documentation processing | SKIP | Performance improvement with no workflow change. |
| 9 | **Request Documentation via PR Comments** (Apr 2026) — @mention Promptless on any PR to trigger documentation | SKIP | Duplicate of existing post `request-docs-via-pr-comments.mdx`. |
| 10 | **Starlight (Astro) Docs Platform Support** (Apr 2026) — First-class Starlight support with auto-detection | SKIP | Duplicate of existing post `starlight-support.mdx`. |
| 11 | **First-Approval GitHub PR Trigger Mode** (Apr 2026) — Trigger on first PR approval instead of PR open | SKIP | Pre-existed in April changelog before this week's commits; not a new addition. |
| 12 | **Process Recent Commits for GitHub Commit Triggers** (Apr 2026) — Enable "Process last 30 days of commits" when creating a commit trigger project | SKIP | Qualifies (new onboarding capability for commit trigger projects), but narrower audience. Deprioritized in favor of self-serve editing. |
| 13 | **Multi-Org GitHub Connect** (Apr 2026) — Connect multiple GitHub orgs to a single Promptless account with independent per-org management | SKIP | QUALIFIES, but duplicate of open PR #430. |
| 14 | **GitHub Issue Trigger Feedback** (Apr 2026) — Emoji reaction, helpful comment, and result comments when tagging @Promptless in GitHub issues | SKIP | UX improvement on existing feature; default NO. |
| 15 | **Improved Comment Visibility in Suggestion Review** (Apr 2026) — Per-file "Show N Comment(s)" toggle | SKIP | UI polish. |
| 16 | **Self-Serve Doc Collection Editing** (Apr 2026) — Edit doc collection settings in dashboard without contacting support | **QUALIFIES** | Significantly improves UX for a non-trivial segment: teams that need to update their docs setup post-onboarding no longer depend on support to make configuration changes. |
| 17 | **GitHub Enterprise Source PR Comments** (Apr 2026) — Source PR comments now posted on GitHub Enterprise PRs | SKIP | Parity feature for narrow GHE audience; borderline, default NO. |
| 18 | **Faster Diff Rendering** (Apr 2026) — GraphQL batching reduces file fetch round-trips | SKIP | Performance improvement, no UX change. |
| 19 | **Faster Agent Knowledge Base** (Apr 2026) — Settings tab loads faster via GitHub API instead of repo cloning | SKIP | Performance improvement. |
| 20 | **Notification Tips** (Apr 2026) — Tips in Slack notification footers and GitHub PR comments | SKIP | Minor discovery improvement. |
| 21 | **Assignee-Aware Weekly Digest** (Apr 2026) — Assigned suggestions sorted first with direct filtered view link | SKIP | Improvement to existing feature; default NO. |
| 22 | **XWiki Integration Removed** (Apr 2026) | SKIP | Deprecation notice. |
| 23 | Bug fixes (multiple, Apr 2026) | SKIP | Bug fixes do not warrant launch posts. |

2 commits in window. 23 entries considered, 1 qualified (Multi-Org skipped as duplicate of PR #430).

## Covered entry (full text)

> **Self-Serve Doc Collection Editing:** Edit doc collection settings directly in the dashboard without contacting support. Click the edit button on any doc collection card to update the docs framework, config path, published URL, Vale config, and Doc Detective settings.

Source: commit [3f4eac1](https://github.com/Promptless/promptless.ai/commit/3f4eac1375934093e60968e9ba34ab12e6265113) — "docs: Add April 2026 changelog entries (#373)".

## PR(s) researched
No PR number referenced in changelog entry. Promptless/promptless not accessible via available tooling — article written from changelog entry content.

## File
`src/content/blog/product-updates/self-serve-doc-collection-editing.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKPSPKB4ptzq6TgknvKF1g)_