### PR TITLE
docs: Move "Requesting New Integrations" to a callout near the top of the integrations page

### DIFF
--- a/src/content/docs/docs/integrations.mdx
+++ b/src/content/docs/docs/integrations.mdx
@@ -5,6 +5,7 @@ sidebar:
   hidden: false
   order: 27
 ---
+import Note from '@components/fern/Note.astro';
 
 Promptless offers several key integrations to help automate and improve your documentation workflow.
 
@@ -14,6 +15,10 @@ Integrations can be used for:
 3. Publishing (i.e. to push documentation updates to your Git-hosted docs)
 
 Some integrations can be used for multiple purposes. Some integrations are in a beta state and may not be listed here. For the most up to date list of integrations, please contact us at help@gopromptless.ai.
+
+<Note title="Requesting New Integrations">
+Need an integration that's not listed here? Contact us at [help@gopromptless.ai](mailto:help@gopromptless.ai) to discuss your requirements.
+</Note>
 
 ## Available Integrations
 
@@ -57,7 +62,3 @@ Each integration includes:
 - Data privacy controls
 
 For detailed security information, visit our [Security and Privacy documentation](/docs/security-and-privacy).
-
-## Requesting New Integrations
-
-Need an integration that's not listed here? Contact us at help@gopromptless.ai to discuss your requirements.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/77a26ca0-0de3-4b97-b384-fec22cd20b85)

Per Prithvi's Slack request, promotes the "Requesting New Integrations" content to a `<Note>` callout placed near the top of `src/content/docs/docs/integrations.mdx` (right after the intro), and removes the corresponding `## Requesting New Integrations` heading section at the bottom. Uses the existing Fern `Note` component to match the callout style used elsewhere in the docs.

**Trigger Events**
- [Slack mention: <@U0B148CFR89> can you move "Requesting New Integrations" closer to the top of <https://promptless.ai/docs/integrations/|this page> and make it some type of call-out rather than an h1/h2?](https://Writing Day 2026.slack.com/archives/C0B0MU7G71T/p1777791418136579)

---

_Tip: Sort by Shortest Review in the [Dashboard](https://app.gopromptless.ai) to find quick wins ⚡_