### PR TITLE
content: Interactive API Documentation: Why the Hard Part Is Keeping It Accurate

### DIFF
--- a/src/content/blog/technical/interactive-api-documentation.mdx
+++ b/src/content/blog/technical/interactive-api-documentation.mdx
@@ -1,0 +1,87 @@
+---
+title: 'Interactive API Documentation: Why the Hard Part Is Keeping It Accurate'
+subtitle: Published April 2026
+description: >-
+  Most teams ship interactive API docs and stop there. Here's why spec drift undermines the "try it out" experience, and what changes when AI agents are involved.
+date: '2026-04-30T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer follows your "try it out" button. They fill in the parameters the interactive console shows. They click execute. The API returns a 422. The request schema in the console doesn't match what the endpoint actually accepts.
+
+They close the tab and look for a community forum. Or they move on to a competitor whose docs work.
+
+This sequence happens because interactive API documentation has a maintenance problem that most teams don't treat as a maintenance problem. They treat it as a publishing problem: solved once, at launch.
+
+## The spec is the product, not the UI
+
+Interactive API documentation (Swagger UI, Redoc, Scalar, ReadMe, Stoplight Elements) all render from the same underlying artifact: an OpenAPI specification. The interactivity isn't in the tool. It's a consequence of the spec being machine-readable.
+
+This matters because most teams think about the documentation layer (which tool, which theme, how the sidebar is organized) and underinvest in the spec layer (whether the spec is accurate).
+
+The typical workflow looks like this: API ships. Someone writes the OpenAPI spec, or generates it from code annotations, or exports it from a tool. The interactive docs go live. From that point on, the spec is treated as stable. Backend engineers add parameters and rename fields. The spec doesn't follow.
+
+This is called spec drift. [According to Kinde](https://www.kinde.com/learn/ai-for-software-engineering/ai-devops/spec-drift-the-hidden-problem-ai-can-help-fix/), it starts the moment a developer merges a route change without updating the spec. That's the default behavior on most teams, because there's no enforcement step that makes updating the spec mandatory before a PR merges.
+
+The [Postman 2024 State of the API report](https://www.postman.com/state-of-api/2024), which surveyed over 5,600 developers, found that 68% of developers cite outdated documentation as their top frustration when working with APIs. Teams that have shipped interactive docs are not exempt from this. The interactivity doesn't solve the accuracy problem. It just adds a new surface on which inaccuracy shows up.
+
+## Why "try it out" raises the stakes
+
+A static reference page with wrong information frustrates developers. An interactive console with wrong information does something different: it actively tests the developer's trust and fails in real time.
+
+When a developer reads a static page and something doesn't work, they might wonder if the problem is in their code. When they click "try it out" and get an unexpected error, there's no ambiguity. The docs are wrong. The documentation site has just proved itself unreliable in front of them.
+
+That trust break compounds. A developer who gets a bad result from the interactive console will also discount the reference docs and conceptual guides. The whole site is now suspect.
+
+The inverse is also true: when interactive docs work, they build unusually strong trust. A developer who successfully calls an endpoint through the console and sees the exact response shape they'll need to parse in their integration has gotten something a static page can't give them. The fidelity of a working interactive experience is high. So is the damage of a broken one.
+
+Most teams don't have a signal for how often "try it out" produces wrong results. As with [documentation drift more broadly](/blog/technical/documentation-drift-detection-problem), the bottleneck is detection: the team that shipped the docs doesn't know something is wrong until a developer outside the team surfaces it. There's no error log for "developer clicked execute and got unexpected behavior." The first signal is usually a support ticket filed weeks after the bad experience.
+
+<BlogNewsletterCTA />
+
+## Your second audience: AI coding assistants
+
+The developer clicking "try it out" is no longer your only concern.
+
+AI coding assistants (Cursor, GitHub Copilot, Claude) parse OpenAPI specs directly to understand API surfaces. When a developer asks their coding assistant how to call your authentication endpoint, the assistant may fetch your OpenAPI spec and generate the code from it. A new tool called [OpenAPI Slimmer](https://medium.com/@mcsavvy/introducing-openapi-slimmer-slim-down-your-api-specs-for-ai-agents-b0f199ea37f2) was built specifically to compress OpenAPI specs for agent consumption, which signals how routinely agents are reading these files.
+
+The blast radius of a stale spec has grown. Before, a wrong parameter in your OpenAPI spec frustrated a developer who was looking at the interactive console. Now, it generates wrong code for every developer in your community whose AI assistant loads that spec.
+
+The spec field that says `token_type: "bearer"` but should say `token_type: "jwt"` no longer just shows up wrong in Swagger UI. It propagates into generated code across every AI-assisted integration. Each developer gets a confident, incorrect implementation. They debug it, then discover the spec was wrong. Some file support tickets. Most don't.
+
+Research on AI agent reliability is consistent on this point: stale context doesn't produce uncertainty. It produces confident wrong answers. There's no hedging. The model answers from what it found. As the [Promptless post on agent context engineering](/blog/technical/agent-context-engineering) describes, each step in an agent's execution uses prior outputs as inputs, so a stale spec retrieved early becomes the assumption underlying every code snippet that follows.
+
+## What spec-first development actually requires
+
+The cleanest solution to spec drift is spec-first development: design the API in OpenAPI, implement to match the spec, and treat the spec as the source of truth from the start. In this model, drift can't accumulate because code is validated against the spec, not the other way around.
+
+This is the right approach for new APIs. For teams with existing APIs and existing codebases, it requires significant workflow change and buy-in that most teams aren't positioned to get.
+
+The practical alternative is continuous spec validation. After every release, an automated process diffs the published OpenAPI spec against actual API behavior: request shapes, response schemas, status codes, authentication flows. Discrepancies get surfaced before developers hit them.
+
+[Research on spec-driven development](https://arxiv.org/html/2602.00180v1) describes three levels of spec rigor: spec-first (spec drives implementation), spec-anchored (spec is updated alongside code), and spec-as-source (spec is generated from a canonical source and regenerated on each deploy). Teams that maintain accurate interactive docs tend to operate at the spec-anchored or spec-as-source level. They don't update the spec manually when they remember. They have a process that makes the spec accurate by default.
+
+The teams whose interactive docs stay accurate over time treat the spec the same way they treat a test suite: something that runs on every deploy, fails loudly when something is wrong, and blocks a release that would otherwise publish incorrect information.
+
+## What accurate interactive docs require
+
+Getting from "we have Swagger UI deployed" to "our interactive docs are reliable" involves a few specific commitments:
+
+**The spec needs to be generated or validated on every API release.** Manual updates don't hold. Engineers are focused on shipping features, not documentation. A spec that's updated by convention will drift.
+
+**Breaking changes in the spec should block deploys the same way failing tests block deploys.** If a developer can merge a route rename without updating the spec, they will. The spec needs enforcement, not reminders.
+
+**The spec's accuracy needs monitoring, not just the spec's existence.** Many teams have confirmed their OpenAPI spec is syntactically valid and renders correctly in Swagger UI. Fewer have confirmed it matches what the API actually does. These are different checks.
+
+Interactive API documentation is a commitment that the spec reflects deployed behavior. Without the maintenance process to back that commitment, it's a liability. The "try it out" button is an implicit promise. When the spec is wrong, the button breaks that promise in front of every developer who tries to use it.
+
+## How Promptless fits in
+
+Promptless monitors API reference documentation against the actual product, surfacing where documentation has drifted from what the API currently does. For teams maintaining interactive docs, this means knowing about spec drift before developers or AI coding assistants encounter it, rather than after. The goal isn't a perfect spec at launch. It's a spec that stays accurate as the product changes.
+
+<BlogRequestDemo />

--- a/src/content/blog/technical/interactive-api-documentation.mdx
+++ b/src/content/blog/technical/interactive-api-documentation.mdx
@@ -28,7 +28,7 @@ The typical workflow looks like this: API ships. Someone writes the OpenAPI spec
 
 This is called spec drift. [According to Kinde](https://www.kinde.com/learn/ai-for-software-engineering/ai-devops/spec-drift-the-hidden-problem-ai-can-help-fix/), it starts the moment a developer merges a route change without updating the spec. That's the default behavior on most teams, because there's no enforcement step that makes updating the spec mandatory before a PR merges.
 
-The [Postman 2024 State of the API report](https://www.postman.com/state-of-api/2024), which surveyed over 5,600 developers, found that 68% of developers cite outdated documentation as their top frustration when working with APIs. Teams that have shipped interactive docs are not exempt from this. The interactivity doesn't solve the accuracy problem. It just adds a new surface on which inaccuracy shows up.
+[The Postman 2024 State of the API report](https://voyager.postman.com/doc/postman-state-of-the-api-report-2024.pdf), which surveyed over 5,600 developers, found that 68% of developers cite outdated documentation as their top frustration when working with APIs. Teams that have shipped interactive docs are not exempt from this. The interactivity doesn't solve the accuracy problem. It just adds a new surface on which inaccuracy shows up.
 
 ## Why "try it out" raises the stakes
 


### PR DESCRIPTION
**Keyword:** `interactive API documentation`

## Article plan

**Thesis:** Interactive API documentation only works when the spec it's built on is accurate. Most teams invest in the presentation layer and neglect the maintenance layer.

**Target reader:** DevRel engineers, API platform teams, and technical writers at developer-facing companies with deployed Swagger/Redoc/Scalar. They've shipped interactive docs and want to improve the developer experience.

**Key angles:**
- Spec drift starts the moment a backend engineer merges a route change without updating the spec. Interactive docs make this failure more visible — and more damaging — because "try it out" actively proves docs wrong in front of developers.
- AI coding assistants (Cursor, GitHub Copilot, Claude) now consume OpenAPI specs directly, multiplying the blast radius of every stale spec field across every AI-assisted integration.
- Practical path forward: continuous spec validation on every deploy, not spec-first redesign.

**Sources cited:** Postman 2024 State of the API report, Kinde (spec drift), arxiv spec-driven development research, OpenAPI Slimmer tool.

**Internal links:** documentation-drift-detection-problem, agent-context-engineering

## File

`src/content/blog/technical/interactive-api-documentation.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CR4H8hfkaEpVPhp621j7BR)_