### PR TITLE
Rename CLI sidebar group to Promptless CLI and collapse by default

### DIFF
--- a/src/lib/generated/sidebar.json
+++ b/src/lib/generated/sidebar.json
@@ -158,7 +158,8 @@
     ]
   },
   {
-    "label": "CLI",
+    "label": "Promptless CLI",
+    "collapsed": true,
     "items": [
       {
         "label": "Promptless CLI",

--- a/src/lib/generated/sidebar.json
+++ b/src/lib/generated/sidebar.json
@@ -162,7 +162,7 @@
     "collapsed": true,
     "items": [
       {
-        "label": "Promptless CLI",
+        "label": "Overview",
         "slug": "docs/cli"
       },
       {


### PR DESCRIPTION
## Summary
- Rename the docs sidebar group from "CLI" to "Promptless CLI"
- Mark the group as `collapsed: true` so it starts collapsed in the nav

## Test plan
- [x] `npm run build` succeeds
- [ ] Verify in dev that the "Promptless CLI" group renders collapsed by default and still expands to all existing entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)