### PR TITLE
content: Documentation Coverage: The Metric Your Engineering Team Has Never Checked

### DIFF
--- a/src/content/blog/technical/documentation-coverage.mdx
+++ b/src/content/blog/technical/documentation-coverage.mdx
@@ -18,13 +18,13 @@ Your documentation has no equivalent.
 
 There is no automated report telling you which API endpoints lack reference docs, which SDK methods have no examples, or which product features have never been explained to a developer. If 30 percent of your product surface is undocumented, nothing catches it.
 
-This is the documentation coverage problem: a systematic gap between what your product does and what your docs describe, with no mechanism to detect it.
+The documentation coverage problem is the systematic gap between what your product does and what your docs describe, with no mechanism to detect it.
 
 ## Coverage Is Not the Same as Quality
 
 Most teams treat documentation problems as quality problems. A page is outdated, an example is wrong, a parameter is misdescribed. These are worth fixing. But they require that the page exists at all.
 
-Documentation coverage asks a prior question: does content exist for this part of the product?
+Documentation coverage asks whether content exists for this part of the product at all.
 
 Coverage and quality are distinct failure modes:
 
@@ -43,7 +43,7 @@ The test coverage analogy is obvious once you hear it. Engineering teams have ac
 
 The tooling gap explains part of this. Test runners produce coverage reports as a side effect of running tests. Documentation has no equivalent runtime artifact. There is no CI step that compares your OpenAPI spec to your docs site and outputs a percentage.
 
-The ownership gap explains the rest. Test coverage lives in engineering. Documentation coverage spans multiple teams: developers write inline comments and READMEs, technical writers own the docs site, and DevRel manages tutorials and guides. Nobody has a complete inventory of what is documented, so nobody notices the gaps between all three.
+The ownership gap explains the rest. Documentation coverage spans multiple teams, with developers writing inline comments and READMEs, technical writers owning the docs site, and DevRel managing tutorials and guides. Nobody has a complete inventory of what is documented, so nobody notices the gaps between all three.
 
 The result is that most teams discover documentation coverage gaps reactively. A developer opens a support ticket asking how to use a feature that was never documented. The question surfaces in a Slack channel. A post appears on a forum. By then, the gap has already caused friction for at least one person and probably for many more who silently gave up.
 
@@ -69,23 +69,23 @@ A B2B technology company that analyzed its docs search logs found that 23 percen
 
 Zero-result searches do not show you everything that is undocumented. They only surface the gaps developers actively searched for. But they are actionable immediately and require no additional tooling if your docs platform has built-in search analytics. GitBook, Fern, Document360, and ReadMe all surface this data in their default dashboards. If you are not looking at it, you are leaving a direct signal unused.
 
-For a deeper look at how to use search analytics alongside other documentation metrics, [Documentation Metrics and Analytics: A Complete Guide](/blog/technical/documentation-metrics-and-analytics-a-complete-guide-for-dev) covers the full measurement stack.
+For a deeper look at how to use search analytics alongside other documentation metrics, the [complete documentation metrics and analytics guide](/blog/technical/documentation-metrics-and-analytics-a-complete-guide-for-dev) covers the full measurement stack.
 
 ### Map support tickets to documentation status
 
 Support tickets are lagging indicators of coverage gaps. When a developer opens a ticket asking how to accomplish something your product supports, there is a reasonable chance it was never documented, or was documented incompletely.
 
-A lightweight tagging process on incoming support tickets (documented, undocumented, or documented but unclear) builds a coverage gap queue sorted by customer impact. HappyFox enterprise data suggests that up to 80 percent of support tickets address issues already present in existing knowledge bases, pointing to a findability problem. The remaining 20 percent often represents genuine coverage gaps: features that exist but were never written up.
+Tagging each incoming support ticket as documented, undocumented, or documented-but-unclear builds a coverage gap queue sorted by customer impact. HappyFox enterprise data suggests that up to 80 percent of support tickets address issues already present in existing knowledge bases, pointing to a findability problem. The remaining 20 percent often represents genuine coverage gaps, meaning features that exist but were never written up.
 
 ## Making Coverage a First-Class Quality Gate
 
 Most teams ship features and write documentation afterward, sometimes weeks later, sometimes never. This is the default because documentation is rarely in the definition of done.
 
-The most direct fix is structural: documentation is required before a feature ships. A feature is not complete until it has at least a basic reference page. This prevents gaps from accumulating in the first place. For API products in particular, this maps cleanly to existing engineering practices: the endpoint exists in the spec when it ships; a corresponding page should exist in the docs.
+The most direct fix is structural. Documentation is required before a feature ships, and a feature is not complete until it has at least a basic reference page. This prevents gaps from accumulating in the first place. For API products in particular, this maps cleanly to existing engineering practices. If an endpoint exists in the spec when it ships, a corresponding page should exist in the docs.
 
-For existing gaps, a coverage audit provides the prioritized backlog. Start with the endpoints or features generating the most support tickets or zero-result searches. Work down from there. [Documentation debt](/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it) compounds when gaps go unaddressed; a coverage backlog gives you a queue to clear rather than an invisible accumulation to ignore.
+For existing gaps, a coverage audit provides the prioritized backlog. Start with the endpoints or features generating the most support tickets or zero-result searches. Work down from there. [Documentation debt](/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it) compounds when gaps go unaddressed; a coverage backlog replaces invisible accumulation with a queue you can clear.
 
-If your documentation is generated from structured sources like OpenAPI specs or code comments, automating coverage checks is straightforward: compare the spec to rendered documentation on each build and flag new endpoints that have no corresponding page.
+If your documentation is generated from structured sources like OpenAPI specs or code comments, you can automate coverage checks by comparing the spec to rendered documentation on each build and flagging new endpoints that have no corresponding page.
 
 If your documentation is not generated from structured sources, a quarterly audit against your product changelog is a reasonable substitute. Reviewing every feature shipped in the past quarter against your docs index takes an afternoon and surfaces gaps before they become support costs.
 

--- a/src/content/blog/technical/documentation-coverage.mdx
+++ b/src/content/blog/technical/documentation-coverage.mdx
@@ -1,0 +1,94 @@
+---
+title: 'Documentation Coverage: The Metric Your Engineering Team Has Never Checked'
+subtitle: Published May 2026
+description: >-
+  Your engineering team tracks test coverage. Almost no one tracks documentation coverage. Here's how to measure whether your product surface is actually documented.
+date: '2026-05-06T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Your engineering team gets a coverage report every time tests run. It tells you exactly which functions have no test coverage and which branches are never exercised. If coverage drops below a threshold, your CI pipeline can fail the build.
+
+Your documentation has no equivalent.
+
+There is no automated report telling you which API endpoints lack reference docs, which SDK methods have no examples, or which product features have never been explained to a developer. If 30 percent of your product surface is undocumented, nothing catches it.
+
+This is the documentation coverage problem: a systematic gap between what your product does and what your docs describe, with no mechanism to detect it.
+
+## Coverage Is Not the Same as Quality
+
+Most teams treat documentation problems as quality problems. A page is outdated, an example is wrong, a parameter is misdescribed. These are worth fixing. But they require that the page exists at all.
+
+Documentation coverage asks a prior question: does content exist for this part of the product?
+
+Coverage and quality are distinct failure modes:
+
+- A coverage gap means developers hit a dead end. They go to your docs looking for information about a feature and find nothing. No page to read. No example to adapt.
+- A quality gap means developers find a page that misleads them. The information exists but is wrong or incomplete.
+
+Both are harmful. Coverage gaps are the more invisible of the two because there is nothing to flag. A developer who finds a wrong page files a support ticket or leaves a feedback comment. A developer who finds nothing assumes the feature does not exist, gives up, or opens a support ticket asking whether something is possible. The only real problem is that nobody documented it.
+
+Coverage also has dimensions. **Breadth** measures what percentage of your public API surface, SDK methods, or product features have at least one documentation page. **Depth** measures whether the documentation that exists is complete enough to be useful. **Freshness** measures whether documented features still reflect how the product actually works. That problem is covered in detail in [Documentation Drift Is a Detection Problem, Not a Writing Problem](/blog/technical/documentation-drift-detection-problem).
+
+If you are starting from zero, start with breadth. You cannot improve depth or freshness for content that does not exist.
+
+## Why Teams Don't Track Coverage
+
+The test coverage analogy is obvious once you hear it. Engineering teams have accepted for decades that untested code is a liability, so they automate coverage measurement as a consequence. Documentation has the same liability structure but almost nobody applies the same rigor.
+
+The tooling gap explains part of this. Test runners produce coverage reports as a side effect of running tests. Documentation has no equivalent runtime artifact. There is no CI step that compares your OpenAPI spec to your docs site and outputs a percentage.
+
+The ownership gap explains the rest. Test coverage lives in engineering. Documentation coverage spans multiple teams: developers write inline comments and READMEs, technical writers own the docs site, and DevRel manages tutorials and guides. Nobody has a complete inventory of what is documented, so nobody notices the gaps between all three.
+
+The result is that most teams discover documentation coverage gaps reactively. A developer opens a support ticket asking how to use a feature that was never documented. The question surfaces in a Slack channel. A post appears on a forum. By then, the gap has already caused friction for at least one person and probably for many more who silently gave up.
+
+Research from GetDX estimates that documentation problems consume 15 to 25 percent of engineering capacity. That cost includes time developers spend searching for information and interrupting colleagues for answers. A significant share of that cost comes from features that shipped without documentation.
+
+<BlogNewsletterCTA />
+
+## How to Measure Documentation Coverage
+
+You do not need specialized tooling to get a first approximation. You need an inventory.
+
+### Compare your API spec to your docs site
+
+If you have an OpenAPI spec, you have a structured inventory of every endpoint, method, parameter, and response your API exposes. Compare that inventory against your documentation site. Count how many endpoints have a corresponding reference page. Count how many are absent.
+
+Tools like Fern, Speakeasy, and Theneo can automate this comparison when your docs are generated from or linked to your spec. If they are not, a manual audit of your spec against your docs index still produces a defensible coverage percentage in a few hours. The number you get may be uncomfortable, but it is more useful than not knowing.
+
+### Treat zero-result searches as a coverage signal
+
+Your documentation search logs are a direct window into gaps. When developers search for something and get no results, they are telling you what they were looking for that does not exist in your docs.
+
+A B2B technology company that analyzed its docs search logs found that 23 percent of all queries returned zero results. After a systematic content effort targeting the most common missing topics, that rate dropped to 6 percent and support escalation rates declined by 18 percent.
+
+Zero-result searches do not show you everything that is undocumented. They only surface the gaps developers actively searched for. But they are actionable immediately and require no additional tooling if your docs platform has built-in search analytics. GitBook, Fern, Document360, and ReadMe all surface this data in their default dashboards. If you are not looking at it, you are leaving a direct signal unused.
+
+For a deeper look at how to use search analytics alongside other documentation metrics, [Documentation Metrics and Analytics: A Complete Guide](/blog/technical/documentation-metrics-and-analytics-a-complete-guide-for-dev) covers the full measurement stack.
+
+### Map support tickets to documentation status
+
+Support tickets are lagging indicators of coverage gaps. When a developer opens a ticket asking how to accomplish something your product supports, there is a reasonable chance it was never documented, or was documented incompletely.
+
+A lightweight tagging process on incoming support tickets (documented, undocumented, or documented but unclear) builds a coverage gap queue sorted by customer impact. HappyFox enterprise data suggests that up to 80 percent of support tickets address issues already present in existing knowledge bases, pointing to a findability problem. The remaining 20 percent often represents genuine coverage gaps: features that exist but were never written up.
+
+## Making Coverage a First-Class Quality Gate
+
+Most teams ship features and write documentation afterward, sometimes weeks later, sometimes never. This is the default because documentation is rarely in the definition of done.
+
+The most direct fix is structural: documentation is required before a feature ships. A feature is not complete until it has at least a basic reference page. This prevents gaps from accumulating in the first place. For API products in particular, this maps cleanly to existing engineering practices: the endpoint exists in the spec when it ships; a corresponding page should exist in the docs.
+
+For existing gaps, a coverage audit provides the prioritized backlog. Start with the endpoints or features generating the most support tickets or zero-result searches. Work down from there. [Documentation debt](/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it) compounds when gaps go unaddressed; a coverage backlog gives you a queue to clear rather than an invisible accumulation to ignore.
+
+If your documentation is generated from structured sources like OpenAPI specs or code comments, automating coverage checks is straightforward: compare the spec to rendered documentation on each build and flag new endpoints that have no corresponding page.
+
+If your documentation is not generated from structured sources, a quarterly audit against your product changelog is a reasonable substitute. Reviewing every feature shipped in the past quarter against your docs index takes an afternoon and surfaces gaps before they become support costs.
+
+The goal is not a perfect score. It is knowing your current coverage, tracking it over time, and having a process that prevents the number from eroding as your product grows.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `documentation coverage`

## Article plan

**Keyword targeted:** `documentation coverage`

**Key ideas:**
1. The test coverage analogy: teams get automated coverage reports for code but have no equivalent for docs — so gaps accumulate silently
2. Coverage (does content exist?) is a distinct failure mode from quality (is content accurate?) and drift (is content current?) — most teams only notice the latter two

**Format:** Practical diagnostic article — teaches readers to apply the test coverage lens to documentation, with three concrete measurement approaches

**Thesis:** Most developer-facing teams have no idea what percentage of their product surface is actually documented, and measuring that gap is the prerequisite to fixing it.

**Target reader:** Engineering managers, developer advocates, and technical writers at developer-facing companies who understand test coverage but have never applied that thinking to documentation

**Promptless connection:** Promptless automatically detects gaps between product surface and documentation state — the core documentation coverage problem

## File

`src/content/blog/technical/documentation-coverage.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZUyZ7nFWpzsjp2RxZhQtV)_