### PR TITLE
docs: Add Writing Day 2026 docs page and /wtd-oss short link

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -26,6 +26,7 @@ const redirects = {
   '/docs': '/docs/getting-started/welcome',
   '/page': '/',
   '/wtd': '/',
+  '/wtd-oss': '/docs/getting-started/wtd-oss',
   '/hn': '/',
   '/blog/customer-stories-vellum': '/blog/customer-stories/vellum',
   '/use-cases': '/',

--- a/src/content/docs/docs/getting-started/getting-help.mdx
+++ b/src/content/docs/docs/getting-started/getting-help.mdx
@@ -3,7 +3,7 @@ title: Getting Support
 slug: docs/getting-started/getting-help
 sidebar:
   hidden: false
-  order: 6
+  order: 7
 ---
 import Card from '@components/fern/Card.astro';
 import CardGroup from '@components/fern/CardGroup.astro';

--- a/src/content/docs/docs/getting-started/pilot-overview.mdx
+++ b/src/content/docs/docs/getting-started/pilot-overview.mdx
@@ -3,7 +3,7 @@ title: Pilot Overview
 slug: docs/getting-started/pilot-overview
 sidebar:
   hidden: true
-  order: 7
+  order: 8
 ---
 import Steps from '@components/fern/Steps.astro';
 import Step from '@components/fern/Step.astro';

--- a/src/content/docs/docs/getting-started/wtd-oss.mdx
+++ b/src/content/docs/docs/getting-started/wtd-oss.mdx
@@ -16,6 +16,8 @@ import WtdSlackJoinButton from '@components/site/WtdSlackJoinButton.astro';
 
 The goal of Writing Day is simple: leave Portland with a real contribution to a well-known open-source project. We've worked with maintainers from Mautic, Vitess, and Helm ahead of time so you can pick up a labeled "good first issue" and ship a PR before the day is over.
 
+<WtdSlackJoinButton />
+
 Bring a laptop, pick an issue, ship a PR.
 
 <Tip>

--- a/src/content/docs/docs/getting-started/wtd-oss.mdx
+++ b/src/content/docs/docs/getting-started/wtd-oss.mdx
@@ -1,0 +1,108 @@
+---
+title: Writing Day at Write the Docs Portland 2026
+subtitle: Ship a real OSS docs PR with pre-vetted issues from Mautic, Vitess, and Helm
+description: >-
+  Overview of the Promptless Writing Day setup at Write the Docs Portland 2026: pre-vetted "good first issue" docs tasks from Mautic, Vitess, and Helm, plus optional Promptless setup for participants.
+slug: docs/getting-started/wtd-oss
+sidebar:
+  hidden: false
+  order: 6
+---
+import Tip from '@components/fern/Tip.astro';
+import Info from '@components/fern/Info.astro';
+import Success from '@components/fern/Success.astro';
+import Note from '@components/fern/Note.astro';
+
+The goal of Writing Day is simple: leave Portland with a real contribution to a well-known open-source project. We've worked with maintainers from Mautic, Vitess, and Helm ahead of time so you can pick up a labeled "good first issue" and ship a PR before the day is over.
+
+Bring a laptop, pick an issue, ship a PR.
+
+<Tip>
+You don't need any prior experience with these projects to contribute. The maintainers have specifically labeled issues that are friendly to first-time contributors.
+</Tip>
+
+## The Projects
+
+Each maintainer has a slightly different ask. Skim the one-liners and the maintainer notes below to find a project that fits before you dive in.
+
+### Mautic
+
+**Mautic** is an open-source marketing automation platform — campaigns, email, contact management, and segmentation.
+
+- **Good first issues:** [`mautic/developer-documentation-new`](https://github.com/mautic/developer-documentation-new/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22)
+- **Contact:** Ayu Adiati (Mautic docs maintainer)
+
+Ayu's note for participants:
+
+> The user docs so far is a bit behind with UI screenshots. Most of them are still for version before 5.2. The most important docs to update is version 7.0 and 7.1 (they have the same UI), then 6.0 and 5.2 as some folks are still using these versions as well.
+>
+> I was focusing in building the guidelines for contributing, so it takes me some time to update them myself bit by bit.
+>
+> In my own experience, I sometimes found missing instructions or any other features that need to be added and updated while updating the screenshots.
+>
+> Dev docs is the one that definitely need some love. Folks has been asking for clarity as the contents are outdated. [...]
+
+### Vitess
+
+**Vitess** is a distributed, sharded MySQL — the database technology behind YouTube, Slack, and other large-scale products that have outgrown a single MySQL instance.
+
+- **Good first issues:** [`vitessio/website`](https://github.com/vitessio/website/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22%20label%3Adocumentation)
+- **Contact:** Matt Lord (Vitess maintainer)
+
+Matt is also open to broader information-architecture work, not just fixes to individual pages. From his note:
+
+> Honestly, stepping back would probably be more helpful.
+>
+> What the website -> docs experience is like for a newcomer and how it could be improved.
+>
+> Where to start, how to find things, etc. Organization more than content.
+
+If you spot an IA issue while exploring, open a new issue describing what you found. The Vitess team is happy to take PRs for anything.
+
+### Helm
+
+**Helm** is the package manager for Kubernetes — the standard way to install, upgrade, and manage applications on a Kubernetes cluster.
+
+- **Good first issues:** [`helm/helm-www`](https://github.com/helm/helm-www/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22)
+
+Helm currently has six open docs issues labeled as good first issues, including one from 2021 that's been waiting a long time for someone to claim it.
+
+<Note>
+We're still adding more projects as docs maintainers get back to us. Check back during the event for the latest list.
+</Note>
+
+## How to Contribute
+
+Pick an issue from one of the projects above, comment to claim it, fork the repo, and open a PR from your fork against the upstream project. Each project has its own contribution guide — read it before you open your PR so you're following the conventions maintainers expect.
+
+### Optional: Use Promptless to Accelerate
+
+<Success title="Free Promptless Access for Writing Day" icon="fa-solid fa-heart">
+We're giving Writing Day participants free access to Promptless for the duration of the event. Use of Promptless is **completely optional** — if you'd rather work in your editor, that's a great way to ship a PR too.
+</Success>
+
+Promptless is the AI agent we build for technical writers. If you'd like to try it on your contribution, Promptless can read the upstream repo and the issue you're working on, draft an update, and open the PR for you.
+
+If you do use Promptless, set up a GitHub classic personal access token (PAT) before you start. The PAT lets Promptless open the PR from **your** GitHub account, so the contribution is credited to you and not to a bot.
+
+#### Create a GitHub classic personal access token
+
+1. Sign in to GitHub and open [github.com/settings/tokens](https://github.com/settings/tokens).
+2. Click **Generate new token** and choose **Generate new token (classic)**.
+3. Give the token a recognizable name — something like `Promptless – Writing Day 2026` works well.
+4. Set an expiration. We recommend a date shortly after the event so the token stays short-lived.
+5. Select the scopes you need:
+
+   - **`public_repo`** — required. Lets Promptless push branches and open PRs against public repositories on your behalf. (If you also plan to contribute to private repositories, select the parent **`repo`** scope instead.)
+   - **`workflow`** — required if any of the issues you might pick involve changes under `.github/workflows/`. Most docs-only contributions don't need this, but selecting it up front means you won't have to regenerate the token mid-PR if a workflow file does end up changing.
+
+6. Click **Generate token**, then copy the token. GitHub only shows it once.
+7. Paste the token into Promptless when it asks for your GitHub credentials during onboarding for the event.
+
+<Info>
+For the official GitHub guidance, see [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) and [Scopes for OAuth apps](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps).
+</Info>
+
+## Help During the Event
+
+If you get stuck on tooling, the scope of an issue, or how to use Promptless during the event, find someone from the Promptless team — we're at Writing Day to help. For broader Promptless support, see [Getting Support](/docs/getting-started/getting-help).

--- a/src/content/docs/docs/getting-started/wtd-oss.mdx
+++ b/src/content/docs/docs/getting-started/wtd-oss.mdx
@@ -31,7 +31,6 @@ Each maintainer has a slightly different ask. Skim the one-liners and the mainta
 **Mautic** is an open-source marketing automation platform — campaigns, email, contact management, and segmentation.
 
 - **Good first issues:** [`mautic/developer-documentation-new`](https://github.com/mautic/developer-documentation-new/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22)
-- **Contact:** Ayu Adiati (Mautic docs maintainer)
 
 Ayu's note for participants:
 
@@ -48,7 +47,6 @@ Ayu's note for participants:
 **Vitess** is a distributed, sharded MySQL — the database technology behind YouTube, Slack, and other large-scale products that have outgrown a single MySQL instance.
 
 - **Good first issues:** [`vitessio/website`](https://github.com/vitessio/website/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22%20label%3Adocumentation)
-- **Contact:** Matt Lord (Vitess maintainer)
 
 Matt is also open to broader information-architecture work, not just fixes to individual pages. From his note:
 
@@ -68,9 +66,6 @@ If you spot an IA issue while exploring, open a new issue describing what you fo
 
 Helm currently has six open docs issues labeled as good first issues, including one from 2021 that's been waiting a long time for someone to claim it.
 
-<Note>
-We're still adding more projects as docs maintainers get back to us. Check back during the event for the latest list.
-</Note>
 
 ## How to Contribute
 
@@ -79,26 +74,26 @@ Pick an issue from one of the projects above, comment to claim it, fork the repo
 ### Optional: Use Promptless to Accelerate
 
 <Success title="Free Promptless Access for Writing Day" icon="fa-solid fa-heart">
-We're giving Writing Day participants free access to Promptless for the duration of the event. Use of Promptless is **completely optional** — if you'd rather work in your editor, that's a great way to ship a PR too.
+We're giving Writing Day participants free access to Promptless for the duration of the event. Use of Promptless is **completely optional**—if you want to work in your own editor, or using Claude Code, Codex, or another agent, that's a great way to contribute to open-source too.
 </Success>
 
 Promptless is the AI agent we build for technical writers. If you'd like to try it on your contribution, Promptless can read the upstream repo and the issue you're working on, draft an update, and open the PR for you.
 
-If you do use Promptless, set up a GitHub classic personal access token (PAT) before you start. The PAT lets Promptless open the PR from **your** GitHub account, so the contribution is credited to you and not to a bot.
+If you do use Promptless, you can set up a GitHub classic personal access token (PAT) before you start. The PAT lets Promptless open the PR from **your** GitHub account, rather than Promptless's bot, so the contribution is credited to you and not to a bot.
 
 #### Create a GitHub classic personal access token
 
 1. Sign in to GitHub and open [github.com/settings/tokens](https://github.com/settings/tokens).
 2. Click **Generate new token** and choose **Generate new token (classic)**.
-3. Give the token a recognizable name — something like `Promptless – Writing Day 2026` works well.
-4. Set an expiration. We recommend a date shortly after the event so the token stays short-lived.
+3. Give the token a recognizable name — something like `writing day`.
+4. Set an expiration. We recommend 1 day or 7 days so the token stays short-lived.
 5. Select the scopes you need:
 
    - **`public_repo`** — required. Lets Promptless push branches and open PRs against public repositories on your behalf. (If you also plan to contribute to private repositories, select the parent **`repo`** scope instead.)
    - **`workflow`** — required if any of the issues you might pick involve changes under `.github/workflows/`. Most docs-only contributions don't need this, but selecting it up front means you won't have to regenerate the token mid-PR if a workflow file does end up changing.
 
 6. Click **Generate token**, then copy the token. GitHub only shows it once.
-7. Paste the token into Promptless when it asks for your GitHub credentials during onboarding for the event.
+7. Paste the token into Promptless when opening your first PR from Promptless!
 
 <Info>
 For the official GitHub guidance, see [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) and [Scopes for OAuth apps](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps).
@@ -106,8 +101,5 @@ For the official GitHub guidance, see [Managing your personal access tokens](htt
 
 ## Help During the Event
 
-If you get stuck on tooling, the scope of an issue, or how to use Promptless during the event, find someone from the Promptless team — we're at Writing Day to help. For broader Promptless support, see [Getting Support](/docs/getting-started/getting-help).
-
-See you in Portland — drop into the Slack channel so we can coordinate on the day, swap notes, and celebrate merged PRs.
 
 <WtdSlackJoinButton />

--- a/src/content/docs/docs/getting-started/wtd-oss.mdx
+++ b/src/content/docs/docs/getting-started/wtd-oss.mdx
@@ -12,10 +12,13 @@ import Tip from '@components/fern/Tip.astro';
 import Info from '@components/fern/Info.astro';
 import Success from '@components/fern/Success.astro';
 import Note from '@components/fern/Note.astro';
+import WtdSlackJoinButton from '@components/site/WtdSlackJoinButton.astro';
 
 The goal of Writing Day is simple: leave Portland with a real contribution to a well-known open-source project. We've worked with maintainers from Mautic, Vitess, and Helm ahead of time so you can pick up a labeled "good first issue" and ship a PR before the day is over.
 
 Bring a laptop, pick an issue, ship a PR.
+
+<WtdSlackJoinButton />
 
 <Tip>
 You don't need any prior experience with these projects to contribute. The maintainers have specifically labeled issues that are friendly to first-time contributors.
@@ -106,3 +109,7 @@ For the official GitHub guidance, see [Managing your personal access tokens](htt
 ## Help During the Event
 
 If you get stuck on tooling, the scope of an issue, or how to use Promptless during the event, find someone from the Promptless team — we're at Writing Day to help. For broader Promptless support, see [Getting Support](/docs/getting-started/getting-help).
+
+See you in Portland — drop into the Slack channel so we can coordinate on the day, swap notes, and celebrate merged PRs.
+
+<WtdSlackJoinButton />

--- a/src/content/docs/docs/getting-started/wtd-oss.mdx
+++ b/src/content/docs/docs/getting-started/wtd-oss.mdx
@@ -18,8 +18,6 @@ The goal of Writing Day is simple: leave Portland with a real contribution to a 
 
 Bring a laptop, pick an issue, ship a PR.
 
-<WtdSlackJoinButton />
-
 <Tip>
 You don't need any prior experience with these projects to contribute. The maintainers have specifically labeled issues that are friendly to first-time contributors.
 </Tip>

--- a/src/lib/generated/sidebar.json
+++ b/src/lib/generated/sidebar.json
@@ -23,6 +23,10 @@
         "slug": "docs/getting-started/promptless-oss"
       },
       {
+        "label": "Writing Day at WTD Portland 2026",
+        "slug": "docs/getting-started/wtd-oss"
+      },
+      {
         "label": "Getting Support",
         "slug": "docs/getting-started/getting-help"
       }

--- a/vercel.json
+++ b/vercel.json
@@ -102,6 +102,11 @@
       "permanent": true
     },
     {
+      "source": "/wtd-oss",
+      "destination": "/docs/getting-started/wtd-oss",
+      "permanent": true
+    },
+    {
       "source": "/hn",
       "destination": "/",
       "permanent": true


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/a758861b-b576-4990-8901-13db4482e1ff)

Adds a new docs page at `/docs/getting-started/wtd-oss` that reorganizes the existing Writing Day blog post into a docs-style overview: project one-liners (Mautic, Vitess, Helm), pre-vetted "good first issue" links, maintainer notes (Ayu/Mautic, Matt Lord/Vitess), and a new "How to Contribute" section with optional Promptless setup and step-by-step instructions for creating a GitHub classic PAT (`public_repo` + `workflow` scopes) so participant PRs are credited to their accounts. Also wires up the `/wtd-oss` short link in both `astro.config.mjs` and `vercel.json`. Left the existing blog post in place for human decision on delete vs. redirect.

**Trigger Events**
- [Slack mention: <@U0B148CFR89> can you help update our docs to have an overview of the set-up for writing day? start with <https://promptless.ai/blog/life-at-promptless/wtd-writing-day|this>, but move it to the docs section rather than blogs

some main talking points:
• we've talked to a few open-source projects th](https://Writing Day 2026.slack.com/archives/C0B09SGLS07/p1777818360691079)

---

_Tip: Add or adjust Promptless's style guide in [Agent Knowledge Base](https://app.gopromptless.ai/configure/settings) ✍️_