### PR TITLE
Add check-broken-links skill and crawler script

### DIFF
--- a/.claude/skills/check-broken-links/SKILL.md
+++ b/.claude/skills/check-broken-links/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: check-broken-links
+description: |
+  Crawl the docs site and report broken links, redirects, and warnings.
+  Runs `scripts/check_links.py`, which wraps `linkchecker` and parses the
+  CSV output into a terminal summary plus timestamped html and csv reports
+  under `tmp/broken-link-reports/`.
+
+  Use this skill when:
+  - The user asks to "check for broken links", "find broken links", "audit
+    links", "run linkchecker", or similar
+  - Verifying internal links after a large nav, redirect, or content move
+  - Pre-flight before a deploy or a significant docs reorganization
+  - Investigating a reported 404 or redirect chain
+
+  Default scope is the local dev server (`http://localhost:4321`). For a
+  production audit, pass `https://promptless.ai` (or any sub-URL) as the
+  argument.
+---
+
+# Check Broken Links
+
+Walks the docs site and reports broken links, redirects, and warnings. Thin Python wrapper around `linkchecker` with a parser that prints a readable terminal summary.
+
+## When to use
+
+- The user asks to find/check/audit broken links
+- After a redirect change, sidebar restructure, or large content move
+- Before a deploy where link integrity matters
+- To investigate a specific 404 or redirect chain
+
+If the user just wants to verify a *single* URL is reachable, this is overkill — `curl -I` is faster. Use this skill for crawls.
+
+## Prerequisites
+
+One of:
+- `uv` installed (`brew install uv`) — the script declares `linkchecker` as an inline PEP 723 dependency, so `uv run` fetches it automatically. **Preferred.**
+- `linkchecker` installed system-wide (`pip install linkchecker` or `pipx install linkchecker`) — then run via plain `python`.
+
+If neither is available, tell the user and stop. Do not try to reimplement the script in bash.
+
+## How to run
+
+The script is at `scripts/check_links.py`. It takes one optional positional argument: the root URL to crawl. Default is the local dev server.
+
+### Local dev (default)
+
+```bash
+# Start the dev server in another shell first
+npm run dev
+
+# Then crawl
+uv run scripts/check_links.py
+# or, with linkchecker installed system-wide:
+python scripts/check_links.py
+```
+
+Local runs are fast and avoid hammering production. Prefer this for routine checks.
+
+### Production
+
+```bash
+uv run scripts/check_links.py https://promptless.ai
+```
+
+Production crawls hit external links too (`--check-extern`), so they're slower and noisier. Use when you specifically want to audit the live site.
+
+### Scoped crawl
+
+The crawler stays on the host of the starting URL but follows any in-host link it finds, so a sub-path argument narrows the *entry point* but not the full crawl. If you want to limit the crawl to one section, pass that section's root URL and accept that it may still follow site-wide nav links:
+
+```bash
+uv run scripts/check_links.py https://promptless.ai/docs/getting-started/welcome
+```
+
+## Output
+
+- Terminal: `N checked, M broken, K warnings`, plus tables of broken and warning rows (url, parent, result/warning).
+- `tmp/broken-link-reports/broken-link-report_{host}_{stamp}.html` — full linkchecker HTML report (browse this for context).
+- `tmp/broken-link-reports/broken-link-report_{host}_{stamp}.csv` — semicolon-delimited raw output.
+
+The `tmp/broken-link-reports/` directory is gitignored.
+
+## Interpreting results
+
+- **broken** (`valid == False`) — needs fixing. Open the HTML report or grep the CSV for the broken URLs, then trace each `parent` page back to the source file in `src/content/`.
+- **warnings** (`valid == True` with a warning string) — usually redirects, slow responses, or 3xx chains. Worth a look but rarely block a deploy. Common cases:
+  - `301`/`302` from external links — fine, the destination resolved.
+  - `429`/timeouts on external hosts (GitHub, social) — flaky, not a real bug.
+- A **clean** run prints `clean.` and writes no rows to the CSV (the file may still exist with only comment headers).
+
+## Triaging broken links
+
+When the script reports broken links, do this:
+
+1. Group the broken rows by `parent` page — one source file often produces several bad outbound links.
+2. For each `parent`, find the source under `src/content/` (`grep -r` for a distinctive slug works).
+3. Decide per link:
+   - **Internal link to a moved page** → check `astro.config.mjs` redirects and `src/lib/generated/redirects.json`. If a redirect should exist, add it; otherwise update the link.
+   - **External link that 404s** → update or remove. Don't add an unverified replacement.
+   - **External link with a transient failure** (timeout, 5xx, 429) → re-run before assuming it's broken.
+4. Re-run the script after fixes to confirm.
+
+Do not "fix" warnings unless they hide a real problem — chasing every 301 wastes time.
+
+## Notes
+
+- The crawl uses `--no-robots` so it ignores `robots.txt`. Keep this; the docs site's `robots.txt` is tuned for search engines, not internal audits.
+- `--check-extern` is on by default. If a production run is taking too long because of slow external hosts, edit the script to drop that flag for a fast internal-only pass.
+- The CSV parser only reads the first 7 columns (`url;parent;base;result;warning;info;valid`) and ignores the rest. If linkchecker changes its column order, update `COLUMNS` in the script.

--- a/.claude/skills/check-broken-links/SKILL.md
+++ b/.claude/skills/check-broken-links/SKILL.md
@@ -1,77 +1,123 @@
 ---
 name: check-broken-links
 description: |
-  Crawl the docs site and report broken links, redirects, and warnings.
-  Runs `scripts/check_links.py`, which wraps `linkchecker` and parses the
-  CSV output into a terminal summary plus timestamped html and csv reports
-  under `tmp/broken-link-reports/`.
+  Crawl a **local** running copy of the docs site and report broken
+  links, redirects, and warnings. Runs `scripts/check_links.py`, which
+  wraps `linkchecker` and parses its CSV output into a terminal summary
+  plus timestamped html and csv reports under `tmp/broken-link-reports/`.
+
+  This skill is for verifying your own in-progress changes against a
+  local dev server. The full workflow is: install deps → start
+  `npm run dev` in the background → wait for `localhost:4321` to come
+  up → crawl → triage broken rows → stop the dev server.
 
   Use this skill when:
-  - The user asks to "check for broken links", "find broken links", "audit
-    links", "run linkchecker", or similar
-  - Verifying internal links after a large nav, redirect, or content move
-  - Pre-flight before a deploy or a significant docs reorganization
-  - Investigating a reported 404 or redirect chain
+  - The user asks to "check for broken links", "find broken links",
+    "audit links", "run linkchecker", or similar
+  - Verifying internal links after a nav change, redirect tweak, page
+    rename, or content move — before merging
+  - Investigating a reported 404 or redirect chain in local changes
 
-  Default scope is the local dev server (`http://localhost:4321`). For a
-  production audit, pass `https://promptless.ai` (or any sub-URL) as the
-  argument.
+  Production audits (`https://promptless.ai`) are supported but rare —
+  prefer local so you're testing the diff you're about to ship, not
+  whatever is currently deployed.
 ---
 
 # Check Broken Links
 
-Walks the docs site and reports broken links, redirects, and warnings. Thin Python wrapper around `linkchecker` with a parser that prints a readable terminal summary.
+Walks a **locally running** docs site and reports broken links, redirects, and warnings. The point is to catch link breakage in your current working copy *before* it ships — crawling production only tells you what's already live.
 
 ## When to use
 
 - The user asks to find/check/audit broken links
-- After a redirect change, sidebar restructure, or large content move
-- Before a deploy where link integrity matters
-- To investigate a specific 404 or redirect chain
+- After a redirect change, sidebar restructure, page rename, or content move — to verify the change before merging
+- To investigate a specific 404 or redirect chain in local changes
 
-If the user just wants to verify a *single* URL is reachable, this is overkill — `curl -I` is faster. Use this skill for crawls.
+If the user just wants to verify a *single* URL, this is overkill — `curl -I` is faster. Use this skill for crawls.
 
 ## Prerequisites
 
-One of:
-- `uv` installed (`brew install uv`) — the script declares `linkchecker` as an inline PEP 723 dependency, so `uv run` fetches it automatically. **Preferred.**
-- `linkchecker` installed system-wide (`pip install linkchecker` or `pipx install linkchecker`) — then run via plain `python`.
+Two stacks need to be ready: the docs site (Node) and the crawler (Python).
 
-If neither is available, tell the user and stop. Do not try to reimplement the script in bash.
+**Node side (to run the docs site):**
+- Node ≥ 20 (see `engines` in `package.json`)
+- `npm install` has been run at least once (check for `node_modules/`)
 
-## How to run
+**Python side (to run the crawler):**
+- `uv` installed (`brew install uv`) — the script declares `linkchecker` as an inline PEP 723 dep, so `uv run` fetches it on demand. **Preferred.**
+- *Or* `linkchecker` installed system-wide (`pip install linkchecker` / `pipx install linkchecker`) and run with plain `python`.
 
-The script is at `scripts/check_links.py`. It takes one optional positional argument: the root URL to crawl. Default is the local dev server.
+If a prerequisite is missing, tell the user what's missing and stop. Do not try to reimplement the script in bash or skip the dev server.
 
-### Local dev (default)
+## The workflow
+
+Do these steps in order. Don't skip the "wait for ready" step — `linkchecker` will report every URL as broken if the server isn't listening yet.
+
+### 1. Install deps (if needed)
 
 ```bash
-# Start the dev server in another shell first
-npm run dev
+# Only if node_modules/ is missing or stale
+npm install
+```
 
-# Then crawl
+### 2. Start the dev server in the background
+
+The dev server is `npm run dev` — Astro binds to **`http://localhost:4321`** by default (see `AGENTS.md`). Start it as a background process so the crawl can run in the same session:
+
+```bash
+npm run dev
+```
+
+Run this via the Bash tool's `run_in_background: true`. **Do not** run it foreground — it never exits, and you need the shell free to run the crawl.
+
+### 3. Wait until the server is actually serving
+
+Astro prints `Local: http://localhost:4321/` once it's ready, which usually takes 5–15 seconds. Poll until you get a 200:
+
+```bash
+for i in {1..30}; do
+  curl -fsS -o /dev/null http://localhost:4321/ && { echo "up"; break; }
+  sleep 1
+done
+```
+
+If it never comes up: read the background shell's output, surface the error, and stop. Common causes: port 4321 in use, `npm install` not run, build error in `src/`.
+
+### 4. Run the crawl
+
+```bash
 uv run scripts/check_links.py
 # or, with linkchecker installed system-wide:
 python scripts/check_links.py
 ```
 
-Local runs are fast and avoid hammering production. Prefer this for routine checks.
+The script defaults to `http://localhost:4321`, so no argument is needed for the standard case. If a user changed `--port`, pass the matching URL explicitly:
 
-### Production
+```bash
+uv run scripts/check_links.py http://localhost:4322
+```
+
+### 5. Stop the dev server
+
+When the crawl finishes, kill the background `npm run dev` process. Leaving it running ties up the port and confuses the next session.
+
+## Scoped crawl (optional)
+
+The crawler stays on the host of the starting URL but follows any in-host link it finds, so a sub-path narrows the *entry point* but not the full crawl. Useful for spot-checking one section:
+
+```bash
+uv run scripts/check_links.py http://localhost:4321/docs/getting-started/welcome
+```
+
+## Production crawl (rare)
+
+Only crawl `https://promptless.ai` when the user explicitly asks to audit the live site (e.g. "are there any broken links in prod right now?"). Pass the URL as the argument and skip steps 1–3 and 5:
 
 ```bash
 uv run scripts/check_links.py https://promptless.ai
 ```
 
-Production crawls hit external links too (`--check-extern`), so they're slower and noisier. Use when you specifically want to audit the live site.
-
-### Scoped crawl
-
-The crawler stays on the host of the starting URL but follows any in-host link it finds, so a sub-path argument narrows the *entry point* but not the full crawl. If you want to limit the crawl to one section, pass that section's root URL and accept that it may still follow site-wide nav links:
-
-```bash
-uv run scripts/check_links.py https://promptless.ai/docs/getting-started/welcome
-```
+Prod crawls are slower, hammer external hosts, and tell you nothing about uncommitted changes. Local first, always.
 
 ## Output
 
@@ -83,23 +129,26 @@ The `tmp/broken-link-reports/` directory is gitignored.
 
 ## Interpreting results
 
-- **broken** (`valid == False`) — needs fixing. Open the HTML report or grep the CSV for the broken URLs, then trace each `parent` page back to the source file in `src/content/`.
-- **warnings** (`valid == True` with a warning string) — usually redirects, slow responses, or 3xx chains. Worth a look but rarely block a deploy. Common cases:
+- **broken** (`valid == False`) — needs fixing. Trace each `parent` page back to the source file in `src/content/`.
+- **warnings** (`valid == True` with a warning string) — usually redirects, slow responses, or 3xx chains. Worth a look but rarely block a merge. Common cases:
   - `301`/`302` from external links — fine, the destination resolved.
   - `429`/timeouts on external hosts (GitHub, social) — flaky, not a real bug.
 - A **clean** run prints `clean.` and writes no rows to the CSV (the file may still exist with only comment headers).
 
+When crawling localhost, broken external links also surface (e.g. a dead `https://example.com` referenced in MDX). Those are still real bugs — the dev server just serves the page that contains them.
+
 ## Triaging broken links
 
-When the script reports broken links, do this:
-
-1. Group the broken rows by `parent` page — one source file often produces several bad outbound links.
-2. For each `parent`, find the source under `src/content/` (`grep -r` for a distinctive slug works).
+1. Group the broken rows by `parent` page — one source file often produces several bad outbound links. The `parent` URL is the localhost one; map it back to the source.
+2. For each `parent`, find the source under `src/content/`:
+   - URL like `http://localhost:4321/docs/foo/bar` → look under `src/content/docs/` for `foo/bar.mdx` (or `foo/bar/index.mdx`).
+   - URL like `http://localhost:4321/blog/foo` → `src/content/blog/foo.mdx`.
+   - When in doubt, `grep -r` for a distinctive slug from the URL.
 3. Decide per link:
    - **Internal link to a moved page** → check `astro.config.mjs` redirects and `src/lib/generated/redirects.json`. If a redirect should exist, add it; otherwise update the link.
    - **External link that 404s** → update or remove. Don't add an unverified replacement.
    - **External link with a transient failure** (timeout, 5xx, 429) → re-run before assuming it's broken.
-4. Re-run the script after fixes to confirm.
+4. Re-run the script (Astro hot-reloads, so no server restart needed) to confirm.
 
 Do not "fix" warnings unless they hide a real problem — chasing every 301 wastes time.
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 .cache-loader
 .astro
 
+# Link checker reports
+/tmp/broken-link-reports/
+
 # Misc
 .DS_Store
 .env.local

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["linkchecker"]
+# ///
+"""check_links - walk the docs site, rattle every doorknob.
+
+Recursively crawls the given URL without leaving the host. External links
+are checked but not followed. Writes timestamped html and csv reports to
+tmp/broken-link-reports/.
+
+usage:
+    uv run scripts/check_links.py                        # crawl http://localhost:4321
+    uv run scripts/check_links.py https://promptless.ai  # crawl production
+
+Or, with linkchecker installed system-wide (`pip install linkchecker`):
+    python scripts/check_links.py [url]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urlparse
+
+# linkchecker CSV columns (first 7 are all we care about; the rest are ignored)
+COLUMNS = ["url", "parent", "base", "result", "warning", "info", "valid"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Crawl a site and report broken links via linkchecker.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "url",
+        nargs="?",
+        default="http://localhost:4321",
+        help="root URL to crawl (default: %(default)s)",
+    )
+    args = parser.parse_args()
+    url: str = args.url
+
+    host = urlparse(url).hostname or "unknown"
+    stamp = datetime.now().strftime("%Y-%b-%d-%a-%H:%M:%S")
+    base = f"broken-link-report_{host}_{stamp}"
+    out_dir = Path("tmp/broken-link-reports")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    html_path = out_dir / f"{base}.html"
+    csv_path = out_dir / f"{base}.csv"
+    print(f"{url} -> {out_dir}/{base}.{{html,csv}}\n")
+
+    cmd = [
+        "linkchecker",
+        url,
+        "--check-extern",
+        "--recursion-level", "-1",
+        "--threads", "10",
+        "--timeout", "30",
+        "--no-robots",
+        "-F", f"html/utf-8/{html_path}",
+        "-F", f"csv/utf-8/{csv_path}",
+    ]
+    subprocess.run(cmd, check=False)
+
+    if not csv_path.exists():
+        return 0
+
+    rows = parse_csv(csv_path)
+    if not rows:
+        print("clean.")
+        return 0
+
+    bad = [r for r in rows if r["valid"] == "False"]
+    warn = [r for r in rows if r["warning"] and r["valid"] == "True"]
+
+    print(f"{len(rows)} checked, {len(bad)} broken, {len(warn)} warnings")
+
+    if bad:
+        print("\nbroken:")
+        print_table(bad, ["url", "parent", "result"])
+    if warn:
+        print("\nwarnings:")
+        print_table(warn, ["url", "parent", "warning"])
+
+    return 0
+
+
+def parse_csv(path: Path) -> list[dict[str, str]]:
+    """linkchecker CSV is semicolon-delimited with `#`-prefixed comment headers."""
+    with path.open(newline="", encoding="utf-8") as f:
+        body = [line for line in f if not line.startswith("#")]
+    if not "".join(body).strip():
+        return []
+    reader = csv.reader(body, delimiter=";")
+    return [dict(zip(COLUMNS, row)) for row in reader if len(row) >= len(COLUMNS)]
+
+
+def print_table(rows: list[dict[str, str]], cols: list[str], max_width: int = 80) -> None:
+    widths = {
+        c: min(max(len(c), max(len(r.get(c, "")) for r in rows)), max_width)
+        for c in cols
+    }
+    fmt = "  ".join(f"{{:<{widths[c]}}}" for c in cols)
+    print(fmt.format(*cols))
+    print(fmt.format(*("-" * widths[c] for c in cols)))
+    for r in rows:
+        print(fmt.format(*(truncate(r.get(c, ""), widths[c]) for c in cols)))
+
+
+def truncate(s: str, width: int) -> str:
+    return s if len(s) <= width else s[: width - 1] + "…"
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
I made this link checker script for the purposes of testing out that Promptless will load customer agent skills inside doc collections and use them reliably.

This link checking skill can be improved but right now I'm just trying to get promptless to invoke the skill at all, not actually make progress or troubleshoot problematic skills.

## Summary
- New `scripts/check_links.py` — self-contained Python wrapper around `linkchecker`. Uses PEP 723 inline script metadata so `uv run scripts/check_links.py` fetches `linkchecker` on demand (no global install). Falls back to plain `python` if `linkchecker` is installed system-wide. Defaults to `http://localhost:4321`; pass `https://promptless.ai` for production audits.
- New `.claude/skills/check-broken-links/SKILL.md` — describes when to trigger the crawl (broken-link audits, post-redirect/reorg checks, 404 investigations), how to run it locally vs. production, and a triage flow for mapping bad rows back to source files in `src/content/`.
- Timestamped html + csv reports land in `tmp/broken-link-reports/` (added to `.gitignore`).

Adapted from the equivalent `bin/check_links` tool in the mono-repo, swapped from Nu+uvx to Python so it fits the rest of `scripts/` and doesn't require Nushell.

## Test plan
- [ ] `uv run scripts/check_links.py --help` prints usage
- [ ] `npm run dev` in one shell, `uv run scripts/check_links.py` in another — confirm a crawl runs and reports land in `tmp/broken-link-reports/`
- [ ] Invoke the skill via `/check-broken-links` (or natural-language trigger) and confirm Claude runs the script