### PR TITLE
content: SDK Documentation Best Practices: What Actually Hurts Developer Adoption

### DIFF
--- a/src/content/blog/technical/sdk-documentation-best-practices.mdx
+++ b/src/content/blog/technical/sdk-documentation-best-practices.mdx
@@ -14,7 +14,7 @@ import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
 A team building on a popular payments SDK spent two days debugging a failed integration. The API docs said a particular field was optional. The actual implementation required it. The spec was six months out of date.
 
-This is the failure mode that matters most in SDK documentation. Not missing coverage. Not poor navigation. Accurate information that became inaccurate and stayed that way.
+The failure mode that matters most in SDK documentation is accurate information that became inaccurate and stayed that way.
 
 SDK documentation is uniquely vulnerable to this problem because the surface area is large and changes fast. Every deprecation and every parameter rename creates a gap between what the docs say and what the code does. [A report tracking API quality](https://nordicapis.com/what-is-api-drift-and-what-can-you-do-about-it/) found that 75% of production APIs do not conform to their own specifications. Most of that gap lives in documentation no one has reviewed since the original launch.
 
@@ -22,7 +22,7 @@ SDK documentation is uniquely vulnerable to this problem because the surface are
 
 Time to First Call (TTFC) measures the time between a developer accessing your documentation and making their first successful API call. It is the clearest proxy for how well your SDK documentation is doing its job.
 
-[Postman calls TTFC the most important API metric.](https://blog.postman.com/the-most-important-api-metric-is-time-to-first-call/) The reasoning is direct: a developer who never reaches a working call doesn't integrate. Everything downstream depends on clearing that first hurdle.
+[Postman calls TTFC the most important API metric.](https://blog.postman.com/the-most-important-api-metric-is-time-to-first-call/) The reasoning is direct because a developer who never reaches a working call doesn't integrate. Everything downstream depends on clearing that first hurdle.
 
 TTFC is directly actionable. If it rises after a major SDK release, something in your onboarding experience regressed. If it falls after you updated the quickstart examples, you know the update mattered. Most of the variance in TTFC traces back to a handful of documentation problems that appear in a predictable order.
 
@@ -30,31 +30,31 @@ TTFC is directly actionable. If it rises after a major SDK release, something in
 
 The quickstart is the highest-stakes section in any SDK documentation. It is the first code a developer runs. It has to work.
 
-A broken quickstart teaches developers one thing: these docs cannot be trusted. After that, they verify every code sample before using it. They ask questions in Discord instead of reading the docs. They open support tickets for problems the documentation should answer. The docs exist, but the trust they were supposed to build is gone.
+A broken quickstart teaches developers that the docs cannot be trusted. After that, they verify every code sample before using it. They ask questions in Discord instead of reading the docs. They open support tickets for problems the documentation should answer. The docs exist, but the trust they were supposed to build is gone.
 
-The fix is straightforward. The quickstart needs to be tested on every release. Automated testing of code examples is standard practice in software engineering and less common in documentation, but the tooling exists. [Fern](https://buildwithfern.com/post/api-documentation-sdk-generation-tools) and [Speakeasy](https://www.speakeasy.com/blog/how-to-build-sdks) both support generating SDK documentation from an API definition, keeping code samples synchronized with the actual implementation by construction. For teams maintaining handwritten docs, a CI step that runs the quickstart against the live SDK catches regressions before they reach developers.
+The fix is simple. The quickstart needs to be tested on every release. Automated testing of code examples is standard practice in software engineering and less common in documentation, but the tooling exists. [Fern](https://buildwithfern.com/post/api-documentation-sdk-generation-tools) and [Speakeasy](https://www.speakeasy.com/blog/how-to-build-sdks) both support generating SDK documentation from an API definition, keeping code samples synchronized with the actual implementation by construction. For teams maintaining handwritten docs, a CI step that runs the quickstart against the live SDK catches regressions before they reach developers.
 
 ## Where documentation gaps compound
 
-Once a developer clears the quickstart, the next friction point is error handling. When an integration breaks in production, a developer's first question is: does the SDK tell me what went wrong, and does the documentation explain what to do about it?
+Once a developer clears the quickstart, the next friction point is error handling. When an integration breaks in production, a developer first needs to know whether the SDK explains what went wrong and whether the documentation explains what to do about it.
 
-SDK docs that cover the happy path and skip errors leave developers with two options when something breaks: read the source code or file a support ticket. Both are expensive.
+SDK docs that cover the happy path and skip errors leave developers with two expensive options when something breaks. They can read the source code or file a support ticket.
 
 [Stripe's error codes page](https://docs.stripe.com/error-codes) is a useful reference point. Every error maps to a description and resolution steps. The API returns a `doc_url` field pointing directly to the relevant documentation entry. A developer hitting an error in production has a direct path to actionable information.
 
-Most SDK documentation doesn't reach this bar. A practical starting point: document the five most common integration errors with the exact error string, what causes it, and how to resolve it. Your support tickets will identify which five those are.
+Most SDK documentation doesn't reach this bar. Start by documenting the five most common integration errors with the exact error string, what causes it, and how to resolve it. Your support tickets will identify which five those are.
 
 <BlogNewsletterCTA />
 
 ## Versioning and deprecation: where most teams fall short
 
-SDK versioning is where documentation fails in slow motion. A parameter is deprecated. A note appears in the changelog. Developers who read the changelog update their code. Developers who don't keep using the deprecated parameter until it breaks.
+SDK versioning is where documentation fails in slow motion. A parameter is deprecated and a note appears in the changelog. Developers who read the changelog update their code. Developers who don't keep using the deprecated parameter until it breaks.
 
 The problem is placement. Deprecation notices in a changelog reach developers who are actively looking for changes. Deprecation notices inline in the reference documentation reach developers who are in the middle of integrating right now.
 
 [Speakeasy's versioning guidance](https://www.speakeasy.com/docs/sdks/manage/versioning) emphasizes migration guides alongside semantic versioning as the foundation for managing SDK evolution. Migration guides matter because they remove the activation energy required to upgrade. A developer who knows exactly what to change will change it. A developer who has to figure it out will defer.
 
-The practical rule: when you deprecate something, add a callout to every reference page that mentions the deprecated item. Not just the changelog. The notice needs to appear where a developer is reading when they are actively building.
+The practical rule is to add a callout to every reference page that mentions a deprecated item. Not just the changelog. The notice needs to appear where a developer is reading when they are actively building.
 
 ## Code examples that stay accurate
 
@@ -72,9 +72,9 @@ A few practices narrow this maintenance gap:
 
 Coverage in SDK documentation has two dimensions that are easy to conflate.
 
-Surface area coverage asks: does every public API method have a documentation entry? This is what most teams measure because it is easy to audit. A script can report it.
+Surface area coverage measures whether every public API method has a documentation entry. This is what most teams measure because it is easy to audit. A script can report it.
 
-Accuracy coverage asks: for the pages that exist, is the content still correct? This is harder to measure and more consequential for developers. A documentation site that is complete but 25% stale actively misleads developers.
+Accuracy coverage measures whether the existing pages are still correct. This is harder to measure and more consequential for developers. A documentation site that is complete but 25% stale actively misleads developers.
 
 The 75% API spec conformance failure captures the accuracy dimension at scale. Most of the teams contributing to that number have complete surface area coverage. Their problem is accuracy, not presence.
 
@@ -82,7 +82,7 @@ Periodic audits that check surface area and stop there are solving the easier pr
 
 ## SDK documentation in a world where agents read your docs
 
-One factor that has shifted the stakes on SDK documentation quality: coding agents now read your documentation.
+Coding agents have shifted the stakes on SDK documentation quality because they now read your documentation.
 
 When a developer uses GitHub Copilot, Claude, or Cursor to integrate your SDK, the agent reads your documentation and generates code from it. A stale code example in your docs doesn't mislead one developer. It generates the same broken pattern across every AI-assisted integration attempt.
 

--- a/src/content/blog/technical/sdk-documentation-best-practices.mdx
+++ b/src/content/blog/technical/sdk-documentation-best-practices.mdx
@@ -1,0 +1,93 @@
+---
+title: 'SDK Documentation Best Practices: What Actually Hurts Developer Adoption'
+subtitle: Published April 2026
+description: >-
+  SDK documentation fails developers in predictable ways. Here's how to cut Time to First Call and keep code examples accurate as your SDK evolves.
+date: '2026-04-28T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A team building on a popular payments SDK spent two days debugging a failed integration. The API docs said a particular field was optional. The actual implementation required it. The spec was six months out of date.
+
+This is the failure mode that matters most in SDK documentation. Not missing coverage. Not poor navigation. Accurate information that became inaccurate and stayed that way.
+
+SDK documentation is uniquely vulnerable to this problem because the surface area is large and changes fast. Every deprecation and every parameter rename creates a gap between what the docs say and what the code does. [A report tracking API quality](https://nordicapis.com/what-is-api-drift-and-what-can-you-do-about-it/) found that 75% of production APIs do not conform to their own specifications. Most of that gap lives in documentation no one has reviewed since the original launch.
+
+## The metric that reveals documentation quality
+
+Time to First Call (TTFC) measures the time between a developer accessing your documentation and making their first successful API call. It is the clearest proxy for how well your SDK documentation is doing its job.
+
+[Postman calls TTFC the most important API metric.](https://blog.postman.com/the-most-important-api-metric-is-time-to-first-call/) The reasoning is direct: a developer who never reaches a working call doesn't integrate. Everything downstream depends on clearing that first hurdle.
+
+TTFC is directly actionable. If it rises after a major SDK release, something in your onboarding experience regressed. If it falls after you updated the quickstart examples, you know the update mattered. Most of the variance in TTFC traces back to a handful of documentation problems that appear in a predictable order.
+
+## The quickstart is where documentation wins or loses
+
+The quickstart is the highest-stakes section in any SDK documentation. It is the first code a developer runs. It has to work.
+
+A broken quickstart teaches developers one thing: these docs cannot be trusted. After that, they verify every code sample before using it. They ask questions in Discord instead of reading the docs. They open support tickets for problems the documentation should answer. The docs exist, but the trust they were supposed to build is gone.
+
+The fix is straightforward. The quickstart needs to be tested on every release. Automated testing of code examples is standard practice in software engineering and less common in documentation, but the tooling exists. [Fern](https://buildwithfern.com/post/api-documentation-sdk-generation-tools) and [Speakeasy](https://www.speakeasy.com/blog/how-to-build-sdks) both support generating SDK documentation from an API definition, keeping code samples synchronized with the actual implementation by construction. For teams maintaining handwritten docs, a CI step that runs the quickstart against the live SDK catches regressions before they reach developers.
+
+## Where documentation gaps compound
+
+Once a developer clears the quickstart, the next friction point is error handling. When an integration breaks in production, a developer's first question is: does the SDK tell me what went wrong, and does the documentation explain what to do about it?
+
+SDK docs that cover the happy path and skip errors leave developers with two options when something breaks: read the source code or file a support ticket. Both are expensive.
+
+[Stripe's error codes page](https://docs.stripe.com/error-codes) is a useful reference point. Every error maps to a description and resolution steps. The API returns a `doc_url` field pointing directly to the relevant documentation entry. A developer hitting an error in production has a direct path to actionable information.
+
+Most SDK documentation doesn't reach this bar. A practical starting point: document the five most common integration errors with the exact error string, what causes it, and how to resolve it. Your support tickets will identify which five those are.
+
+<BlogNewsletterCTA />
+
+## Versioning and deprecation: where most teams fall short
+
+SDK versioning is where documentation fails in slow motion. A parameter is deprecated. A note appears in the changelog. Developers who read the changelog update their code. Developers who don't keep using the deprecated parameter until it breaks.
+
+The problem is placement. Deprecation notices in a changelog reach developers who are actively looking for changes. Deprecation notices inline in the reference documentation reach developers who are in the middle of integrating right now.
+
+[Speakeasy's versioning guidance](https://www.speakeasy.com/docs/sdks/manage/versioning) emphasizes migration guides alongside semantic versioning as the foundation for managing SDK evolution. Migration guides matter because they remove the activation energy required to upgrade. A developer who knows exactly what to change will change it. A developer who has to figure it out will defer.
+
+The practical rule: when you deprecate something, add a callout to every reference page that mentions the deprecated item. Not just the changelog. The notice needs to appear where a developer is reading when they are actively building.
+
+## Code examples that stay accurate
+
+Code examples are the most valuable content in SDK documentation. They are also the most expensive to maintain. Every parameter rename, every method signature change creates an inconsistency that won't surface until a developer runs the example and gets an error.
+
+A few practices narrow this maintenance gap:
+
+**Generate from a canonical source.** For API reference documentation, generated examples from an API definition stay synchronized with the implementation by construction. Fern and Speakeasy both support this approach. Handwritten examples need a process to stay honest.
+
+**Separate stable content from volatile content.** Tutorial examples that walk through a complete workflow are more valuable but harder to keep current. Reference examples tied to specific parameters are easier to automate. Keeping them separate in your documentation structure lets you maintain them with different processes.
+
+**Test examples in CI.** A failing CI check on a code example is far cheaper than a developer spending two days debugging a stale one. If your documentation examples aren't tested, you're relying on someone noticing the problem after it has already shipped.
+
+## The two dimensions of documentation coverage
+
+Coverage in SDK documentation has two dimensions that are easy to conflate.
+
+Surface area coverage asks: does every public API method have a documentation entry? This is what most teams measure because it is easy to audit. A script can report it.
+
+Accuracy coverage asks: for the pages that exist, is the content still correct? This is harder to measure and more consequential for developers. A documentation site that is complete but 25% stale actively misleads developers.
+
+The 75% API spec conformance failure captures the accuracy dimension at scale. Most of the teams contributing to that number have complete surface area coverage. Their problem is accuracy, not presence.
+
+Periodic audits that check surface area and stop there are solving the easier problem. Accuracy degrades continuously, with every product change that doesn't trigger a corresponding documentation update. [Keeping docs accurate as the product ships](/blog/technical/how-teams-keep-docs-up-to-date-with-promptless) requires a different kind of process than the one that produced the docs in the first place.
+
+## SDK documentation in a world where agents read your docs
+
+One factor that has shifted the stakes on SDK documentation quality: coding agents now read your documentation.
+
+When a developer uses GitHub Copilot, Claude, or Cursor to integrate your SDK, the agent reads your documentation and generates code from it. A stale code example in your docs doesn't mislead one developer. It generates the same broken pattern across every AI-assisted integration attempt.
+
+[As covered in the guide to optimizing docs for agents](/blog/technical/agent-docs), agents treat retrieved documentation as ground truth. They have no mechanism for detecting that an example accurate in 2024 fails in 2026. They reproduce the error confidently, and the developer debugging the result has no obvious indication the problem originated in the docs.
+
+SDK documentation accuracy is no longer just a developer experience concern. For products that developers integrate programmatically, the accuracy of your documentation is part of your API contract.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `SDK documentation best practices`

## Article plan

**Target keyword(s):** "SDK documentation best practices" + "time to first call documentation"

**Key ideas:** (1) The most damaging SDK documentation failure mode is code examples that silently stop working — not missing coverage. One team spent two days debugging an integration traced to a 6-month-old spec inaccuracy. (2) TTFC (time to first call) is the clearest proxy for SDK documentation quality, and most of its variance traces to quickstart accuracy.

**Thesis:** The highest-leverage improvements to SDK documentation aren't about completeness — they're about keeping the code examples that get a developer to their first working call accurate as the SDK ships.

**Sections:** Intro (75% API spec conformance stat) → TTFC metric → Quickstart → Error handling → Versioning/deprecation → Code example maintenance → Coverage dimensions → Agents and SDK docs

**Promptless connection:** Promptless monitors documentation accuracy continuously, surfacing when SDK examples break or parameters change before developers hit the problem.

## File

`src/content/blog/technical/sdk-documentation-best-practices.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_016LGpVNgfRJj9CPUnfSsCfp)_