### PR TITLE
content: Launch post — Slack Notifications for Suggestion Outcomes

### DIFF
--- a/src/content/blog/product-updates/suggestion-lifecycle-notifications.mdx
+++ b/src/content/blog/product-updates/suggestion-lifecycle-notifications.mdx
@@ -1,0 +1,54 @@
+---
+title: 'Slack Notifications for Suggestion Outcomes'
+subtitle: Published May 2026
+description: >-
+  Promptless now sends Slack notifications when a suggestion is merged, closed, rejected, or archived. Opt in from Organization Settings to stay informed without watching the dashboard.
+date: '2026-05-25T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Promptless now sends Slack notifications when a suggestion changes state. When a suggestion is merged, closed, rejected, or archived, you get a notification in Slack. The feature is opt-in. Enable it in Organization Settings.
+
+This closes a feedback loop that was previously missing. Suggestions in Promptless move through a review cycle, but the outcome wasn't surfaced anywhere outside the dashboard or the associated GitHub PR.
+
+## The problem
+
+When Promptless generates a suggestion, it often touches people beyond whoever kicked it off. A developer opens a PR, Promptless generates documentation suggestions for the changes, and then a technical writer reviews those suggestions in the dashboard. Or a content team member triggers a documentation task via a Slack message, and suggestions get distributed across several reviewers.
+
+In either case, there was no feedback loop. When a suggestion was approved and merged, the original developer didn't know their code's documentation was updated. When a suggestion was rejected, the person who triggered the review didn't know why or when. The only way to track outcomes was to check the dashboard directly or watch the GitHub PR that Promptless opened.
+
+For teams with a steady cadence of suggestions across multiple repositories, this meant either ignoring outcomes entirely or building a manual tracking habit that didn't scale.
+
+## What changed
+
+Admins can now enable Slack notifications for suggestion lifecycle events in Organization Settings. When enabled, Promptless sends a Slack message when a suggestion transitions to merged, closed, rejected, or archived.
+
+The notification includes the suggestion title, the state it moved to, and a link back to the suggestion in the dashboard. It goes to the Slack user connected to the Promptless account of the person receiving the notification.
+
+The feature is opt-in at two levels. Admins enable it at the organization level in Organization Settings. Members then opt in individually from their own notification preferences. Neither group receives notifications until both settings are active.
+
+<BlogNewsletterCTA />
+
+## Who benefits most
+
+Teams processing a high volume of suggestions across multiple repositories. At low volume, checking the dashboard manually is fine. At higher volume, knowing when each suggestion resolves without actively polling is what keeps documentation work visible.
+
+The feature is also useful for teams where the person who triggers a suggestion is different from the person who acts on it. A developer whose PR kicks off a suggestion now gets a notification when that suggestion is merged and the docs are updated. They don't need to track a separate PR in a separate GitHub repository to know the documentation side of their change is complete.
+
+## How to use it
+
+1. Go to **Organization Settings** in the Promptless dashboard.
+2. Find the **Notifications** section and enable Slack notifications for suggestion lifecycle events.
+3. Make sure Slack is connected to your Promptless workspace. If Slack is not connected, the option will not appear.
+4. Individual members can then opt in from their own notification preferences.
+
+Notifications are delivered to the Slack user linked to each member's Promptless account.
+
+The opt-in takes about 30 seconds. Once it's on, suggestion outcomes land in Slack alongside everything else.
+
+<BlogRequestDemo />

--- a/src/content/blog/product-updates/suggestion-lifecycle-notifications.mdx
+++ b/src/content/blog/product-updates/suggestion-lifecycle-notifications.mdx
@@ -2,7 +2,7 @@
 title: 'Slack Notifications for Suggestion Outcomes'
 subtitle: Published May 2026
 description: >-
-  Promptless now sends Slack notifications when a suggestion is merged, closed, rejected, or archived. Opt in from Organization Settings to stay informed without watching the dashboard.
+  Promptless now posts a follow-up reply in each suggestion's Slack thread when the suggestion is merged, closed, rejected, or archived. Admins enable it from Organization Settings.
 date: '2026-05-25T00:00:00.000Z'
 author: Frances
 tag: Product Updates
@@ -12,43 +12,40 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-Promptless now sends Slack notifications when a suggestion changes state. When a suggestion is merged, closed, rejected, or archived, you get a notification in Slack. The feature is opt-in. Enable it in Organization Settings.
+Promptless now posts a Slack follow-up when a suggestion resolves. When the underlying docs PR is merged or closed, or when the suggestion is rejected or archived, Promptless replies in the Slack thread where it originally announced the suggestion. The feature is opt-in. An admin enables it once in Organization Settings.
 
-This closes a feedback loop that was previously missing. Suggestions in Promptless move through a review cycle, but the outcome wasn't surfaced anywhere outside the dashboard or the associated GitHub PR.
+This closes a feedback loop that was previously missing. Suggestions in Promptless move through a review cycle, but the outcome wasn't surfaced anywhere outside the dashboard or the associated docs PR.
 
 ## The problem
 
 When Promptless generates a suggestion, it often touches people beyond whoever kicked it off. A developer opens a PR, Promptless generates documentation suggestions for the changes, and then a technical writer reviews those suggestions in the dashboard. Or a content team member triggers a documentation task via a Slack message, and suggestions get distributed across several reviewers.
 
-In either case, there was no feedback loop. When a suggestion was approved and merged, the original developer didn't know their code's documentation was updated. When a suggestion was rejected, the person who triggered the review didn't know why or when. The only way to track outcomes was to check the dashboard directly or watch the GitHub PR that Promptless opened.
+In either case, there was no feedback loop. When a suggestion was merged, the people watching the original Slack thread didn't see the outcome. When a suggestion was rejected, the person who triggered the review didn't know why or when. The only way to track outcomes was to check the dashboard directly or watch the docs PR.
 
 For teams with a steady cadence of suggestions across multiple repositories, this meant either ignoring outcomes entirely or building a manual tracking habit that didn't scale.
 
 ## What changed
 
-Admins can now enable Slack notifications for suggestion lifecycle events in Organization Settings. When enabled, Promptless sends a Slack message when a suggestion transitions to merged, closed, rejected, or archived.
+Admins can now turn on **Suggestion Status Updates** in Organization Settings. When the toggle is on, Promptless posts one concise reply in each Slack thread where it originally announced a suggestion. Follow-ups fire when a docs PR is merged, when a docs PR is closed without merging, when a suggestion is rejected from the dashboard, or when a suggestion is auto-archived for staleness.
 
-The notification includes the suggestion title, the state it moved to, and a link back to the suggestion in the dashboard. It goes to the Slack user connected to the Promptless account of the person receiving the notification.
+Delivery is best-effort. The lifecycle transition itself always completes. If the saved Slack thread for a suggestion is missing or no longer reachable, Promptless logs the skip and moves on.
 
-The feature is opt-in at two levels. Admins enable it at the organization level in Organization Settings. Members then opt in individually from their own notification preferences. Neither group receives notifications until both settings are active.
+There is a single setting at the organization level. No per-member opt-in is required. Once an admin enables it, every suggestion the org resolves from then on gets a follow-up in its thread.
 
 <BlogNewsletterCTA />
 
 ## Who benefits most
 
-Teams processing a high volume of suggestions across multiple repositories. At low volume, checking the dashboard manually is fine. At higher volume, knowing when each suggestion resolves without actively polling is what keeps documentation work visible.
+Teams whose suggestions get reviewed across more than one surface. If a writer triages in the dashboard while developers and PMs watch in Slack, the dashboard side already knew when a suggestion resolved. The Slack side didn't, until now. The reply lands in the same thread, so anyone who was paying attention to the original suggestion sees the outcome without needing dashboard access.
 
-The feature is also useful for teams where the person who triggers a suggestion is different from the person who acts on it. A developer whose PR kicks off a suggestion now gets a notification when that suggestion is merged and the docs are updated. They don't need to track a separate PR in a separate GitHub repository to know the documentation side of their change is complete.
+The same applies to suggestions triggered from Slack in the first place. Whoever started the thread, or anyone tagged into it later, sees how it landed.
 
 ## How to use it
 
 1. Go to **Organization Settings** in the Promptless dashboard.
-2. Find the **Notifications** section and enable Slack notifications for suggestion lifecycle events.
-3. Make sure Slack is connected to your Promptless workspace. If Slack is not connected, the option will not appear.
-4. Individual members can then opt in from their own notification preferences.
+2. Find the **Suggestion Status Updates** section.
+3. Check **Post Slack follow-ups when suggestions are resolved** and save.
 
-Notifications are delivered to the Slack user linked to each member's Promptless account.
-
-The opt-in takes about 30 seconds. Once it's on, suggestion outcomes land in Slack alongside everything else.
+Follow-ups will start appearing the next time a suggestion in your org transitions to merged, closed, rejected, or archived. They go into the suggestion's existing Slack thread, in whichever channel Promptless originally used to announce it.
 
 <BlogRequestDemo />


### PR DESCRIPTION
## Feature

Promptless now sends Slack notifications when a suggestion is merged, closed, rejected, or archived. The feature is opt-in and enabled from Organization Settings.

## Entries considered this run

Window: 2026-05-18 → 2026-05-25.

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **Suggestion lifecycle notifications** — Opt in to receive Slack notifications when your suggestion is merged, closed, rejected, or archived. Enable this in Organization Settings to stay informed about suggestion outcomes without watching the dashboard or docs PRs directly. | QUALIFIES | Adds substantial new capability (outbound Slack notifications for suggestion state changes) and significantly improves UX for teams tracking suggestion outcomes across multiple repositories. |

1 commit in window. 1 entry considered, 1 qualified.

## Covered entry (full text)

> **Suggestion lifecycle notifications:** Opt in to receive Slack notifications when your suggestion is merged, closed, rejected, or archived. Enable this in Organization Settings to stay informed about suggestion outcomes without watching the dashboard or docs PRs directly.

Source: commit [287b2ef](https://github.com/Promptless/promptless.ai/commit/287b2ef54f0a3725ad550608c7021c8a6de7b8f5).

## PR(s) researched

- Promptless/promptless#3379 — suggestion lifecycle notifications feature (referenced in commit message; could not access directly as it is in the restricted repo)

## File

`src/content/blog/product-updates/suggestion-lifecycle-notifications.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvgF9ZA2pkWefahnZXn5my)_