### PR TITLE
Redesign WTD page as Promptless schedule with ICS export

### DIFF
--- a/src/components/site/WtdCalendar.astro
+++ b/src/components/site/WtdCalendar.astro
@@ -8,6 +8,12 @@
  * against the left-border-only WTD events.
  */
 
+interface SubEvent {
+  time: string;
+  title: string;
+  speaker: string;
+}
+
 interface CalendarEvent {
   id: string;
   title: string;
@@ -20,6 +26,7 @@ interface CalendarEvent {
   address?: string;
   promptlessFaces?: boolean;
   cta?: { label: string; href: string };
+  subEvents?: SubEvent[];
 }
 
 interface CalendarDay {
@@ -62,8 +69,19 @@ const days: CalendarDay[] = [
     dateShort: 'Mon, May 4',
     subtitle: 'Conference Day 1',
     events: [
-      { id: 'mon-talks', title: 'Conference Talks', startHour: 9, endHour: 17, time: '9 AM – 5 PM', type: 'talks', link: 'https://www.writethedocs.org/conf/portland/2026/schedule/' },
-      { id: 'mon-unconf', title: 'Unconference', startHour: 9, endHour: 17, time: '9 AM – 5 PM', type: 'unconference', link: 'https://www.writethedocs.org/conf/portland/2026/unconference/' },
+      {
+        id: 'mon-marthas',
+        title: "Coffee & Workshops at Martha's",
+        startHour: 10,
+        endHour: 12,
+        time: '10 AM – 12 PM',
+        type: 'promptless' as const,
+        subEvents: [
+          { time: '10:00 AM', title: 'Context Engineering for Agents', speaker: 'Manny Silva' },
+          { time: '10:45 AM', title: 'Docs as Code: Starting from Scratch', speaker: 'Mike Jang' },
+          { time: '11:30 AM', title: 'Docs Observability: Measure Less, Learn More', speaker: 'Mano Toth' },
+        ],
+      },
       { id: 'mon-pl-dinner', title: 'Promptless Dinner', startHour: 17.5, endHour: 19, time: '5:30 – 7 PM', type: 'promptless', link: 'https://maps.app.goo.gl/usiEh2wMt7BDS7cU7', address: 'Jupiter NEXT (downstairs)', cta: { label: 'RSVP', href: 'https://luma.com/tpl91l3a' } },
       { id: 'mon-social', title: 'Monday Night Social', startHour: 19, endHour: 21, time: '7 – 9 PM', type: 'social', link: 'https://maps.app.goo.gl/usiEh2wMt7BDS7cU7', address: 'Jupiter NEXT (upstairs)' },
     ],
@@ -73,8 +91,15 @@ const days: CalendarDay[] = [
     dateShort: 'Tue, May 5',
     subtitle: 'Conference Day 2',
     events: [
-      { id: 'tue-talks', title: 'Conference Talks', startHour: 9, endHour: 15.75, time: '9 AM – 3:45 PM', type: 'talks', link: 'https://www.writethedocs.org/conf/portland/2026/schedule/' },
-      { id: 'tue-unconf', title: 'Unconference', startHour: 9, endHour: 15.75, time: '9 AM – 3:45 PM', type: 'unconference', link: 'https://www.writethedocs.org/conf/portland/2026/unconference/' },
+      {
+        id: 'tue-doc-audit',
+        title: "Manny's Doc Audit",
+        startHour: 9,
+        endHour: 12,
+        time: '9 AM – 12 PM',
+        type: 'promptless' as const,
+        cta: { label: 'Book 15 min →', href: 'https://cal.com/team/promptless/manny-docs-process-audit' },
+      },
     ],
   },
 ];
@@ -129,11 +154,20 @@ for (let h = RANGE_START; h <= RANGE_END; h += 2) {
 
 <div class="wtd-cal not-content">
   <div class="wtd-cal-header">
-    <h2 class="wtd-cal-title">Promptless is the Keystone Sponsor of Write the Docs Portland 2026</h2>
+    <h2 class="wtd-cal-title">Promptless at Write the Docs Portland 2026</h2>
     <p class="wtd-cal-sub">May 2 – 5 &middot; Portland, Oregon</p>
-    <a class="wtd-cal-gcal-btn" href="https://calendar.google.com/calendar/embed?src=c_97af215d12d262b0d36061d2c4596b54db79d796e2d7a398ae777103b571b87d%40group.calendar.google.com&ctz=America%2FLos_Angeles" target="_blank" rel="noopener noreferrer">
+    <a class="wtd-cal-gcal-btn" href="/wtd-portland-2026.ics">
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/><path d="M8 14h.01"/><path d="M12 14h.01"/><path d="M16 14h.01"/><path d="M8 18h.01"/><path d="M12 18h.01"/><path d="M16 18h.01"/></svg>
-      Add to Google Calendar
+      Add to Calendar
+    </a>
+  </div>
+
+  <div class="wtd-cal-manny-banner">
+    <div class="wtd-cal-manny-banner-text">
+      <strong>Get a free doc audit with Manny</strong> — On Tuesday May 5, Manny Silva is holding open office hours for 15-minute documentation audits. Grab a slot and get actionable feedback on your docs.
+    </div>
+    <a class="wtd-cal-manny-banner-btn" href="https://cal.com/team/promptless/manny-docs-process-audit" target="_blank" rel="noopener noreferrer">
+      Book 15 min →
     </a>
   </div>
 
@@ -179,6 +213,17 @@ for (let h = RANGE_START; h <= RANGE_END; h += 2) {
                       <span class="wtd-cal-block-time">{ev.time}</span>
                       <span class="wtd-cal-block-title">{ev.title}{ev.location && <span class="wtd-cal-block-loc"> at {ev.location}</span>}</span>
                       {ev.address && <span class="wtd-cal-block-addr">{ev.address}</span>}
+                      {ev.subEvents && ev.subEvents.length > 0 && (
+                        <ul class="wtd-cal-block-talks">
+                          {ev.subEvents.map(sub => (
+                            <li class="wtd-cal-block-talk">
+                              <span class="wtd-cal-block-talk-time">{sub.time}</span>
+                              <span class="wtd-cal-block-talk-title">{sub.title}</span>
+                              <span class="wtd-cal-block-talk-speaker">{sub.speaker}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
                       {(ev.promptlessFaces || ev.cta) && (
                         <div class="wtd-cal-bottom">
                           {ev.promptlessFaces && (
@@ -542,6 +587,83 @@ for (let h = RANGE_START; h <= RANGE_END; h += 2) {
     border: 0;
   }
 
+  /* ── Manny CTA banner ── */
+  .wtd-cal-manny-banner {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+    padding: 0.85rem 1.1rem;
+    background: var(--c-pl-bg);
+    border: 2px solid var(--c-pl);
+    border-radius: 0.6rem;
+  }
+
+  .wtd-cal-manny-banner-text {
+    flex: 1;
+    font-size: 0.9rem;
+    color: #111827;
+    line-height: 1.45;
+  }
+
+  .wtd-cal-manny-banner-btn {
+    flex-shrink: 0;
+    padding: 0.45rem 1rem;
+    background: var(--c-pl);
+    color: #fff !important;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    border-radius: 0.4rem;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background 140ms ease;
+  }
+
+  .wtd-cal-manny-banner-btn:hover {
+    background: #3d56d4;
+  }
+
+  /* ── Sub-event talk list ── */
+  .wtd-cal-block-talks {
+    list-style: none;
+    margin: 0.3rem 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    flex: 1;
+    overflow: visible;
+  }
+
+  .wtd-cal-block-talk {
+    display: flex;
+    flex-direction: column;
+    gap: 0.02rem;
+    padding-left: 0.5rem;
+    border-left: 2px solid var(--c-pl);
+  }
+
+  .wtd-cal-block-talk-time {
+    font-size: 0.62rem;
+    font-weight: 700;
+    color: color-mix(in srgb, var(--c-pl) 80%, #374151);
+    line-height: 1;
+  }
+
+  .wtd-cal-block-talk-title {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #111827;
+    line-height: 1.2;
+  }
+
+  .wtd-cal-block-talk-speaker {
+    font-size: 0.68rem;
+    color: #6b7280;
+    line-height: 1;
+  }
+
   /* ── Responsive ── */
   @media (max-width: 600px) {
     .wtd-cal-grid {
@@ -550,6 +672,12 @@ for (let h = RANGE_START; h <= RANGE_END; h += 2) {
 
     .wtd-cal-tick {
       font-size: 0.58rem;
+    }
+
+    .wtd-cal-manny-banner {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.65rem;
     }
   }
 </style>

--- a/src/content/website/wtd-portland-2026.mdx
+++ b/src/content/website/wtd-portland-2026.mdx
@@ -1,6 +1,6 @@
 ---
-title: Schedule - Write the Docs Portland 2026
-description: "Conference schedule for Write the Docs Portland 2026, May 2-5 at Revolution Hall, Portland, Oregon."
+title: Promptless at Write the Docs Portland 2026
+description: "Where to find Promptless at Write the Docs Portland 2026, May 2-5 at Revolution Hall, Portland, Oregon."
 routePath: /wtd-portland-2026
 order: 5
 hidden: true

--- a/src/pages/wtd-portland-2026.ics.ts
+++ b/src/pages/wtd-portland-2026.ics.ts
@@ -1,0 +1,162 @@
+import type { APIRoute } from 'astro';
+
+function toICSDateTime(date: string, decimalHour: number): string {
+  const h = Math.floor(decimalHour);
+  const m = Math.round((decimalHour - h) * 60);
+  return `${date}T${String(h).padStart(2, '0')}${String(m).padStart(2, '0')}00`;
+}
+
+function escapeValue(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/;/g, '\\;').replace(/,/g, '\\,').replace(/\n/g, '\\n');
+}
+
+function foldLine(line: string): string {
+  if (line.length <= 75) return line;
+  const segments: string[] = [line.slice(0, 75)];
+  let pos = 75;
+  while (pos < line.length) {
+    segments.push(' ' + line.slice(pos, pos + 74));
+    pos += 74;
+  }
+  return segments.join('\r\n');
+}
+
+function prop(key: string, value: string): string {
+  return foldLine(`${key}:${value}`);
+}
+
+const DTSTAMP = new Date().toISOString().replace(/[-:]/g, '').slice(0, 15) + 'Z';
+
+interface ICSEvent {
+  uid: string;
+  date: string;
+  startHour: number;
+  endHour: number;
+  summary: string;
+  description?: string;
+  location?: string;
+  url?: string;
+}
+
+const events: ICSEvent[] = [
+  // Saturday May 2
+  {
+    uid: 'sat-lunch@promptless.ai',
+    date: '20260502',
+    startHour: 12.5,
+    endHour: 13 + 40 / 60,
+    summary: 'WTD: Lunch at Nob Hill Food Carts',
+    location: 'Nob Hill Food Carts, Portland, OR',
+    url: 'https://www.writethedocs.org/conf/portland/2026/hike/',
+  },
+  {
+    uid: 'sat-hike@promptless.ai',
+    date: '20260502',
+    startHour: 14,
+    endHour: 17,
+    summary: 'WTD: Conference Hike',
+    url: 'https://www.writethedocs.org/conf/portland/2026/hike/',
+  },
+  // Sunday May 3
+  {
+    uid: 'sun-writing@promptless.ai',
+    date: '20260503',
+    startHour: 9,
+    endHour: 17,
+    summary: 'WTD: Writing Day',
+    location: 'Revolution Hall, Portland, OR',
+    url: 'https://www.writethedocs.org/conf/portland/2026/writing-day/',
+  },
+  {
+    uid: 'sun-reception@promptless.ai',
+    date: '20260503',
+    startHour: 17,
+    endHour: 19,
+    summary: 'WTD: Sunday Reception',
+    location: 'Revolution Hall, Portland, OR',
+  },
+  {
+    uid: 'sun-pl-dinner@promptless.ai',
+    date: '20260503',
+    startHour: 19,
+    endHour: 21,
+    summary: 'Promptless Dinner at East Burn',
+    description: 'RSVP at https://luma.com/1m13xfc3',
+    location: 'East Burn, 1800 E Burnside St, Portland, OR 97214',
+  },
+  // Monday May 4
+  {
+    uid: 'mon-marthas@promptless.ai',
+    date: '20260504',
+    startHour: 10,
+    endHour: 12,
+    summary: "Coffee & Workshops at Martha's with Promptless",
+    description:
+      '10:00 AM — Context Engineering for Agents (Manny Silva)\n' +
+      '10:45 AM — Docs as Code: Starting from Scratch (Mike Jang)\n' +
+      '11:30 AM — Docs Observability: Measure Less, Learn More (Mano Toth)',
+    location: "Martha's, Portland, OR",
+  },
+  {
+    uid: 'mon-pl-dinner@promptless.ai',
+    date: '20260504',
+    startHour: 17.5,
+    endHour: 19,
+    summary: 'Promptless Dinner at Jupiter NEXT',
+    description: 'RSVP at https://luma.com/tpl91l3a',
+    location: 'Jupiter NEXT (downstairs), Portland, OR',
+  },
+  {
+    uid: 'mon-social@promptless.ai',
+    date: '20260504',
+    startHour: 19,
+    endHour: 21,
+    summary: 'WTD: Monday Night Social',
+    location: 'Jupiter NEXT (upstairs), Portland, OR',
+  },
+  // Tuesday May 5
+  {
+    uid: 'tue-doc-audit@promptless.ai',
+    date: '20260505',
+    startHour: 9,
+    endHour: 12,
+    summary: "Manny's Doc Audit — Book a free 15-min slot",
+    description: 'Book a free 15-minute documentation audit with Manny Silva at https://cal.com/team/promptless/manny-docs-process-audit',
+    location: 'Revolution Hall, Portland, OR',
+    url: 'https://cal.com/team/promptless/manny-docs-process-audit',
+  },
+];
+
+export const GET: APIRoute = () => {
+  const lines: string[] = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    prop('PRODID', '-//Promptless//WTD Portland 2026//EN'),
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    prop('X-WR-CALNAME', 'Promptless at WTD Portland 2026'),
+    'X-WR-TIMEZONE:America/Los_Angeles',
+  ];
+
+  for (const ev of events) {
+    lines.push('BEGIN:VEVENT');
+    lines.push(prop('UID', ev.uid));
+    lines.push(prop('DTSTAMP', DTSTAMP));
+    lines.push(foldLine(`DTSTART;TZID=America/Los_Angeles:${toICSDateTime(ev.date, ev.startHour)}`));
+    lines.push(foldLine(`DTEND;TZID=America/Los_Angeles:${toICSDateTime(ev.date, ev.endHour)}`));
+    lines.push(prop('SUMMARY', escapeValue(ev.summary)));
+    if (ev.description) lines.push(prop('DESCRIPTION', escapeValue(ev.description)));
+    if (ev.location) lines.push(prop('LOCATION', escapeValue(ev.location)));
+    if (ev.url) lines.push(prop('URL', ev.url));
+    lines.push('END:VEVENT');
+  }
+
+  lines.push('END:VCALENDAR');
+
+  return new Response(lines.join('\r\n'), {
+    headers: {
+      'Content-Type': 'text/calendar; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="promptless-wtd-portland-2026.ics"',
+    },
+  });
+};


### PR DESCRIPTION
## Summary

- Renames the WTD page to **Promptless at Write the Docs Portland 2026** and reframes it as a schedule of Promptless events (not the full conference schedule)
- Replaces the conference talks/unconference calendar blocks with Promptless-specific events: Martha's Coffee & Workshops on Monday (with 3 speaker sessions shown inline) and Manny's Doc Audit on Tuesday (9 AM–12 PM)
- Adds a prominent CTA banner above the calendar to book a free 15-minute doc audit with Manny via cal.com
- Adds `/wtd-portland-2026.ics` — a statically-generated iCalendar endpoint with all 9 events, proper `TZID=America/Los_Angeles`, and RFC 5545-compliant line folding — replacing the broken Google Calendar embed button

## Test plan

- [ ] Visit `/wtd-portland-2026` and confirm the page title and banner render correctly
- [ ] Click "Add to Calendar" and confirm the `.ics` file downloads with all 9 events at correct times (PDT)
- [ ] Import the `.ics` into Google Calendar / Apple Calendar and verify events appear correctly
- [ ] Click "Book 15 min →" CTA (banner and Tuesday block) and confirm it opens the correct cal.com link
- [ ] Confirm the Martha's block shows the 3 sub-talks overflowing the block boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)