### PR TITLE
feat: Add WTD 2026 demo hub page

### DIFF
--- a/src/content/website/wtd-demo.mdx
+++ b/src/content/website/wtd-demo.mdx
@@ -1,0 +1,145 @@
+---
+title: WTD Demo Hub
+description: Demo reference page for Write the Docs 2026 — links and talking points for each live demo scenario.
+routePath: /wtd-demo
+order: 6
+hidden: true
+---
+
+<style>{`
+  .demo-links {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin: 1rem 0 1.5rem;
+  }
+  .demo-link {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 1rem;
+    text-decoration: none;
+  }
+  .demo-link:hover {
+    text-decoration: underline;
+  }
+  .demo-link img {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    display: block;
+  }
+`}</style>
+
+This page is a presenter reference. Open it on your phone or a second screen while demoing. Each section has the links to queue up and a script of talking points.
+
+---
+
+## Demo 1 — Source PR triggers a docs update
+
+**The story:** A code change lands. Promptless detects it, drafts a suggestion, and opens a docs PR — no one had to file a ticket or remember to update anything.
+
+<div class="demo-links">
+  <a href="#TODO" class="demo-link">
+    <img src="/assets/github-logo.svg" alt="GitHub" />
+    Source code PR (the trigger)
+  </a>
+  <a href="#TODO" class="demo-link">
+    <img src="/assets/square_logo_blue.svg" alt="Promptless" />
+    Suggestion in Promptless
+  </a>
+  <a href="#TODO" class="demo-link">
+    <img src="/assets/github-logo.svg" alt="GitHub" />
+    Docs PR that was opened
+  </a>
+  <a href="#TODO" class="demo-link">
+    <img src="/assets/github-logo.svg" alt="GitHub" />
+    Published result / Vercel preview
+  </a>
+</div>
+
+<details>
+<summary>Talking points (~ 3 min)</summary>
+
+- **Open with the source PR.** "Here's an ordinary pull request — a developer shipped a change. They didn't write a single line of docs."
+- **Jump to Promptless.** "Promptless picked it up automatically. It read the diff, found the affected documentation, and drafted a suggestion. Notice the citations — you can see exactly which lines of code drove each change."
+- **Show the docs PR.** "Because the suggestion looked good, Promptless opened this PR against the docs repo. The writer just had to review and merge."
+- **Show the published page.** "And this is what readers see now. The docs matched the code within minutes of the PR landing."
+- **The punchline:** "No ticket. No reminder. No 'we should document that' that gets forgotten. It just happened."
+
+**Time split:** ~45 s on source PR / ~60 s on suggestion / ~45 s on docs PR / ~30 s on live result.
+
+</details>
+
+---
+
+## Demo 2 — Slack conversation triggers a docs update
+
+**The story:** Engineers are talking in Slack. Someone tags Promptless with context. A suggestion is created. You can walk through the revision history to show how the writing got better iteratively before the docs PR was opened.
+
+<div class="demo-links">
+  <a href="#TODO" class="demo-link">
+    <img src="/assets/slack-logo.svg" alt="Slack" />
+    Slack thread
+  </a>
+  <a href="#TODO" class="demo-link">
+    <img src="/assets/square_logo_blue.svg" alt="Promptless" />
+    Suggestion in Promptless
+  </a>
+  <a href="#TODO" class="demo-link">
+    <img src="/assets/square_logo_blue.svg" alt="Promptless" />
+    Revision history on the suggestion
+  </a>
+  <a href="#TODO" class="demo-link">
+    <img src="/assets/github-logo.svg" alt="GitHub" />
+    Docs PR that was opened
+  </a>
+</div>
+
+<details>
+<summary>Talking points (~ 3 min)</summary>
+
+- **Open the Slack thread.** "Here's a real conversation — engineers are hashing out how something works. Buried in this thread is knowledge that no one ever put in the docs."
+- **Point to the @Promptless tag.** "Someone said 'hey, this should be in the docs' and tagged Promptless. That's the only manual step in this whole flow."
+- **Jump to Promptless.** "Promptless read the thread, figured out which doc page was most relevant, and drafted a suggestion."
+- **Show the revision history.** "Here's where it gets interesting. The writer left feedback on the suggestion — 'this section needs more detail' — and Promptless revised it. You can see every iteration. This is how the draft got sharper over time."
+- **Show the docs PR.** "Once the writer was happy, Promptless opened the PR. The Slack conversation is cited right there in the PR description — reviewers can trace everything back to source."
+- **The punchline:** "The tribal knowledge in that Slack thread is now in the docs forever."
+
+**Time split:** ~45 s on Slack thread / ~60 s on suggestion + revision history / ~45 s on docs PR.
+
+</details>
+
+---
+
+## Demo 3 — Direct tasking opens a reviewed docs PR
+
+**The story:** A writer directly assigns Promptless a task. Promptless opens a docs PR. The team reviews and comments in GitHub, and it gets merged through the normal review flow.
+
+<div class="demo-links">
+  <a href="#TODO" class="demo-link">
+    <img src="/assets/square_logo_blue.svg" alt="Promptless" />
+    Task / direct assignment in Promptless
+  </a>
+  <a href="#TODO" class="demo-link">
+    <img src="/assets/github-logo.svg" alt="GitHub" />
+    Docs PR with review comments
+  </a>
+  <a href="#TODO" class="demo-link">
+    <img src="/assets/github-logo.svg" alt="GitHub" />
+    Merged result / published page
+  </a>
+</div>
+
+<details>
+<summary>Talking points (~ 2 min)</summary>
+
+- **Open the task in Promptless.** "You don't have to wait for a trigger. Writers can assign Promptless a task directly — 'add a getting-started guide for feature X' — and it just runs."
+- **Show the docs PR.** "Promptless opened this PR. Look at the review thread — real GitHub comments from the team, exactly the same review process they use for any PR."
+- **Highlight a specific comment.** "The reviewer asked for a code example here. Promptless added it in the next commit."
+- **Show the merged state.** "And it's live. The whole thing went through normal version control — you get history, blame, rollback, everything."
+- **The punchline:** "Promptless fits into the workflow your team already has. Nothing changes except who writes the first draft."
+
+**Time split:** ~30 s on task / ~75 s on PR + review thread / ~15 s on merged result.
+
+</details>

--- a/src/pages/wtd-demo.astro
+++ b/src/pages/wtd-demo.astro
@@ -1,0 +1,28 @@
+---
+import { getEntry } from 'astro:content';
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+
+const entry = await getEntry('website', 'wtd-demo');
+
+if (!entry) {
+  throw new Error('Missing website content entry: wtd-demo');
+}
+
+const { Content, headings } = await entry.render();
+---
+
+<StarlightPage
+  hasSidebar={false}
+  headings={headings}
+  frontmatter={{
+    title: entry.data.title,
+    description: entry.data.description,
+    template: 'doc',
+    editUrl: false,
+    tableOfContents: true,
+  }}
+>
+  <div class="pl-site-page">
+    <Content />
+  </div>
+</StarlightPage>


### PR DESCRIPTION
## Summary

- Adds a hidden presenter-reference page at `/wtd-demo`
- Covers three demo scenarios: source PR triggers, Slack conversation triggers, and direct tasking
- Each section includes queued links (placeholders) and collapsible talking points with time splits

## Test plan

- [ ] Page renders at `/wtd-demo` without errors
- [ ] `hidden: true` frontmatter keeps it out of sidebar navigation
- [ ] Collapsible `<details>` sections open/close correctly
- [ ] Logo icons load (github, slack, Promptless square logo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)