### PR TITLE
content: Developer Education: Why Tutorials Break When You Treat Them Like Reference Docs

### DIFF
--- a/src/content/blog/technical/developer-education-tutorials.mdx
+++ b/src/content/blog/technical/developer-education-tutorials.mdx
@@ -1,0 +1,81 @@
+---
+title: 'Developer Education: Why Tutorials Break When You Treat Them Like Reference Docs'
+subtitle: Published May 2026
+description: >-
+  Developer education fails when tutorials are maintained like reference docs. Here's why sequential dependency makes tutorials uniquely expensive to keep current.
+date: '2026-05-25T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer follows your quickstart tutorial. Steps one, two, and three work fine. Step four fails with an authentication error. The auth flow was updated five months ago. The tutorial was not.
+
+They try to debug it, check the changelog, find nothing helpful, and close the tab. They don't file a ticket. They're just gone.
+
+This is what developer education failure looks like in practice. The root cause is the maintenance model.
+
+## Education and documentation are different jobs
+
+Developer documentation answers a specific question. A reference page tells you what parameters an endpoint accepts. A conceptual guide explains how authentication works. These are lookup artifacts. A developer consults them, gets what they need, and moves on.
+
+Developer education guides a developer toward a working outcome. A tutorial takes someone from zero to a functioning integration. A sample app shows how multiple features work together in a realistic context. These are sequential artifacts. Step two depends on step one. The whole path has to work end-to-end for the education to function.
+
+Most developer education programs treat tutorials and sample apps as a type of documentation. They go through the same publishing workflow and the same update cadence, with no dedicated owner. That's the mistake. The difference in structure produces a completely different maintenance burden.
+
+A stale reference page is a localized problem. One parameter name is wrong, one return type is outdated. A developer can often work around it or recognize what changed. A stale tutorial is a path failure. Outdated authentication in step three makes every step after it unreachable, and the developer has no signal about whether steps four through eight are even worth attempting.
+
+## Why tutorial failure is silent
+
+When a reference page is wrong, developers sometimes flag it. They've already gotten far enough into the integration to know what the correct value should be, and occasionally they file an issue or send an email.
+
+When a tutorial breaks at step four, the developer never gets far enough to know what's wrong. They assume the problem is on their end. They try a few variations, hit the same wall, and abandon the path. [Research consistently puts the abandonment rate at around 50%](https://userguiding.com/blog/user-onboarding-statistics) when documentation fails a developer. Tutorials have a higher failure surface than any single reference page, so the effective abandonment rate for broken tutorials is correspondingly higher.
+
+The silence is what makes this expensive. A support ticket is a signal you can act on. An abandoned session looks identical to a successful one in your traffic analytics. [Postman's 2024 State of the API report](https://www.postman.com/state-of-api/2024) found that 68% of developers cite outdated documentation as their top frustration when working with APIs. That frustration is generating churn that doesn't appear in your dashboards.
+
+Code samples compound the problem. A code sample calling a deprecated method looks valid. The syntax passes any linter. It only fails when a developer copies it and runs it. Most teams have no automated check that code samples in their tutorials remain executable as the product evolves. The samples drift invisibly.
+
+<BlogNewsletterCTA />
+
+## What high-quality developer education programs do differently
+
+The teams that build developer education that scales treat their tutorials as maintained software, not published content.
+
+Stripe's onboarding is a frequently cited benchmark. They target [Time to First API Call under 90 seconds](https://blog.postman.com/the-most-important-api-metric-is-time-to-first-call/), which means their quickstart path is a product with a clear success metric, not a document with a publish date. That framing changes how the content is maintained. You don't let a product drift.
+
+The concrete differences between teams that get this right and teams that don't:
+
+**Code samples run in CI.** If a code sample calls an endpoint that no longer exists, or uses an authentication method that was deprecated, CI catches it before the next developer does. Most teams have never connected their documentation code samples to any automated execution.
+
+**Tutorials have named owners.** The team whose code a tutorial covers owns the tutorial. When the authentication flow changes, the team that shipped the change is responsible for updating the tutorial covering it. Without named ownership, tutorials live in a shared maintenance queue where everyone assumes someone else will handle it.
+
+**Sequential paths are audited as paths, not as individual pages.** A tutorial covering signup, authentication, first API call, and webhook setup has four potential breakpoints. Reviewing each page independently misses failures that only appear when you walk the full sequence. Teams that maintain tutorials well walk through them end-to-end after significant releases, not just when a specific step is flagged.
+
+## Measuring whether developer education is working
+
+[The 2024 State of Developer Relations report](https://www.devrel.agency/post/survey-insights-education-first-devrel) found that 60.7% of DevRel practitioners cite proving impact with data as their top challenge. Part of why this is hard is that the wrong metrics are often in use.
+
+Page views tell you how many people started a tutorial. They don't tell you whether those people produced a working integration. A tutorial that generates 10,000 page views and a 10% completion rate is performing worse than one that generates 2,000 page views and a 70% completion rate, but the page view metric inverts the ranking.
+
+The metrics that expose whether developer education is actually working:
+
+- **Tutorial completion rate.** What percentage of developers who start a tutorial reach the final step? Completion rates below 30% on a key onboarding tutorial usually indicate a broken step somewhere in the path, not a discovery problem.
+- **Time to First API Call.** For integration tutorials, TTFC from tutorial start to first successful API call is the outcome metric. A rising TTFC on a tutorial that hasn't been changed is a signal that something the tutorial depends on has changed.
+- **Support ticket correlation.** Tag support tickets by the tutorial or doc section that preceded the issue. Tickets that cluster around a specific step in a tutorial are pointing directly at the maintenance gap.
+
+These metrics require instrumentation that many documentation sites don't have. But even approximate tracking, like manually reviewing completion events for a key tutorial once a quarter, surfaces problems that page view metrics cannot.
+
+## The detection problem
+
+Tutorials break because code changes without documentation review. An engineer ships a new authentication method. The PR reviewer checks the code. Nobody checks whether the three tutorials covering authentication now have a broken step.
+
+The gap between code changes and documentation review is the root cause. For reference pages, the gap means individual facts go stale. For tutorials, it means complete learning paths stop working.
+
+[Documentation drift is fundamentally a detection problem](https://promptless.ai/blog/technical/documentation-drift-detection-problem): the challenge is knowing which content became stale when the product changed, before a developer hits the broken step. For developer education specifically, detection needs to work at the tutorial level: when a code change touches an API surface that a tutorial covers, that tutorial surfaces for review. The [teams that keep docs in sync with a shipping product](https://promptless.ai/blog/technical/how-teams-keep-docs-up-to-date-with-promptless) build this connection upstream rather than discovering broken paths through support tickets after the fact.
+
+Tutorials are the highest-stakes content in a developer education program. They're the path between a developer's first look at your product and their first working integration. Maintaining them like documentation gets you documentation results. Maintaining them like software gets you an education program that actually works.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer education`

## Article plan

**Thesis:** Developer education fails at scale when tutorials are treated as published documents rather than maintained software, because tutorials have sequential dependencies that make a single stale step break the entire learning path.

**Target reader:** Developer advocates, DevRel engineers, and technical writers at developer-tool companies building or scaling a developer education program.

**Key points:**
1. Developer education and developer documentation serve different purposes: docs answer reference questions, education guides toward a working outcome. Conflating them produces content that does neither well.
2. Tutorials are sequentially dependent: one outdated step breaks the entire path. This makes tutorials the highest-maintenance asset, yet most teams update them on the same cadence as reference pages.
3. Code samples go stale silently. No CI failure, no alert. A sample calling a deprecated method looks valid until someone runs it.
4. Companies with great developer education (Stripe, Twilio, AWS) run CI on code samples and assign tutorial owners. Most treat tutorials as documents.
5. Measuring developer education requires completion rates and TTFC, not page views.

**Promptless connection:** Promptless detects when code changes make documentation stale. For educational content, this is the detection layer tutorials need: flagging when an API surface covered by a tutorial changes.

## File

`src/content/blog/technical/developer-education-tutorials.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_0163HLqSsojQp7tzBrZ3AwaN)_