### PR TITLE
content: API Documentation Automation: Why Generation Is Only Half the Problem

### DIFF
--- a/src/content/blog/technical/api-documentation-automation.mdx
+++ b/src/content/blog/technical/api-documentation-automation.mdx
@@ -1,0 +1,75 @@
+---
+title: 'API Documentation Automation: Why Generation Is Only Half the Problem'
+subtitle: Published May 2026
+description: >-
+  74% of API teams use OpenAPI for automated doc generation. 55% still report inconsistent docs. Here's why generation automation alone isn't enough.
+date: '2026-05-18T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A product team ships a new required parameter to their authentication endpoint. The OpenAPI spec gets updated. The documentation platform renders the new reference page automatically. Deployment happens on Friday.
+
+On Monday, a developer opens the API quickstart guide (the one with the five-step tutorial and the annotated code samples). That page wasn't generated from the spec. It was written by a technical writer eight months ago. The required parameter isn't mentioned anywhere in it.
+
+The automation worked exactly as designed. The drift happened anyway.
+
+## The generation problem is already solved
+
+74% of companies now use the OpenAPI Specification to describe their APIs, according to the [2025 State of Docs report](https://www.stateofdocs.com/2025/documentation-tooling-and-api-docs). Tools like Redocly, Fern, and SwaggerUI can take a valid spec and render interactive, searchable reference documentation automatically. New endpoint? Add it to the spec and the docs update on the next build. Parameter renamed? The reference page reflects it without anyone touching the docs folder.
+
+This is real automation, and it works. The generation problem (producing accurate reference documentation from a machine-readable spec) has been largely solved for teams that keep an accurate spec.
+
+So why does more than half of all API teams still report inconsistent documentation as a significant problem? Same year, same industry. Generation is widespread. The maintenance problem persists.
+
+## Where automation stops
+
+API reference documentation is one category of API documentation. It covers endpoints, parameters, response schemas, and status codes. It's also the category most likely to be generated from a spec.
+
+The documentation developers actually struggle with includes tutorials, quickstart guides, error handling docs, authentication walkthroughs, and SDK usage examples. These don't auto-generate from a spec. They're written by technical writers and updated manually, which means they update only when someone notices the mismatch and writes the fix.
+
+A team shipping weekly averages 4 to 8 user-facing changes per week, with each change affecting 2 to 5 documentation articles. That's 8 to 40 articles per week that might need updates. The spec-generated reference page updates automatically. The tutorial with the inline code sample, the error code reference, the SDK guide for a parameter that just got renamed: none of those do.
+
+The 2025 State of Docs report found that keeping documentation up to date is the top challenge for more than half of all documentation teams. That's not a problem you can generate your way out of.
+
+## The spec itself goes stale
+
+Even for teams fully committed to spec-driven docs, there's a subtler problem: the OpenAPI spec diverges from what the API actually does.
+
+75% of APIs don't conform to their own specifications, according to a [recent analysis of production API behavior](https://zivodoc.com/blog/api-documentation-drift-prevention/). Specs describe the intended API. The actual API is what the code does at runtime. In fast-moving teams, new response fields appear in the payload before the spec is updated. Deprecated parameters stay in the spec long after they've been removed. Error codes shift between versions.
+
+When generation tools build from a stale spec, they produce accurate-looking documentation that describes the wrong behavior. The docs update on every build. They just build from the wrong source.
+
+This is part of why 68% of developers cite outdated documentation as their top frustration when working with APIs, according to the [Postman 2024 State of the API report](https://www.postman.com/state-of-api/2024), even at companies with established, automated documentation pipelines.
+
+<BlogNewsletterCTA />
+
+## What maintenance automation actually requires
+
+The generation phase is a build-time problem: given a spec, produce a rendered output. It's well-suited to automation because the inputs are structured and the transformation is deterministic.
+
+The maintenance phase is a detection problem: given that code changed, figure out which docs are affected and surface them before a developer hits the stale page. This requires watching for changes upstream (in pull requests, deployment logs, and release notes) and cross-referencing those signals against current documentation.
+
+[Docs-as-code workflows](https://promptless.ai/blog/technical/help-center-to-docs-as-code) help at the margins. Requiring doc updates in the same PR as API changes creates the right habit when someone remembers to check. But it depends on the developer knowing which docs need updating, and on the documentation owner being in the loop for the right PRs.
+
+The deeper gap is that documentation pipelines typically have no real-time visibility into what changed in the product. A technical writer finds out about API changes by watching Slack, scanning PR descriptions, or waiting for a support ticket that turns out to trace back to a stale doc. That's surveillance work. It doesn't scale, and it doesn't catch what slips through.
+
+## Closing the loop
+
+The second phase of API documentation automation connects your CI/CD pipeline to a documentation freshness signal. When an API endpoint changes, the system surfaces which docs reference that endpoint for review. Not after a quarterly audit. Immediately, before the next developer reads the stale page.
+
+For teams that have built this loop, the maintenance problem changes shape. Instead of triaging a growing backlog of potentially-wrong docs, writers work from a queue of known mismatches, each one flagged at the moment the product changed. The detection problem gets solved, and that's where most of the delay actually lives.
+
+The [API changelog](https://promptless.ai/blog/technical/api-changelog-best-practices) and [documentation drift](https://promptless.ai/blog/technical/documentation-drift-detection-problem) problems are both downstream of this. If you know what changed in the product, you can write the changelog entry that communicates it and update the reference page that reflects it. Detection is the prerequisite.
+
+## How Promptless fits in
+
+Promptless is built for the maintenance layer. It continuously monitors your documentation against your actual product and codebase, detecting when API behavior has diverged from what the docs describe. When a PR ships a change that affects a tutorial or guide, Promptless surfaces the affected pages before the next developer reads them.
+
+The generation step is already handled by your existing tooling. Promptless closes the loop on everything that generation doesn't reach: tutorials, quickstart guides, SDK examples, and the spec itself when it drifts out of sync with what the API actually does.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `API documentation automation`

## Article plan

**Thesis:** Most teams have already automated API doc generation. The unsolved problem is automating maintenance — detecting when API behavior has diverged from docs after the initial generation.

**Target reader:** Technical writers and DevRel engineers at API-first companies who already have spec-generated docs and are still dealing with drift. EMs wondering why their "automated" docs keep going stale.

**Key points:**
1. OpenAPI-driven generation is solved and widely deployed (74% of companies use it)
2. 55% still report inconsistent docs — because generation is a one-time build step, not continuous maintenance
3. Prose docs (tutorials, guides, SDK examples) don't auto-generate and are the highest-drift surface
4. Even spec-generated docs go wrong when the spec drifts from production API behavior (75% of APIs don't conform to their own specs)
5. The second phase of automation is detection: watching for upstream changes and surfacing affected docs immediately

**Promptless connection:** Promptless is the maintenance layer — continuously monitoring docs against actual product/code, surfacing drift at the moment a change ships.

**Internal links:** docs-as-code workflow, API changelog best practices, documentation drift detection problem

## File

`src/content/blog/technical/api-documentation-automation.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4U8u7nDcjZ3WmJRt1J1rr)_