### PR TITLE
Fix jobs page demo CTA anchor

### DIFF
--- a/src/content/website/jobs.mdx
+++ b/src/content/website/jobs.mdx
@@ -28,7 +28,7 @@ For all roles, reach out at **founders@promptless.ai**!
     natural break point to give them a nudge. */}
 <div class="pl-jobs-cta pl-jobs-cta-v1">
   <p class="pl-jobs-cta-context">Curious how the product works?</p>
-  <a href="https://promptless.ai/demo#video" data-track-action="watch_demo" data-track-funnel="evaluation" data-track-location="jobs_page">Watch the demo &rarr;</a>
+  <a href="https://promptless.ai/#demo" data-track-action="watch_demo" data-track-funnel="evaluation" data-track-location="jobs_page">Watch the demo &rarr;</a>
 </div>
 
 ## Founding Engineer
@@ -64,5 +64,5 @@ You'll build the core product—the AI agents, the integrations, the infrastruct
     natural break point to give them a nudge. */}
 <div class="pl-jobs-cta pl-jobs-cta-v1">
   <p class="pl-jobs-cta-context">Curious how the product works?</p>
-  <a href="https://promptless.ai/demo#video" data-track-action="watch_demo" data-track-funnel="evaluation" data-track-location="jobs_page">Watch the demo &rarr;</a>
+  <a href="https://promptless.ai/#demo" data-track-action="watch_demo" data-track-funnel="evaluation" data-track-location="jobs_page">Watch the demo &rarr;</a>
 </div>


### PR DESCRIPTION
## Summary
- update both jobs-page "Watch the demo" CTAs to link directly to the homepage demo section
- avoid routing candidates through /demo#video, which points at a stale anchor before the /demo redirect lands on /#demo

## Why
The jobs page comment says the demo CTAs are intentionally placed because candidates were leaving without exploring the product. The current URL uses /demo#video, but the active homepage video section is #demo and the /demo compatibility page redirects to /#demo. Linking directly to /#demo keeps the candidate CTA aligned with the actual rendered section and removes an unnecessary redirect.

## Verification
- npm run typecheck
- npm run build
- git diff --check