### PR TITLE
content: What Your Docs Are Actually Teaching Developers

### DIFF
--- a/src/content/blog/technical/what-your-docs-are-actually-teaching-developers.mdx
+++ b/src/content/blog/technical/what-your-docs-are-actually-teaching-developers.mdx
@@ -1,0 +1,75 @@
+---
+title: 'What Your Docs Are Actually Teaching Developers'
+subtitle: Published June 2026
+description: >-
+  Documentation is the primary developer education channel for API products. When it goes stale, it teaches wrong patterns to every developer who follows it.
+date: '2026-06-03T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+When a developer opens your quickstart guide, they are not looking up a reference. They are trying to learn how your product works. They want to understand the right integration pattern, what parameters to pass, and what to do when the auth token expires. For most developers, that quickstart and your API reference are their entire education program for your product.
+
+Most companies don't treat it that way.
+
+## The channel developers actually use
+
+The developer relations industry runs on conferences, webinars, community forums, and technical blog posts. Companies invest substantial resources in developer advocates who speak at events, produce video walkthroughs, and build sample apps. Most developers at scale never interact with any of it.
+
+According to the [Postman 2025 State of the API report](https://www.postman.com/state-of-api/2025/), over 80% of developers say clear documentation heavily influences their decision to adopt an API. [SlashData's developer research](https://slashdata.co) found that 47-65% of senior developers specifically cite better docs and code samples as the top indicator of API quality. Developers don't rate APIs by the conference talks their team gave. They rate them by whether the docs got them to a working integration.
+
+Documentation is the education channel. The other DevRel programs are marketing.
+
+This distinction matters because education requires maintenance and marketing doesn't. A conference talk from six months ago is still a good conference talk. A quickstart guide from six months ago may now be teaching the wrong authentication flow.
+
+## What the docs are actually teaching
+
+Every code sample in your documentation teaches a pattern. Every authentication guide teaches the correct way to handle tokens. When that material goes stale, those lessons become wrong.
+
+A developer following your quickstart hits a 401 error your docs don't explain. She spends 45 minutes debugging before finding a GitHub issue that explains the token format changed in version 1.4. She's just learned your product the hard way, from a GitHub issue instead of from you. The lesson she takes isn't just the correct auth flow. It's that your documentation can't be trusted.
+
+[Postman's 2024 State of the API report](https://www.postman.com/state-of-api/2024) found that 68% of developers cite outdated documentation as their top frustration. Research compiled by [Zuplo](https://zuplo.com/blog/2025/03/12/leverage-api-documentation-for-faster-onboarding) estimates that around 50% of developers abandon an API when documentation fails them. Most of them don't file a support ticket. They leave, and the lesson they carry is that your product was unreliable.
+
+<BlogNewsletterCTA />
+
+## The miseducation problem
+
+Outdated documentation teaches incorrect things. That's a worse outcome than missing documentation.
+
+A developer following a tutorial that uses a deprecated method learns the wrong integration pattern. She builds on it. She ships it. Six months later, when the deprecated method is removed, she has a production system built on something she learned from your docs. Your documentation was her education, and it educated her incorrectly.
+
+Missing documentation frustrates developers in the moment. Wrong documentation corrupts the mental model they carry forward. Fixing the tutorial after the fact doesn't reach the developers who already built against the stale pattern.
+
+A [DEV Community analysis of developer-first documentation](https://dev.to/teamcamp/developer-first-documentation-why-73-of-teams-fail-and-how-to-build-docs-that-actually-get-used-36fb) found that 73% of teams fail at developer-first documentation. The failures aren't typically missing pages. They're accumulated drift between what the documentation teaches and what the product currently does.
+
+## AI has amplified the stakes
+
+In 2026, developers don't read documentation in isolation. They paste quickstart guides into Cursor, GitHub Copilot, and other AI coding tools and ask them to scaffold the integration. These tools ingest your documentation literally.
+
+A developer working around a stale code sample can usually figure out what changed. She recognizes the pattern is deprecated, checks the changelog, and adapts. An AI coding assistant following your quickstart reproduces the deprecated pattern exactly and generates broken code. The developer then debugs the AI's output, traces the error back to your docs, and hits the same miseducation problem with an extra layer of confusion.
+
+Beyond individual workflows, LLMs trained on or retrieval-augmented with your documentation carry your stale patterns into every response they give. When your docs teach the old authentication method, every AI assistant that ingests them propagates that method to every developer who asks. The miseducation scales beyond your own documentation surface.
+
+As [documentation drift detection](https://promptless.ai/blog/technical/documentation-drift-detection-problem) has become an infrastructure concern, stale docs have gone from a developer experience problem to an accuracy-at-scale problem.
+
+## Treating docs as a curriculum
+
+Education programs have maintenance schedules. Documentation, in most organizations, has a publication date and no scheduled review.
+
+The reason is classification. Documentation is treated as reference material: write it, publish it, update it when someone notices the gap. A curriculum is reviewed when the underlying material changes. The gap between these two approaches is exactly where miseducation accumulates.
+
+The organizational failure pattern is specific: documentation has a publishing owner and no maintenance owner. Code review flags when a PR changes an API endpoint. Nothing flags that the documentation for that endpoint now teaches the wrong pattern. The change ships. The tutorial stays wrong until a developer reports it, or until someone happens to notice.
+
+Connecting documentation to the code review cycle closes this gap. When a PR changes an API endpoint, the pages covering that endpoint should surface in that review cycle, not later when a developer hits the stale version. When a parameter is renamed, the tutorials using the old name should be flagged before they teach the next developer the wrong thing.
+
+This is what [keeping documentation synchronized with an actively shipping product](https://promptless.ai/blog/technical/how-teams-keep-docs-up-to-date-with-promptless) actually requires: a detection layer that surfaces what has drifted, so the maintenance work is scoped rather than open-ended.
+
+If your product ships every two weeks, your developer education program updates on a two-week cycle by default. The question is whether your documentation maintenance catches up on the same schedule.
+
+[Promptless](https://promptless.ai) monitors documentation against the actual product and codebase, flagging drift from current product behavior before developers learn the wrong thing from it.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer education`

## Article plan

**Thesis:** Documentation is the primary developer education channel for API products, and stale docs don't just fail to educate — they miseducate, teaching wrong patterns that persist in production systems.

**Target reader:** DevRel engineers, technical writers, developer advocates at companies with API/SDK products

**Key points:**
1. Most developer learning happens through docs, not through DevRel webinars or conferences (Postman: 80% docs-driven adoption; SlashData: 47-65% senior devs cite docs as top API quality signal)
2. Stale docs teach incorrect patterns — not just missing information, but actively wrong information that developers build on
3. The miseducation compounds: wrong patterns get shipped into production, and fixing the tutorial later doesn't reach those developers
4. AI coding tools have amplified the stakes — they reproduce stale patterns exactly and propagate them at scale
5. The root cause is organizational: docs have a publishing owner but no maintenance owner; treating docs as a curriculum requires a maintenance cycle

**Promptless connection:** Promptless detects when product changes have made documentation inaccurate — keeping the developer education channel teaching the right things.

## File

`src/content/blog/technical/what-your-docs-are-actually-teaching-developers.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxqFC6eQ5mwik1RLcRXhZV)_