### PR TITLE
content: Developer Relations Docs Have a New Primary Reader

### DIFF
--- a/src/content/blog/technical/developer-relations-docs-new-primary-reader.mdx
+++ b/src/content/blog/technical/developer-relations-docs-new-primary-reader.mdx
@@ -1,0 +1,79 @@
+---
+title: 'Developer Relations Docs Have a New Primary Reader'
+subtitle: Published May 2026
+description: >-
+  AI coding agents now consume DevRel docs before any human developer does. Here's what that means for ownership, accuracy, and how DevRel teams should work.
+date: '2026-05-28T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Your quickstart guide has a new first reader. Before any developer on your trial list opens your docs, their coding assistant probably has.
+
+AI coding agents like Claude, Cursor, and GitHub Copilot reach into documentation portals as part of normal development flows. They retrieve API references and scaffold integrations from whatever sample code they find. [65% of developers report their AI coding assistant misses relevant context during code review and refactoring](https://blog.stateshift.com/best-practices-for-devrel-programs/). That missing context has a source: outdated API references and sample code written against last year's SDK.
+
+DevRel teams have always cared about documentation quality. The change is in what quality now requires.
+
+## The First-Touch Audience Has Changed
+
+Developer relations has always optimized docs for the human reading experience. Getting a developer from zero to first working call as fast as possible. That still matters. It is no longer sufficient on its own.
+
+AI coding agents don't read narratively. They retrieve selectively, matching the developer's current query against whatever content is available. An agent asked to implement your webhook flow will pull the authentication section and the event schema, in whatever state those pages happen to be right now.
+
+The practical consequence is that your documentation quality shows up in developers' work before those developers have read a single word of your docs. When your API reference describes a field that was renamed six months ago, developers integrating via AI get wrong code on the first pass. They debug it, trace it back, and either open a support ticket or move on. The doc failure stays invisible. The developer friction is real.
+
+One example illustrates the new blast radius. A team deployed an internal support agent against their company knowledge base. A pricing document still referenced a promotional rate from two quarters prior. The agent offered a major customer a 50% discount that no one had authorized, because [the document appeared current but was wrong according to the product](https://getunblocked.com/blog/context-engineering/). The retriever had no signal that the content was stale.
+
+That scenario involved an internal knowledge base. The same mechanism applies to external developer relations documentation, and your DevRel docs are consumed by far more agents.
+
+## The Ownership Gap That Predates AI
+
+DevRel teams are often accountable for developer experience without controlling the full documentation surface that produces it.
+
+At most developer-facing companies, documentation ownership is fragmented. The API reference lives with Product. The changelog is maintained by Engineering (or by no one in particular). The getting started guide was written for the product launch and has been lightly updated since. DevRel maintains the tutorials and code samples. Each team has its own publishing cadence and its own threshold for what warrants a doc update.
+
+This fragmentation existed before AI agents. Historically, it meant developers occasionally hit inconsistencies: a tutorial referencing an endpoint the API reference had already updated, requiring 20 minutes to sort out which version was current. Annoying, but recoverable by a developer who could read carefully and reason through the gap.
+
+With AI agents in the workflow, the inconsistency gets encoded into generated code. The agent retrieves whichever source it found, builds against it, and the developer receives a scaffolded integration that doesn't work as written. The inconsistency becomes a generation accuracy problem rather than a reading comprehension problem.
+
+DevRel teams are positioned to see this better than anyone else in the organization. They get the feedback when integrations fail. They write tutorials that depend on the API reference being accurate. The problem is that most DevRel teams have no systematic way to detect [documentation drift](/blog/technical/documentation-drift-detection-problem) across all the teams contributing to their docs surface.
+
+<BlogNewsletterCTA />
+
+## What DevRel Teams Should Actually Own
+
+The gap between accountability and control is a structural problem. DevRel cannot own the API reference or the changelog from an authoring standpoint. What they can own is accuracy monitoring: a cross-cutting view of whether the documentation surface is currently correct, regardless of who wrote each page.
+
+### Documentation inventory
+
+Most DevRel teams have a docs site and a rough mental model of what's in it. What's needed is a living map: what docs exist, which team owns each section, and when each page was last verified against the actual product. This is the minimum required to know where drift is likely to have accumulated.
+
+Without an inventory, the documentation surface grows opaque over time. Pages added during a product launch stay up indefinitely. Tutorials written for deprecated flows remain indexed and retrievable. The only signal that something is wrong arrives via support ticket or community question, after a developer has already hit the problem.
+
+### Change signals tied to specific pages
+
+Changelogs tell you what changed. DevRel teams need alerts that connect product changes to the specific documentation pages those changes affect. When an endpoint is updated, that signal should surface which tutorial pages reference that endpoint, not just that an endpoint changed.
+
+The difference between a change log and a change alert is the difference between knowing an update happened and knowing what you need to do about it. Most teams have the former. Few have the latter.
+
+### Freshness metadata on published content
+
+Structuring documentation with explicit `last_updated` metadata and canonical URLs gives AI agents a basis for preferring fresher content. Without it, an agent treats a page from 2023 and a page from last week as equally reliable, because both appear in the index and both match on semantic similarity. A stale page that still ranks well will be retrieved over a current one. This is the same problem covered in depth in our piece on [agent context engineering](/blog/technical/agent-context-engineering): the retriever has no freshness signal, so accuracy and recency are invisible to it.
+
+Adding freshness signals is a documentation infrastructure change, which means it often gets deprioritized behind content work. The order should probably be reversed. The content only functions correctly if agents can tell which version is current.
+
+## The Accountability Shift
+
+DevRel's core value has always been making developers successful with your product. The tutorials and sample code that support that goal now feed into a consumption layer that treats stale content as confidently as it treats fresh content.
+
+That makes cross-team documentation accuracy a DevRel responsibility in a way it hasn't been before. The existing articles your team maintains were written at a point in time. The monitoring question (do they still accurately describe the product?) requires ongoing attention rather than a launch-time review.
+
+Teams that build this monitoring layer consistently find the same thing: most accuracy failures concentrate on a small number of high-traffic pages. Fixing those pages and keeping them current has an outsized effect on the quality of integrations developers produce using AI assistance.
+
+The documentation your DevRel team promotes is being read at scale before any human developer opens it. Making sure that read produces correct outputs is now part of the job.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer relations docs`

## Article plan

**Thesis:** DevRel teams are responsible for developer experience, but they've rarely owned documentation accuracy. AI agents make that gap costly.

**Target reader:** Developer advocates and DevRel engineers at API-first companies who care about DX but don't always control the docs they're accountable for.

**Key angles:**
- AI coding agents are now the first-touch consumer of DevRel docs (65% of devs report their AI assistant misses context from documentation gaps)
- Stale DevRel docs now produce AI execution errors, not just developer confusion (real example: stale pricing doc causes agent to offer unauthorized discounts)
- DevRel documentation has fragmented ownership across Product/Engineering/Marketing/DevRel with no cross-cutting accuracy view
- Three things DevRel teams should own: documentation inventory, change signals tied to specific pages, freshness metadata
- Promptless connection: gives DevRel teams the detection layer they're currently missing

**Related keywords surfaced:** AI-first developer documentation, DevRel documentation strategy

## File

`src/content/blog/technical/developer-relations-docs-new-primary-reader.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvdFSXg6M3wQKTnCyf2utK)_