### PR TITLE
content: Developer Relations Documentation: The Maintenance Gap Engineering Teams Create

### DIFF
--- a/src/content/blog/technical/developer-relations-documentation-maintenance-gap.mdx
+++ b/src/content/blog/technical/developer-relations-documentation-maintenance-gap.mdx
@@ -1,0 +1,73 @@
+---
+title: 'Developer Relations Documentation: The Maintenance Gap Engineering Teams Create'
+subtitle: Published May 2026
+description: >-
+  DevRel teams own the docs that drive developer adoption. But the code those docs depend on lives in engineering. Here's why that gap creates silent drift, and what it takes to close it.
+date: '2026-05-20T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer reads your quickstart, runs the code sample, and gets a 401 error. The endpoint exists. Their API key is valid. But the authentication flow changed three sprints ago, and nobody updated the tutorial.
+
+This keeps happening to developer relations teams, and the cause is structural. The people who write the tutorials are not the people who ship the code those tutorials depend on.
+
+## Why DevRel docs break silently
+
+Developer relations teams own the documentation that matters most for adoption: quickstarts, integration tutorials, SDK walkthroughs, and code samples. These pages determine whether an external developer can go from "heard about your API" to "successfully integrated" in a reasonable amount of time.
+
+These pages are also the most code-dependent content on your docs site. A quickstart doesn't just describe the API in abstract terms. It shows a developer exactly how to authenticate, which endpoint to call, what parameters to pass, and how to handle the response. Every step depends on current product behavior.
+
+Rename a parameter and the quickstart breaks. The page doesn't throw an error. It still reads clearly. It just describes something that no longer works, and developers trust it because it's on your official docs site.
+
+Engineers make these changes continuously because that's shipping. A renamed parameter is a normal sprint task. The developer advocate who wrote the tutorial three months ago wasn't in that sprint.
+
+## The ownership gap
+
+The structural problem: the people who make breaking changes are not the people who own the content those changes affect.
+
+Engineers who update an API endpoint are focused on the task in their sprint. Checking which tutorial pages reference the changed parameter is outside their scope. That's not a failure of diligence. It's just not what they were asked to do.
+
+Developer relations teams own the tutorials but don't have visibility into engineering's pull requests. They're not in the standups where API changes get discussed. The handoff ("let DevRel know this tutorial needs updating") happens informally, or not at all.
+
+A survey of API teams found that [55% struggle with inconsistent documentation](https://www.postman.com/state-of-api/2025/), and a 2025 State of Docs report identified keeping documentation current as the top challenge for more than half of all documentation teams. Those numbers describe the predictable outcome of two teams sharing responsibility for the same content with no systematic coordination between them.
+
+## When DevRel teams find out
+
+Most developer relations teams learn about broken content through the same lagging signals. A developer reports an error in the community forum. A support ticket arrives with a screenshot of the failed API call.
+
+By the time a support ticket references a broken tutorial, the outdated content has been live for days or weeks. The developers who hit the error and didn't file a ticket moved on, or concluded the product wasn't worth the friction.
+
+Research from TSIA on support deflection found that 40–60% of support tickets can be resolved through documentation. Stale docs deflect nothing. A developer who follows an outdated tutorial, fails, and then files a support ticket is more frustrated than a developer who simply filed a ticket without trying the docs first. The tutorial added a step to the failure.
+
+<BlogNewsletterCTA />
+
+The trust cost compounds. According to Postman research, 68% of developers cite outdated documentation as their top frustration when working with APIs. That's not frustration with missing docs. It's frustration with docs that looked credible and turned out to be wrong. Recovering that trust takes consistent accuracy over time, not a documentation sprint.
+
+## What detection actually requires
+
+The standard response to this problem is a writing process change: quarterly audits, a docs-update field in the PR template, doc sprints tied to releases. These help at the margins.
+
+A PR template that asks "did you update the relevant docs?" only works if the engineer knows which docs are affected. For an API change, the honest answer is often "I don't know." Not because engineers don't care, but because knowing which of forty tutorial pages references a specific parameter requires attention that nobody was asked to provide.
+
+A quarterly audit catches drift that has already been live long enough to make the calendar. If your authentication flow changed in February and the audit runs in April, developers spent two months hitting a broken tutorial. (The pattern is discussed in more depth in our post on [why onboarding documentation breaks after launch](/blog/technical/developer-onboarding-documentation-fails-after-launch).)
+
+The fix is a detection layer: a way for developer relations teams to know, in time, when an engineering change affects the content they own.
+
+This means connecting two pieces of information: what changed in the product code and which DevRel content depends on that behavior. When a PR modifies an authentication method, a detection system surfaces the specific quickstarts, tutorials, and code samples that reference that method. The DevRel team gets a targeted, actionable flag before a developer encounters the broken content.
+
+This inverts the burden. Instead of asking engineers to identify documentation impact (which they can't reliably do), the system watches for changes in engineering and matches them to content dependencies automatically. The DevRel team reviews a queue of flagged content rather than scanning the entire docs site looking for what might have changed.
+
+## The diagnostic question
+
+If your team is a developer relations team, the writing work is probably already done well. The gap is in detection. Here's a useful diagnostic: when an API team ships a breaking change today, how long before that change becomes a task on your radar as a documentation update?
+
+If the answer is "when a developer reports the broken tutorial in our community Slack," the detection layer is missing. The writing quality wasn't the bottleneck. The signal was.
+
+Connecting developer relations documentation to the engineering changes that affect it is infrastructure work. It's the difference between a tutorial that works and a tutorial that works until it quietly doesn't.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer relations docs`

## Article plan

**Thesis:** DevRel teams own the docs that matter most for adoption, and they're the last to know when engineering breaks them.

**Target reader:** Developer advocates, DevRel engineers, and DevRel managers at SaaS companies with developer-facing products. They already write good content; they're frustrated it keeps going stale.

**Key points:**
1. DevRel owns the highest-stakes docs (quickstarts, tutorials, code samples) — the entry point for every external developer
2. These docs are code-dependent and break silently when APIs change
3. The ownership gap: engineers ship API changes without knowing which tutorials are affected; DevRel doesn't sit in engineering standups
4. DevRel teams find out via support tickets and community reports — lagging indicators by days or weeks
5. The trust cost compounds: 68% of developers cite outdated docs as their top API frustration (Postman)
6. The fix is a detection layer connecting code changes to content dependencies, not a PR checkbox or quarterly audit

**Promptless connection:** Promptless monitors the connection between docs content and the code it describes, surfacing engineering changes that affect DevRel content before developers hit the error.

## File

`src/content/blog/technical/developer-relations-documentation-maintenance-gap.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Voqs1V3jH74RcfNJD3Addg)_