### PR TITLE
content: API Documentation Automation: Why Your Spec Is the Real Bottleneck

### DIFF
--- a/src/content/blog/technical/api-documentation-automation.mdx
+++ b/src/content/blog/technical/api-documentation-automation.mdx
@@ -1,0 +1,75 @@
+---
+title: 'API Documentation Automation: Why Your Spec Is the Real Bottleneck'
+subtitle: Published June 2026
+description: >-
+  Most API documentation automation tools solve the generation problem. Here's what they leave behind, and why the spec itself is where docs go stale.
+date: '2026-06-02T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer reads your API reference. The endpoint is documented. The parameter they need is listed as optional. They ship. It fails at runtime. The spec annotation was updated two months ago to make that parameter required, but the docs generator ran before the annotation was fixed and nobody re-ran it after.
+
+That sequence doesn't happen because nobody automated your docs. It happens because the automation ran once and faithfully reproduced a stale spec.
+
+According to the Postman 2024 State of the API report, 44% of developers regularly read source code to understand an API because the documentation doesn't match what the product actually does. That's not a team that failed to document their API. It's a team whose documentation describes a previous version of it.
+
+## Why API docs decay by default
+
+Every time an API changes, a sync gap opens between the code and the docs. Closing that gap requires a deliberate step: update the docs. That step is separate from the step that ships the code, and it belongs to a different person on a different schedule.
+
+The gap closes slowly or not at all. A parameter gets renamed in the code. The engineer updates the spec annotation. The PR ships. The docs generator runs on a weekly schedule and produces updated reference docs. Three days later a developer reads the old reference page still in the CDN cache.
+
+GetDX research estimates that documentation-related problems consume 15 to 25 percent of engineering capacity. That's the equivalent of 15 to 25 engineers on a 100-person team compensating for missing or outdated docs. Most of that isn't teams without documentation. It's teams with documentation that's one or two cycles behind reality.
+
+## What OpenAPI automation solves
+
+The generation step is genuinely hard before automation. Writing reference docs from scratch for a hundred endpoints means a week of work before the first line of content is useful. OpenAPI-based generators solve that. You annotate your spec, run the generator, and get a structured reference covering every endpoint and parameter. HubSpot reduced engineering resources on docs by 50% after adopting this approach. Coinbase cut doc update time from 20 minutes to 60 seconds.
+
+Those numbers are real. OpenAPI generation removes the blank-page problem and ties your reference docs to a structured source.
+
+The cost is that your documentation is now only as good as your spec.
+
+## The spec is the new documentation
+
+Before automation, documentation was the thing that drifted. After automation, the spec is the thing that drifts.
+
+If an engineer ships an API change without updating the spec annotation, the generator produces reference docs that describe yesterday's API. The automation didn't fail. It produced exactly what it was given. The spec was wrong.
+
+This is a process problem no generation tool solves on its own. The spec needs to be treated as a deliverable on every API change, reviewed in the same PR as the code change. Most teams don't enforce this under deadline pressure.
+
+The practical signal is in your PR workflow. If your review checklist includes "tests pass" but not "spec annotations updated," your generated docs will drift every time an undocumented change ships.
+
+<BlogNewsletterCTA />
+
+## Inferring spec changes from production traffic
+
+One approach to the spec maintenance gap is to infer changes automatically from production traffic rather than relying on engineers to annotate proactively.
+
+Tools like APItoolkit analyze real API requests and responses to detect undocumented endpoints, renamed parameters, and changed response shapes. When a new field starts appearing in responses, the tool flags it. When a parameter stops being accepted, the tool surfaces the change. The spec becomes a reflection of what the API actually does rather than what someone remembered to annotate.
+
+This doesn't solve the accuracy of field descriptions or context. It surfaces the structural changes that manual annotation consistently misses under deadline pressure.
+
+## What automation doesn't reach
+
+API reference documentation is one layer of developer documentation. The layer that causes more integration friction is everything else: quickstart guides, authentication walkthroughs, integration examples, and SDK tutorials. That content doesn't live in a spec. There's no generator for it.
+
+When your authentication flow changes, no automation tool detects that your "Getting Started" guide still shows the old token format. That page was written once, published, and then forgotten.
+
+[Documentation drift](/blog/technical/documentation-drift-detection-problem) in prose documentation happens on the same timeline as spec drift, but without the tooling layer that at least makes spec drift visible. A developer following your quickstart guide doesn't know it describes an old version of your product until they hit the step that doesn't work.
+
+The State of Docs 2025 report found that more than half of documentation professionals identify keeping docs up to date as their biggest challenge. That number reflects the full documentation surface, not just API reference. It reflects the guides and tutorials that automation doesn't touch.
+
+## Automation narrows the gap
+
+OpenAPI-based generation is worth doing. It removes a significant maintenance burden from reference documentation and ties your most structured content to a versioned source.
+
+What it doesn't do is close the gap between code changes and documentation updates. The spec still needs to be maintained. Prose documentation still needs a process for [staying current when the API changes](/blog/technical/how-teams-keep-docs-up-to-date-with-promptless). And if you're not monitoring for [API changelog-driven drift](/blog/technical/api-changelog-best-practices), you'll find out about the gaps when developers open support tickets.
+
+Automation narrows the problem. Treating it as a complete solution is how teams end up with 44% of developers reading source code anyway.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `API documentation automation`

## Article plan

**Thesis:** Automation tools generate your API reference from a spec. The harder problem is keeping the spec current — and automation doesn't touch the prose layer at all.

**Target reader:** Technical writers and DevRel engineers at API-first companies who've adopted or are evaluating OpenAPI-based docs generation.

**Key points:**
1. API docs decay by default: every change creates a sync gap. 44% of developers read source code because docs don't match the product (Postman 2024).
2. OpenAPI automation removes the blank-page problem. Real gains: HubSpot –50% engineering resources on docs, Coinbase 20 min → 60 seconds.
3. After automation, the spec becomes the documentation. If engineers don't annotate changes, generated docs are stale.
4. Production-traffic inference (APItoolkit etc.) can close the spec maintenance gap automatically.
5. Guides, quickstarts, and integration examples live outside the spec — no generator reaches them.

**Promptless connection:** Promptless monitors the prose documentation layer when the API changes, which is exactly what automation tools don't touch.

## File

`src/content/blog/technical/api-documentation-automation.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjHzK9kqst3cZEDgm2YyKi)_