### PR TITLE
Improve job posting structured data

### DIFF
--- a/src/pages/jobs.astro
+++ b/src/pages/jobs.astro
@@ -22,8 +22,10 @@ const location = {
   "@type": "Place",
   "address": {
     "@type": "PostalAddress",
+    "streetAddress": "577 2nd Street",
     "addressLocality": "San Francisco",
     "addressRegion": "CA",
+    "postalCode": "94107",
     "addressCountry": "US"
   }
 };
@@ -35,7 +37,9 @@ const jobPostings = [
     "title": "Founding Engineer (All Levels)",
     "description": "Join the Promptless team as a founding engineer. Build AI that keeps documentation in sync with code.",
     "datePosted": "2025-01-01",
+    "validThrough": "2026-12-31T23:59:59-08:00",
     "employmentType": "FULL_TIME",
+    "url": "https://promptless.ai/jobs#founding-engineer",
     "hiringOrganization": org,
     "jobLocation": location,
     "baseSalary": {
@@ -48,16 +52,6 @@ const jobPostings = [
         "unitText": "YEAR"
       }
     }
-  },
-  {
-    "@context": "https://schema.org",
-    "@type": "JobPosting",
-    "title": "Founding Docs Practice Lead",
-    "description": "Own the documentation practice at Promptless. Onboard customers, build the playbook for AI-assisted documentation, and coach teams on effective workflows.",
-    "datePosted": "2025-01-01",
-    "employmentType": "FULL_TIME",
-    "hiringOrganization": org,
-    "jobLocation": location,
   }
 ];
 ---


### PR DESCRIPTION
## Summary
- add full San Francisco address metadata to the active job posting
- add validThrough and canonical job URL metadata
- remove the inactive Founding Docs Practice Lead job posting schema

## Testing
- Not run: dependencies are not installed in this workspace; astro was unavailable when attempted earlier.