### PR TITLE
content: Developer Education Has a Tutorial Maintenance Problem Most Teams Ignore

### DIFF
--- a/src/content/blog/technical/developer-education-tutorial-maintenance.mdx
+++ b/src/content/blog/technical/developer-education-tutorial-maintenance.mdx
@@ -1,0 +1,81 @@
+---
+title: 'Developer Education Has a Tutorial Maintenance Problem Most Teams Ignore'
+subtitle: Published May 2026
+description: >-
+  44% of DevRel teams say content creation is their top challenge. The harder problem is what happens to tutorials after the product changes.
+date: '2026-05-26T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer relations team at a SaaS company ran a cohort analysis on new API signups. Activation was higher for developers who came from a specific tutorial series than for those who started from the reference docs. They decided to double down: write more tutorials, publish them faster, expand to more use cases.
+
+Six months later, activation rates from that same tutorial series had dropped. The product had shipped two major releases. The tutorials had not.
+
+## The conversation stops at creation
+
+The revenue case for developer education is well-documented. [CircleCI attributed over $3.5 million in sales pipeline](https://about.scarf.sh/post/measuring-the-commercial-roi-of-devrel) to events and educational content produced by their DevRel team, with event investments yielding a 2-3x return within a 6-12 month sales cycle. [SlashData research](https://slashdata.co) found that 47-65% of senior developers cite better documentation and code samples as a key signal of API quality.
+
+In response to this evidence, most teams invest in creation. A [2024 survey of DevRel practitioners](https://www.devrel.agency/post/survey-insights-education-first-devrel) found that 44.8% cite ongoing content creation as their top challenge. The instinct is understandable: if tutorials drive adoption, write more tutorials.
+
+The conversation rarely extends to what happens to the tutorials that already exist.
+
+<BlogNewsletterCTA />
+
+## Why tutorials decay differently than reference docs
+
+Reference documentation has an update mechanism. Teams generate it from code or an OpenAPI spec. When a method signature changes, the reference updates with the next build. When a parameter is added, it appears in the generated output. The pipeline handles continuity.
+
+Tutorials have no equivalent mechanism. A getting-started guide is handwritten prose describing how your product worked on the day someone wrote it. When the product changes, the guide keeps saying what it said.
+
+The decay triggers are predictable:
+
+**SDK version bumps.** A tutorial installing `pip install yourpackage==2.1` imports methods that were reorganized or renamed in v3. The code runs; the error is opaque.
+
+**Authentication changes.** Tutorials that walk through an auth flow step-by-step become wrong the moment the auth flow changes. The reference docs may be updated. The tutorial still describes the old pattern.
+
+**Endpoint deprecations.** A tutorial calling `/api/v1/users` keeps calling it after you redirect it or remove it. Developers hit a 410 with no context for why.
+
+**Configuration drift.** Any tutorial that shows specific environment variable names, config file formats, or dashboard screenshots drifts the moment the product UI or configuration model changes.
+
+Each of these triggers is predictable because each one is recorded somewhere: the changelog, the release notes, the deprecation notice. The problem is that nothing connects those records to the tutorials that reference the affected surfaces. A team can maintain a rigorous release process and still ship a major release without reviewing a single tutorial.
+
+## The cost of a broken first experience
+
+A stale reference page sends a developer to a method that has been renamed. They check the source code or the updated reference, find the current name, and continue.
+
+A stale getting-started guide stops a developer before they've built anything.
+
+This matters because of where tutorials sit in the adoption funnel. Developers start with them. They follow a tutorial to make their first API call, run their first integration, test their first webhook. The data on this window is concrete: [developers who make their first successful API call within 10 minutes are 3-4x more likely to convert to a paid plan](https://treblle.com/blog/accelerating-api-integrations-best-practices-for-faster-onboarding). That window exists because the first few minutes are when adoption momentum either builds or collapses.
+
+A broken tutorial in step two of a quickstart doesn't generate an alert. It generates a developer who closes the tab.
+
+The signal comes late. Support tickets from new users are often the first indication that a tutorial has drifted. By then, the tutorial has already turned away the developers who tried it and quit without filing a ticket. That group is larger.
+
+[68% of enterprise technical content hasn't been updated in over six months.](https://syntaxscribe.com/blog/stale-vs-no-documentation) Developer education content makes up a significant share of that total.
+
+## What systematic maintenance looks like
+
+The teams that maintain tutorial libraries well share a structural pattern. Their code samples live in version control alongside the SDK or product codebase. Those samples run as part of the test suite. When the SDK changes and a sample breaks, it surfaces as a failing test, not as a support ticket months later.
+
+The tutorial prose stays separate from the samples, but the samples are the authoritative layer. A passing test signals that the code in the tutorial is still accurate. A failing test queues the tutorial for review before users encounter it.
+
+Stripe and Twilio are the most commonly cited examples of developer education done well. Both maintain multi-language sample libraries with this structure. [Their quickstart guides hold up](https://nordicapis.com/10-examples-of-sdks-with-great-developer-experience/) because the underlying code is continuously tested, not because someone audits the prose on a schedule.
+
+Most teams don't have this setup. Their tutorials are markdown files edited by whoever has bandwidth, reviewed when someone notices something wrong. The tutorial library grows with each new workshop, use-case guide, and integration blog post. The maintenance surface grows with it, unmonitored.
+
+## Connecting tutorials to the product lifecycle
+
+A quarterly content audit doesn't solve the decay problem. Audits capture accuracy at a moment in time and then let it decay again until the next cycle.
+
+What holds is connecting tutorial review to the product lifecycle. When the changelog records a deprecation, the tutorials that reference that endpoint get flagged. When a major SDK version ships, the tutorials that install a specific previous version get queued. The review isn't scheduled on a calendar. It's triggered by the same events that make the tutorial inaccurate.
+
+This requires knowing what your tutorials reference. [Documentation coverage](https://promptless.ai/blog/technical/documentation-coverage) thinking applies here: coverage includes whether the tutorials for a given feature still describe what the feature currently does, not just whether a tutorial exists.
+
+[Technical writing with AI](https://promptless.ai/blog/technical/technical-writing-with-ai) tools can accelerate the creation side further, which increases the maintenance surface faster than a team can manually track it. A growing tutorial library needs a feedback loop more than it needs new content. The feedback loop tells you when what you've already published has stopped being accurate.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer education`

## Article plan

**Target keyword:** developer education (primary), DevRel tutorials (secondary)

**Thesis:** Developer education creates an educational documentation surface that expands with every tutorial, but decays with every product update. The teams maintaining the best tutorial libraries connect the product changelog to the tutorial review queue.

**Key points:**
1. DevRel teams invest in content creation because education drives adoption (CircleCI $3.5M pipeline, SlashData 47-65% of senior devs expect better samples) — but 44.8% cite creation as their top challenge and the conversation rarely extends to what happens to existing tutorials
2. Tutorials decay through specific, predictable triggers: SDK version bumps, auth changes, endpoint deprecations, config drift — and nothing automatically connects these events to the tutorials that reference them
3. Broken tutorials cost more than broken reference pages: developers who make their first API call within 10 minutes are 3-4x more likely to convert; a stale tutorial at step 2 of a quickstart kills that window silently
4. Teams with the best tutorial libraries (Stripe, Twilio) keep code samples in version control and run them as tests — failures surface as broken builds, not support tickets
5. The fix: connect tutorial review to the product lifecycle, not a quarterly calendar; documentation coverage means knowing whether tutorials describe the feature *correctly*, not just whether they exist

**Promptless connection:** Developer education creates an expanding documentation surface with the same staleness risk as reference docs. The article links naturally to documentation coverage and technical writing with AI articles.

## File

`src/content/blog/technical/developer-education-tutorial-maintenance.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_012LsNtvnGtDMH5Qq2PYetot)_