### PR TITLE
Add content strategy (audiences, personas, CUJs, proposed Docs IA)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @prithvi2206 @frances720 @mattlink @adit-chandra @hawkeyexl
+
+# Docs content
+/src/content/docs/docs/ @hawkeyexl

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ yarn-debug.log*
 yarn-error.log*
 .vercel
 .env
+
+# Customer call evidence (digests of Fathom transcripts) — do not commit
+docs/content_strategy/_evidence/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ a file in `docs/`, update this map.
 docs/
 +-- README.md           # Meta-docs: how to maintain the docs/ folder
 +-- analytics.md        # PostHog setup, event catalog, tracking gaps and recommendations
++-- content_strategy/   # Audience/persona/CUJ/IA strategy (see "Docs & Audience Strategy" below)
 ```
 
 ## Project Structure
@@ -74,14 +75,17 @@ Each `.mmd` file supports optional rendering directives in comments at the top:
 %% mmdc-height: 600
 ```
 
-## Good Docs Project Templates
+## Docs & Audience Strategy
 
-The Good Docs Project template bundle is stored at:
+Audience, persona, journey (CUJ), and proposed Docs-tab IA definitions live in
+`docs/content_strategy/` (internal; not built into the site). Read the relevant file on demand —
+do not inline. Derived from customer/prospect call evidence.
 
-`meta/reference/good-docs-project-template-1.5.0/`
+- `docs/content_strategy/README.md` — index + how the IDs link (start here)
+- `docs/content_strategy/audiences/` — 6 target segments (`aud-*`), incl. a cross-cutting brownfield segment
+- `docs/content_strategy/personas/` — 1 minimal persona per audience (`persona-*`)
+- `docs/content_strategy/journeys/` — 16 critical user journeys (`cuj-*`), steps → `/docs/...`
+- `docs/content_strategy/information_architecture/` — CUJ-driven Docs-tab IA + gap analysis
 
-Use these files as read-only reference material when planning documentation information architecture, page types, explanation flow, templates, and writing patterns.
-
-Do not edit, rewrite, reformat, rename, delete, or regenerate files under `meta/reference/good-docs-project-template-1.5.0/` unless the user explicitly asks to update the vendored template bundle itself.
-
-When applying recommendations from the templates, make changes in the Promptless documentation source files instead, such as files under `src/content/docs/`.
+When planning docs IA, page types, or content priorities, consult `proposed-ia.md` and
+`ia-gap-analysis.md`, and make actual content changes under `src/content/docs/`.

--- a/docs/content_strategy/README.md
+++ b/docs/content_strategy/README.md
@@ -1,0 +1,56 @@
+# Docs & Audience Strategy (`docs/content_strategy/`)
+
+**Scope:** Versioned, agent-readable strategy artifacts for Promptless — **who we serve**
+(audiences), **as whom** (personas), **to do what** (critical user journeys), and **how the
+Docs tab should be organized** to serve them (information architecture). These are internal
+working docs; they live under `docs/content_strategy/` (repo-root `docs/` is internal meta-docs, not the published Starlight docs in `src/content/docs/`) and are **not** built into the
+site.
+
+Derived bottom-up from customer and prospect interviews. Only the synthesized, **anonymized**
+strategy is published here — no customer names or source-call references.
+
+## Layout
+
+| Folder | What's in it | Start at |
+|--------|--------------|----------|
+| [`audiences/`](audiences/_overview.md) | 6 target segments + overview | `_overview.md` |
+| [`personas/`](personas/_overview.md) | 1 minimal persona per audience | `_overview.md` |
+| [`journeys/`](journeys/_overview.md) | 16 critical user journeys (CUJs) | `_overview.md` |
+| [`information_architecture/`](information_architecture/proposed-ia.md) | Proposed Docs-tab IA + gap analysis | `proposed-ia.md` |
+
+## How the pieces link (terminology anchors)
+
+IDs are stable cross-reference anchors; follow them between files:
+
+```
+audience (aud-*) ──< persona (persona-*) ──< journey (cuj-*) ──> doc touchpoint (/docs/...)
+                                                       │
+                                          proposed-ia.md organizes those touchpoints
+                                          ia-gap-analysis.md flags the missing ones
+```
+
+- Each **persona** names its `audience`; each **CUJ** names its `personas` and maps `steps`
+  to real `/docs/...` routes (or flags `[GAP]`/`exists: false`).
+- The **IA** is built from the CUJs, scoped to the **Docs tab only** (`src/content/docs/docs/`).
+
+## Headline findings
+
+- **Six audiences**: five split by *who owns docs × company maturity* (enterprise docs team,
+  scale-up/solo writer — the largest segment, engineer-owned, OSS maintainer, DevRel/DevEx),
+  plus a cross-cutting **brownfield** audience defined by the state of a large existing corpus.
+- **Universal job:** "tell me what changed that needs docs, and draft it." Reactive change
+  discovery is the shared pain.
+- **Pilots are won or lost at calibration** (noise / volume / release-timing) and at the
+  **review queue** (who clears it). The IA promotes both to top-level.
+- **Biggest content gaps** (see [gap analysis](information_architecture/ia-gap-analysis.md)):
+  noise/timing tuning, connection-health troubleshooting, auto-assignment, screenshot depth,
+  migration guides, multi-repo/versioned routing, localization, agent-friendliness, reporting.
+
+## Maintaining this
+
+- **Refresh from new interviews:** update the affected audience/persona/journey files as you
+  learn more. Keep all findings **anonymized** — no customer names or source-call references in
+  these published files.
+- **Keep IDs stable** — they're referenced across files and from `AGENTS.md`.
+- **Keep frontmatter assertion-dense** (e.g. CUJ `steps[].doc` routes) so it can later be
+  link-checked against `src/content/docs/`.

--- a/docs/content_strategy/audiences/_overview.md
+++ b/docs/content_strategy/audiences/_overview.md
@@ -17,7 +17,7 @@ audiences:
 audience has its own file in this directory. Audiences were derived bottom-up from
 digested customer and prospect calls, not from assumption. Personas
 (`../personas/`), journeys (`../journeys/`), and the proposed Docs IA
-(`../information_architecture/`) all trace back to these five segments.
+(`../information_architecture/`) all trace back to these six segments.
 
 **It does NOT cover:** marketing positioning, pricing tiers, or competitive analysis.
 

--- a/docs/content_strategy/audiences/_overview.md
+++ b/docs/content_strategy/audiences/_overview.md
@@ -1,0 +1,64 @@
+---
+id: audiences-overview
+type: overview
+scope: Target audiences for Promptless, derived from customer & prospect calls (Dec 2025–Jun 2026)
+audiences:
+  - aud-enterprise-docs-team
+  - aud-scaleup-docs-team
+  - aud-engineer-owned-docs
+  - aud-oss-maintainer
+  - aud-devrel-devex
+  - aud-brownfield-docs-team
+---
+
+# Audiences — Overview
+
+**Scope:** This file indexes the target audiences for Promptless and how they relate. Each
+audience has its own file in this directory. Audiences were derived bottom-up from
+digested customer and prospect calls, not from assumption. Personas
+(`../personas/`), journeys (`../journeys/`), and the proposed Docs IA
+(`../information_architecture/`) all trace back to these five segments.
+
+**It does NOT cover:** marketing positioning, pricing tiers, or competitive analysis.
+
+## The organizing axis
+
+The first five audiences are segmented by the question that most predicts needs, pains, and
+buying process: **who owns customer-facing docs, and at what company maturity.** Tooling stack,
+team size, security posture, and dominant pain all fall out of that axis. The sixth audience
+([aud-brownfield-docs-team](brownfield-docs-team.md)) is a deliberate exception: a
+**corpus-state lens** that cuts *across* the others (a brownfield doc set can belong to an
+enterprise or an outgrown scale-up). Use it when the state of the existing corpus — not team
+size or ownership — is the defining problem.
+
+| ID | Audience | Who owns docs | Defining tension |
+|----|----------|---------------|------------------|
+| [aud-enterprise-docs-team](enterprise-docs-team.md) | Enterprise documentation team | Established team (3–50 writers), often w/ docs-ops & localization | Many products × many eng teams × release timing; security/procurement gauntlet |
+| [aud-scaleup-docs-team](scaleup-docs-team.md) | Scale-up / high-growth docs team | 1–3 writers (often solo), docs-as-code | One writer can't keep pace with eng velocity |
+| [aud-engineer-owned-docs](engineer-owned-docs.md) | Engineer-owned docs (no writer) | Engineers / a founder champion | No one owns the queue; docs debt accrues silently |
+| [aud-oss-maintainer](oss-maintainer.md) | OSS project maintainer | Community maintainers (free OSS program) | Contributors skip doc PRs; multi-repo, versioned, multilingual |
+| [aud-devrel-devex](devrel-devex.md) | DevRel / DevEx owner | A developer advocate / DevEx engineer | SDK/API docs must be accurate enough for humans *and* AI agents |
+| [aud-brownfield-docs-team](brownfield-docs-team.md) | Established team w/ brownfield corpus *(cross-cutting)* | Established team / senior writer over a large legacy corpus | Remediate & restructure thousands of stale, inconsistent legacy pages without a rewrite |
+
+## Cross-cutting signal (true across most segments)
+
+- **The core job is the same everywhere:** "tell me what changed that needs docs, and draft
+  the update — so things stop falling through the cracks." Reactive change-discovery is the
+  universal pain.
+- **Screenshots** are the most-requested single capability across paid segments.
+- **Release timing / feature-flag awareness** (don't draft before it ships) is the most
+  common *unsolved* workflow problem.
+- **Access & security approval** (GitHub/GitLab app, repo scoping, SSO, self-host) is the
+  most common *pilot blocker*, and it escalates sharply with company size.
+- **Docs-as-code is a hard prerequisite.** Teams on Word/PDF/CCMS-only (legacy authoring and
+  help-authoring tools, SVN) are poor fits today; many arrive mid-migration off a hosted/legacy
+  docs platform and treat that migration as part of adopting Promptless.
+
+## Notes on scope decisions
+
+- **Support/CX-owned help centers** appear as a *flavor*
+  inside the enterprise and scale-up audiences rather than a sixth segment — the owner's
+  title differs but the journey matches.
+- Excluded from audiences (present in evidence as non-fits or non-buyers): outsourced docs
+  agencies / consulting-deliverable shops, Word/PDF-only teams,
+  recruiting, investor, community/devrel, and vendor-pitch calls.

--- a/docs/content_strategy/audiences/brownfield-docs-team.md
+++ b/docs/content_strategy/audiences/brownfield-docs-team.md
@@ -1,0 +1,83 @@
+---
+id: aud-brownfield-docs-team
+type: audience
+segment: Established docs team with a brownfield doc set
+maturity: established (any company size)
+docs_owner: an established docs team or senior writer responsible for a large, pre-existing corpus
+firmographics: [mature-product, large-existing-corpus, accumulated-doc-debt, legacy-structure-or-tooling, often-enterprise-but-not-always]
+relationship_stages: [prospect, customer]
+personas: [persona-brownfield-docs-lead]
+features_emphasized: [deep-analysis, ia-overhaul, legacy-remediation, standards-enforcement, migration, multi-repo-routing, agent-friendliness]
+underrepresented: true
+---
+
+# Audience: Established docs team with a brownfield doc set
+
+**Scope:** Established documentation teams whose defining challenge is the **state of an
+existing ("brownfield") corpus** — hundreds to thousands of pages accumulated over years, with
+debt, inconsistency, dated structure, or legacy tooling. The work is as much *remediating and
+restructuring what already exists* as keeping up with new change.
+
+**Relationship to other audiences (important):** This audience is a **corpus-state lens**, not
+a company-size lens, so it deliberately **overlaps** [aud-enterprise-docs-team](enterprise-docs-team.md)
+(many large enterprise docs orgs are both enterprise *and* brownfield) and can also describe a
+[aud-scaleup-docs-team](scaleup-docs-team.md) that has outgrown its early docs. Use this file
+when the *brownfield corpus itself* is the problem; use the others when scale, security, or
+team size is the dominant lens.
+
+> **Note on evidence:** This segment is intentionally documented even though it is
+> **under-represented as a dedicated buying motion** in the current call set — most brownfield
+> signal appears *inside* enterprise accounts rather than as its own deal. An enterprise
+> data-platform docs team is the canonical example; supporting signal comes from an enterprise
+> team with a multi-thousand-page corpus (long-tail staleness), a team with legacy base-API
+> gaps, a team doing a capability-based IA rebuild, a team with a template/IA refactor backlog,
+> and a team unifying two divergent legacy processes.
+
+## Who they are
+
+A docs manager or senior technical writer who inherited a large, long-lived doc set. The team
+exists and is competent, but the corpus has outgrown its original structure: topics sprawl,
+content contradicts itself, screenshots and steps are stale across thousands of pages, and the
+information architecture reflects an old product shape. Example: an enterprise data-platform
+docs team (the canonical example) — one of ~12 writers owning a major product area, where
+PM-driven triage misses changes and release-note churn compounds against an already-large
+surface.
+
+## What they're trying to do
+
+Bring a large existing corpus back to health **without a full manual rewrite** — pay down
+debt, fix and consolidate stale/inconsistent pages, retrofit current standards and templates,
+and (often) **restructure the IA** to match the product as it is now — while still keeping up
+with ongoing change.
+
+## Defining pains
+
+- **Long-tail staleness:** in a huge corpus, most pages are quietly out of date and no one can
+  audit them all (one enterprise team's multi-thousand-page corpus; another framed doc debt as
+  "AI-index noise").
+- **Dated / mismatched IA:** the structure reflects an older product; navigation no longer maps
+  to how the product or its users actually work (one team's capability-based rebuild; another's
+  IA refactor).
+- **Inconsistency at scale:** legacy pages are off-style, off-template, and contradictory;
+  divergent processes were never unified (one team's legacy off-style pages; another's two
+  divergent processes).
+- **Legacy structure/tooling drag:** older platforms or hand-maintained structure resist
+  automated upkeep and frequently entangle with a migration ([cuj-migrate-to-docs-as-code](../journeys/cuj-migrate-to-docs-as-code.md)).
+- **Debt vs. throughput tension:** the team must remediate the past *and* keep pace with the
+  present, with the same headcount.
+
+## Buying constraints
+
+- Mirrors [aud-enterprise-docs-team](enterprise-docs-team.md) when the company is large
+  (security/self-host/procurement). The distinct constraint is **trust at scale**: a tool let
+  loose on a brownfield corpus must not flood the team with noise or low-quality edits, or it
+  makes the debt feel worse, not better.
+- Value is judged on **measurable corpus-health gains** (freshness, consistency, coverage), not
+  just go-forward drafting — see [cuj-prove-value](../journeys/cuj-prove-value.md).
+
+## Qualified reader (for docs targeting)
+
+- **Prerequisites they bring:** professional docs-ops and IA literacy; they think in terms of
+  taxonomies, templates, and content models, not just individual pages.
+- **Subject dependencies:** need content-audit/remediation, IA-overhaul, standards-enforcement,
+  Deep Analysis, and migration content to be explicit and scaled to a large existing corpus.

--- a/docs/content_strategy/audiences/devrel-devex.md
+++ b/docs/content_strategy/audiences/devrel-devex.md
@@ -1,0 +1,57 @@
+---
+id: aud-devrel-devex
+type: audience
+segment: DevRel / DevEx owner of developer-facing docs
+maturity: startup-to-enterprise
+docs_owner: a developer advocate or DevEx/DevX engineer who owns docs alongside other duties
+firmographics: [developer-tools, api-first, sdk-heavy, commercial-or-oss]
+relationship_stages: [prospect, customer]
+personas: [persona-devrel-owner]
+features_emphasized: [sdk-api-docs, agent-friendliness, llms-txt, code-example-validation, discoverability, style-enforcement, cross-repo-triggers]
+---
+
+# Audience: DevRel / DevEx owner
+
+**Scope:** Developer-relations or developer-experience owners at API-first / SDK-heavy
+products who own developer docs as *part* of a broader role (advocacy, DevEx tooling,
+technical marketing). Differs from [aud-scaleup-docs-team](scaleup-docs-team.md) in that the
+owner is not a technical writer and optimizes for **developer + AI-agent consumption**, not
+editorial throughput.
+
+## Who they are
+
+DevRel/DevEx engineers and developer advocates at dev-tool companies. Examples span
+error-monitoring, commerce-framework, and AI/LLM-tooling products, plus several smaller
+dev-tool SaaS. They care about the developer journey
+through SDK/API reference and guides, and they're acutely aware that **AI coding agents are
+now a primary docs consumer**.
+
+## What they're trying to do
+
+Keep large, fast-moving SDK/API docs accurate while spending their own time on advocacy and
+DevEx — and make docs **discoverable and trustworthy to AI agents** (so agents recommend and
+correctly implement the product). Several have built a homegrown AI/GitHub-Action docs script
+and want to retire it for something reliable.
+
+## Defining pains
+
+- **Surface area too large to chase:** multi-SDK, multi-language reference goes stale faster
+  than one advocate can track; constant "this is wrong/outdated" feedback.
+- **Accuracy for agents:** docs aren't discoverable or structured for agents (no `llms.txt`);
+  inaccurate reference makes agents implement the SDK wrong.
+- **Homegrown automation is unreliable:** their own scripts take input at face value and
+  produce errors; they want validated accuracy (code-example testing resonates).
+- **Style consistency** across docs and technical marketing copy.
+
+## Buying constraints
+
+- Champion is technical and evaluates on **accuracy and cross-repo trigger fidelity**; light
+  procurement unless inside a larger enterprise.
+- Will benchmark against building it themselves — differentiation must be clear.
+
+## Qualified reader (for docs targeting)
+
+- **Prerequisites they bring:** strong API/SDK and Git fluency; thinks in terms of developer
+  and agent consumers.
+- **Subject dependencies:** need agent-friendliness/`llms.txt`, code-example validation
+  (code-example testing), SDK/API accuracy, and cross-repo triggers documented explicitly.

--- a/docs/content_strategy/audiences/engineer-owned-docs.md
+++ b/docs/content_strategy/audiences/engineer-owned-docs.md
@@ -1,0 +1,57 @@
+---
+id: aud-engineer-owned-docs
+type: audience
+segment: Engineer-owned docs (no dedicated writer)
+maturity: startup-to-midmarket
+docs_owner: engineers, an eng manager, or a founder champion — no technical writer
+firmographics: [startup, midmarket, commercial-saas, docs-as-code, eng-led]
+relationship_stages: [prospect, customer]
+personas: [persona-eng-docs-owner]
+features_emphasized: [pr-drafting, auto-assign, review-queue, deep-analysis, release-notes, screenshots, suggestion-filtering, api-triggers]
+---
+
+# Audience: Engineer-owned docs (no dedicated writer)
+
+**Scope:** Companies where customer-facing docs are owned by engineers, an eng manager, or a
+founder — with **no technical writer at all.** Differs from
+[aud-scaleup-docs-team](scaleup-docs-team.md) (which has at least one writer) by the absence
+of any docs owner whose *job* is docs, and from [aud-oss-maintainer](oss-maintainer.md) by
+being commercial/closed-source.
+
+## Who they are
+
+Engineering-led teams at startups and mid-market SaaS who treat docs as a shared eng
+responsibility. Examples span developer-tools, healthcare, AI, and observability SaaS. The
+champion is usually an engineer or eng manager who feels the docs-debt pain acutely but has
+no time to clear it.
+
+## What they're trying to do
+
+Get customer-facing docs maintained **without hiring a writer** — automate detection,
+drafting, and ideally assignment so the engineering team can approve rather than author.
+
+## Defining pains
+
+- **No one owns the queue.** Suggestions pile up with no clear assignee; docs debt grows
+  silently. They ask for **auto-assignment and an inbox** more than any other segment.
+- **Day-one noise:** turning the tool on against a debt-laden repo produces overwhelming
+  volume; they need internal-vs-external filtering and relevance tuning fast.
+- **Debt paydown:** large mature areas (e.g. integrations) are undocumented; they want
+  **Deep Analysis / one-off batch tasks** to catch up, not just go-forward drafting.
+- **No release-notes process:** changes ship with no changelog; they want notes generated
+  from PRs/Slack.
+- **Editorial nuance gap:** engineers know code PRs lack the "why" and the full feature
+  picture; they're aware quality needs a human pass but want that pass to be cheap.
+
+## Buying constraints
+
+- Low procurement friction; high sensitivity to **signal-to-noise** — if the first batch is
+  noisy, engineers disengage and the queue dies.
+- Internal/private-repo noise filtering and (sometimes) restricting to public repos are
+  common gating concerns.
+
+## Qualified reader (for docs targeting)
+
+- **Prerequisites they bring:** strong Git/CI fluency; weak docs-process/editorial vocabulary.
+- **Subject dependencies:** need the review queue, auto-assignment, noise tuning, Deep
+  Analysis, and release-notes generation explained in engineer terms, assuming no writer.

--- a/docs/content_strategy/audiences/enterprise-docs-team.md
+++ b/docs/content_strategy/audiences/enterprise-docs-team.md
@@ -1,0 +1,62 @@
+---
+id: aud-enterprise-docs-team
+type: audience
+segment: Enterprise documentation team
+maturity: enterprise
+docs_owner: established docs team (3–50 writers), often with docs-ops, tooling, and localization functions
+firmographics: [enterprise, multi-product, multi-repo, regulated/security-sensitive, procurement-driven]
+relationship_stages: [prospect, customer]
+personas: [persona-enterprise-docs-lead]
+features_emphasized: [release-timing, screenshots, self-hosting, sso, multi-repo-routing, localization, deep-analysis, security-review, api]
+---
+
+# Audience: Enterprise documentation team
+
+**Scope:** Established documentation organizations at large/enterprise companies evaluating or
+using Promptless across many products and engineering teams. Covers their structure, pains,
+and buying constraints. Does **not** cover small/solo writer teams (see
+[aud-scaleup-docs-team](scaleup-docs-team.md)) or engineer-owned docs (see
+[aud-engineer-owned-docs](engineer-owned-docs.md)).
+
+## Who they are
+
+A dedicated docs function — a manager or director plus several to dozens of technical
+writers, sometimes with separate docs-ops, content-strategy, and localization roles. They own
+a large, mature corpus (hundreds to thousands of pages) spanning many products, shipped by
+many autonomous engineering teams on independent release cadences. Examples in evidence span
+large enterprise docs orgs (one with ~50 writers; another with 8+ writers across many GitHub
+orgs; teams with multi-thousand-page corpora) across many products and industries — including
+data-platform, networking, developer-tools, and security/compliance-driven companies.
+
+## What they're trying to do
+
+Keep a sprawling corpus accurate as dozens of teams ship continuously, **without adding
+headcount** — and increasingly, prove the docs team's efficiency/ROI to leadership. Several
+arrive having already tried an in-house AI pilot that underwhelmed (hallucination, low trust),
+so they scrutinize AI output quality hard.
+
+## Defining pains
+
+- **Change visibility at scale:** "We can't tell what changed across 20+ products and 6+ orgs
+  that needs docs." Knowing *when* and *what* is the core problem, not writing speed.
+- **Release timing / feature flags:** drafting must not fire before a feature actually ships.
+- **Understaffing:** e.g. one team reported writers at ~8% of engineering headcount.
+- **Legacy tooling & migrations:** DITA/CCMS stacks, help-authoring tools (sometimes in
+  gov/FedRAMP contexts), or hosted docs platforms (including ones whose support degraded
+  post-acquisition) — migration is often entangled with adoption.
+- **Trust & governance:** AI "slop," validation/linting of edits, and labeling suggestions to
+  fit the eng release process.
+
+## Buying constraints (what gates a deal)
+
+- **Security & deployment review:** SSO, self-hosting/on-prem, data handling, subprocessors,
+  compliance certifications, network architecture — a formal gauntlet.
+- **Procurement & budget:** multi-stakeholder (IT/portfolio, security, finance, legal). Pilots
+  are sometimes sequenced *behind* a prerequisite (e.g. a CMS migration first).
+
+## Qualified reader (for docs targeting)
+
+- **Prerequisites they bring:** professional docs-ops literacy; familiarity with their own
+  CI/release process; security/compliance vocabulary.
+- **Subject dependencies:** want self-host, SSO, multi-repo routing, and security docs to be
+  thorough and standalone enough to forward to IT/security reviewers.

--- a/docs/content_strategy/audiences/oss-maintainer.md
+++ b/docs/content_strategy/audiences/oss-maintainer.md
@@ -1,0 +1,56 @@
+---
+id: aud-oss-maintainer
+type: audience
+segment: OSS project maintainer (free OSS program)
+maturity: community/foundation
+docs_owner: community maintainers and contributors; sometimes a volunteer docs lead
+firmographics: [open-source, multi-repo, versioned-docs, multilingual, cloud-native-foundation-adjacent, free-oss-program]
+relationship_stages: [prospect, customer]
+personas: [persona-oss-maintainer]
+features_emphasized: [oss-program, read-only-app, multi-repo-routing, versioned-docs, localization, code-example-validation, agent-friendliness]
+---
+
+# Audience: OSS project maintainer
+
+**Scope:** Open-source project maintainers using (or evaluating) Promptless's **free OSS
+program**. Covers community/foundation projects, often cloud-native-foundation-adjacent. Differs from
+[aud-engineer-owned-docs](engineer-owned-docs.md) by being open-source, community-governed,
+and on the free program rather than a commercial deal.
+
+## Who they are
+
+Maintainers and core contributors of OSS projects who also carry the docs burden. Examples
+span cloud-native / Kubernetes-adjacent projects, marketing-automation and data-infrastructure
+projects, a large research-organization project, and open-core security projects. Some have
+a volunteer docs/education lead; most rely on whoever shows up.
+
+## What they're trying to do
+
+Keep project docs accurate and complete as the codebase moves fast and **contributors skip
+doc PRs** — so maintainers can spend time on higher-value work. For SDK/protocol projects,
+they also want docs accurate enough that **AI coding agents recommend and correctly implement
+the project**.
+
+## Defining pains
+
+- **Contributors don't write docs.** Code merges; docs lag. The maintainer backfills.
+- **Multi-repo, multi-version routing:** changes must land in the right repo and the right
+  versioned docs set; mapping versions is fiddly.
+- **Localization / i18n:** translations run months behind across project locales.
+- **Backfill of gaps:** docs are thin, scattered, or low-reliability and need catch-up.
+- **Sync between OSS and commercial docs:** for open-core projects, changes in the OSS layer
+  must propagate into premium docs.
+
+## Buying constraints
+
+- **Free program**, so no procurement — but adoption needs a **read-only GitHub app** and
+  comfort granting access to public repos; governance is diffuse (no single decision-maker).
+- Strategic value to Promptless is brand/community and reference logos (high-profile cloud-native projects), not
+  revenue.
+
+## Qualified reader (for docs targeting)
+
+- **Prerequisites they bring:** deep Git/OSS workflow fluency; multi-repo and versioning
+  literacy.
+- **Subject dependencies:** need OSS-program onboarding, read-only app setup, multi-repo +
+  versioned-docs routing, localization, and code-example validation documented explicitly.

--- a/docs/content_strategy/audiences/scaleup-docs-team.md
+++ b/docs/content_strategy/audiences/scaleup-docs-team.md
@@ -1,0 +1,60 @@
+---
+id: aud-scaleup-docs-team
+type: audience
+segment: Scale-up / high-growth docs team (small or solo)
+maturity: startup-to-scaleup
+docs_owner: 1–3 technical writers, frequently a single "team of one"; sometimes reporting into product, support, or eng
+firmographics: [high-growth-startup, scaleup, docs-as-code, fast-release-cadence, commercial-saas]
+relationship_stages: [prospect, customer]
+personas: [persona-scaleup-solo-writer]
+features_emphasized: [pr-drafting, screenshots, triggers, change-detection, notifications, review-queue, migration-to-docs-as-code]
+---
+
+# Audience: Scale-up / high-growth docs team
+
+**Scope:** Small documentation teams — very often a single writer — at fast-moving commercial
+SaaS companies on a docs-as-code stack. This is the **largest and highest-intent segment** in
+the evidence. Does **not** cover enterprise docs orgs (see
+[aud-enterprise-docs-team](enterprise-docs-team.md)) or teams with no writer at all (see
+[aud-engineer-owned-docs](engineer-owned-docs.md)).
+
+## Who they are
+
+The "team of one" (or two-to-three) technical writer at a high-growth startup/scale-up.
+Examples span commercial SaaS companies across developer-tools, infrastructure, fintech,
+data, and analytics. They already work docs-as-code on a modern static-site stack (or are
+migrating toward it) or are the person pushing the org there. They frequently report into
+product, support/CX, or engineering rather than a docs org.
+
+## What they're trying to do
+
+Keep customer-facing docs current against an engineering team shipping far faster than one
+person can track — and stop being purely reactive. Many also want to **demonstrate their own
+leverage** to leadership before headcount is approved (or to justify their role as the team
+automates around them).
+
+## Defining pains
+
+- **"I'm underwater / things fall through the cracks."** The single most common sentence in
+  the corpus. One writer cannot watch every PR, release, and channel.
+- **Reactive change discovery:** no reliable signal of *what shipped that needs docs.*
+- **Screenshot maintenance:** repeated manual recapture on every UI/label change.
+- **Setup & access friction:** expired GitLab tokens, repo scoping, IT/security sign-off can
+  stall or silently break the pilot.
+- **Tooling lock-in / migration:** many are mid-move off a hosted/legacy docs platform (often
+  after a vendor acquisition degraded support) and want docs-as-code + AI in one move.
+
+## Buying constraints
+
+- Light procurement; the writer is often the champion *and* the evaluator. Deals turn on
+  **fast time-to-first-useful-suggestion** and visible quality, not on security review (though
+  GitLab/self-host and read-only access still come up).
+- Champion risk: when the sole writer leaves, continuity depends on whether eng/product can
+  pick up the queue.
+
+## Qualified reader (for docs targeting)
+
+- **Prerequisites they bring:** comfortable with Git/PRs, Markdown, and their docs SSG; little
+  patience for heavy setup.
+- **Subject dependencies:** need fast getting-started, trigger/context-source setup, the
+  review/triage loop, and screenshots to be self-serve and quick.

--- a/docs/content_strategy/information_architecture/ia-gap-analysis.md
+++ b/docs/content_strategy/information_architecture/ia-gap-analysis.md
@@ -24,16 +24,16 @@ This gap list is the intended deliverable — it shows where docs must grow to s
 | getting-started/setup-quickstart | Start here → Quickstart |
 | getting-started/promptless-oss | Start here → Open-source quickstart |
 | getting-started/getting-help | Reference & help → Getting help |
-| integrations/github · github-enterprise · bitbucket | Connect your stack → Source control |
+| integrations/github-integration · github-enterprise-integration · bitbucket-integration | Connect your stack → Source control |
 | configuring-promptless/triggers/* | Connect your stack → Triggers |
-| configuring-promptless/context-sources/* · integrations/atlassian · linear | Connect your stack → Context sources |
+| configuring-promptless/context-sources/* · integrations/atlassian-integration · linear-integration | Connect your stack → Context sources |
 | configuring-promptless/doc-collections/git-hub-repos-docs-as-code · how-promptless-learns-your-docs | Connect your stack → Doc locations & collections |
 | configuring-promptless/customizing-notifications | Tune → Notifications |
 | integrations/launchdarkly-integration-beta | Tune → Release timing & feature flags |
 | how-to-use-promptless/providing-feedback | Tune → Teaching conventions (also Work the queue) |
 | how-to-use-promptless/using-the-web-interface | Work the queue → web interface / inbox |
-| how-to-use-promptless/interacting-with-promptless-prs | Work the queue → Reviewing & editing PRs |
-| how-to-use-promptless/working-with-slack · integrations/slack · microsoft-teams · intercom-beta | Work the queue → Slack/Teams (+ Connect → Triggers) |
+| how-to-use-promptless/interacting-with-promptless-p-rs | Work the queue → Reviewing & editing PRs |
+| how-to-use-promptless/working-with-slack · integrations/slack-integration · microsoft-teams-integration · intercom-integration-beta | Work the queue → Slack/Teams (+ Connect → Triggers) |
 | how-to-use-promptless/using-promptless-capture | Get the most out of → Screenshots |
 | how-to-use-promptless/deep-analysis | Get the most out of → Deep Analysis |
 | configuring-promptless/doc-collections/doc-detective-integration | Get the most out of → Agent-friendly docs |
@@ -42,8 +42,8 @@ This gap list is the intended deliverable — it shows where docs must grow to s
 | security-and-privacy/* | Security & deployment |
 | self-hosting · self-hosting/kubernetes-helm | Security & deployment → Self-hosting |
 | integrations/* (full set) | Reference & help → Integrations reference |
-| frequently-asked-questions | Reference & help → FAQ |
-| account-management | Reference & help → Account management |
+| frequently-asked-questions/frequently-asked-questions | Reference & help → FAQ |
+| account-management/account-management | Reference & help → Account management |
 
 ## 2. `[NEW]` — content the CUJs require that does not exist
 

--- a/docs/content_strategy/information_architecture/ia-gap-analysis.md
+++ b/docs/content_strategy/information_architecture/ia-gap-analysis.md
@@ -1,0 +1,90 @@
+---
+id: ia-gap-analysis
+type: information-architecture
+scope: Gaps between the CUJ-driven proposed Docs IA and current src/content/docs/docs/
+covers_nav_tab: docs
+companion: proposed-ia.md
+current_source: src/content/docs/docs/
+---
+
+# IA Gap Analysis — Docs tab
+
+**Scope:** Compares the [CUJ-driven proposed IA](proposed-ia.md) against the **current** Docs-tab
+content in `src/content/docs/docs/`. Two outputs: (1) content the journeys require that **does
+not exist** (`[NEW]`), and (2) current pages that **map to no CUJ** (review for prune/keep).
+This gap list is the intended deliverable — it shows where docs must grow to serve real users.
+
+## 1. Current → proposed mapping (existing pages keep a home)
+
+| Current page (under `/docs/`) | Proposed section |
+|---|---|
+| getting-started/welcome | Start here → Welcome |
+| getting-started/core-concepts · core-concepts/* | Start here → How Promptless works |
+| getting-started/pilot-overview | Start here → Run a pilot |
+| getting-started/setup-quickstart | Start here → Quickstart |
+| getting-started/promptless-oss | Start here → Open-source quickstart |
+| getting-started/getting-help | Reference & help → Getting help |
+| integrations/github · github-enterprise · bitbucket | Connect your stack → Source control |
+| configuring-promptless/triggers/* | Connect your stack → Triggers |
+| configuring-promptless/context-sources/* · integrations/atlassian · linear | Connect your stack → Context sources |
+| configuring-promptless/doc-collections/git-hub-repos-docs-as-code · how-promptless-learns-your-docs | Connect your stack → Doc locations & collections |
+| configuring-promptless/customizing-notifications | Tune → Notifications |
+| integrations/launchdarkly-integration-beta | Tune → Release timing & feature flags |
+| how-to-use-promptless/providing-feedback | Tune → Teaching conventions (also Work the queue) |
+| how-to-use-promptless/using-the-web-interface | Work the queue → web interface / inbox |
+| how-to-use-promptless/interacting-with-promptless-prs | Work the queue → Reviewing & editing PRs |
+| how-to-use-promptless/working-with-slack · integrations/slack · microsoft-teams · intercom-beta | Work the queue → Slack/Teams (+ Connect → Triggers) |
+| how-to-use-promptless/using-promptless-capture | Get the most out of → Screenshots |
+| how-to-use-promptless/deep-analysis | Get the most out of → Deep Analysis |
+| configuring-promptless/doc-collections/doc-detective-integration | Get the most out of → Agent-friendly docs |
+| how-to-use-promptless/agent-knowledge-base | Get the most out of → Agent knowledge base |
+| how-to-use-promptless/managing-environment-variables | Scale across teams → Env variables |
+| security-and-privacy/* | Security & deployment |
+| self-hosting · self-hosting/kubernetes-helm | Security & deployment → Self-hosting |
+| integrations/* (full set) | Reference & help → Integrations reference |
+| frequently-asked-questions | Reference & help → FAQ |
+| account-management | Reference & help → Account management |
+
+## 2. `[NEW]` — content the CUJs require that does not exist
+
+Ordered by leverage (impact on pilot success / deals × frequency in the corpus).
+
+| Gap (new page/area) | Serves CUJ | Why it matters (evidence) | Priority |
+|---|---|---|---|
+| **Noise & relevance filtering** | calibrate-suggestions | Pilots die on day-one noise; suppress internal-only/self-evident changes (multiple customers) | P0 |
+| **Release timing & feature flags** (general model, not just feature-flag integrations) | calibrate-suggestions, release-notes | Most-cited unsolved workflow: map release stage → suggestion status; "drafted too early" (multiple customers) | P0 |
+| **Connection health & troubleshooting** | connect-sources | Silent token/auth failures produce zero suggestions and kill pilots invisibly (a customer) | P0 |
+| **Assignment & routing (auto-assign)** | triage-review-queue | #1 ask of engineer-owned teams; "no one owns the queue" (multiple customers) | P0 |
+| **Screenshot depth: auth-to-target, firewalled/test envs, annotations** | screenshots | Top requested capability; concrete blockers stall pilots (auth flows for one, firewall/color for another) | P0 |
+| **Migrate to docs-as-code** (platform choice + per-source guides + redirects) | migrate-to-docs-as-code | Gates many deals; teams stuck on Doc360/ReadMe/Fern/HubSpot/RoboHelp | P1 |
+| **Multi-repo routing** | multi-repo-routing | Routing bugs across orgs/collections erode trust (one customer; another with 6+ orgs) | P1 |
+| **Versioned docs** | multi-repo-routing | Map changes to correct version set (parallel major versions; enterprise parallel versions) | P1 |
+| **Access & permissions (read-only/least-privilege posture)** | connect-sources, enterprise-security-review | Recurring security/IT gating; ties access scope to the security story | P1 |
+| **Release notes & changelogs** | release-notes | No release-notes process is common; explicit demand (multiple customers) | P1 |
+| **Localization** (locale modeling, propagation, TMS/Phrase) | localization | Translations years behind (OSS projects); TMS hook (an enterprise team) | P2 |
+| **Agent-friendly docs: llms.txt + SDK/API accuracy** | agent-friendly-docs | Agents are now primary consumers (multiple customers); forward-looking | P2 |
+| **Reporting & ROI** | prove-value | Value-proof gates expansion & champion's role (multiple customers; one cited ~40% of doc PRs) | P2 |
+| **Content audit (surface stale/inconsistent existing pages)** | remediate-legacy-content, overhaul-ia | Long-tail staleness no one can audit by hand (one enterprise's ~4k pages; another's debt-as-noise) | P2 |
+| **Remediate existing pages at scale** (update/consolidate, distinct from gap backfill) | remediate-legacy-content | Brownfield corpora full of stale/duplicate pages (multiple customers) | P2 |
+| **Standards & template enforcement across legacy content** | remediate-legacy-content | Off-style/off-template legacy; unify divergent processes (multiple customers) | P2 |
+| **Restructure / IA-overhaul guidance** (content map, target IA, move/merge, redirects) | overhaul-ia | Capability-based IA rebuilds & refactor backlogs (one customer's "v3.0", another's refactor) | P2 |
+| **Pilot success rubric** (exit metrics) | evaluate-pilot | Enterprises want a crisp definition of pilot success | P2 |
+| **OSS read-only install path** (vs commercial install) | oss-onboarding | Public-repo read-only flow under-documented | P2 |
+
+## 3. Current pages that map to no CUJ (review)
+
+| Page | Disposition |
+|---|---|
+| getting-started/promptless-1-0 | Version/launch note — likely **move to Changelog** or fold into "How Promptless works"; not a journey page. |
+| getting-started/core-concepts **and** core-concepts/* **and** how-to-use-promptless.mdx (+ section landing pages) | **Duplication**: concepts appear under both `getting-started/` and `core-concepts/`. Consolidate into one "How Promptless works" home. |
+| integrations.mdx / how-to-use-promptless.mdx / configuring-promptless landing pages | Section landing pages — keep as section indexes in the new structure, but re-home. |
+
+## 4. Notes
+
+- The proposed IA is intentionally more **journey-shaped** than the current
+  concept/configure/how-to split. The biggest single change is promoting **calibration** and
+  the **review queue** to top-level — the two areas the corpus shows decide retention.
+- Nothing here changes nav code or content. Implementing it would mean creating the `[NEW]`
+  pages, consolidating the concepts duplication, and updating
+  [site-navigation.ts](../../../src/lib/site-navigation.ts) + the generated sidebar — a separate
+  effort.

--- a/docs/content_strategy/information_architecture/proposed-ia.md
+++ b/docs/content_strategy/information_architecture/proposed-ia.md
@@ -15,7 +15,7 @@ companion: ia-gap-analysis.md
 changelog, free-tools, or jobs sections of [site-navigation.ts](../../../src/lib/site-navigation.ts).
 
 **Method — CUJ-first, not content-first.** This IA is designed from the
-[critical user journeys](../journeys/_overview.md) — what the five
+[critical user journeys](../journeys/_overview.md) — what the six
 [personas](../personas/_overview.md) need to *accomplish* — **not** from the topics that
 happen to have pages today. Where a journey needs content that doesn't exist yet, the section
 appears here anyway and is flagged `[NEW]`. The mapping of these gaps to current content is in

--- a/docs/content_strategy/information_architecture/proposed-ia.md
+++ b/docs/content_strategy/information_architecture/proposed-ia.md
@@ -1,0 +1,144 @@
+---
+id: proposed-ia
+type: information-architecture
+scope: Proposed Docs-tab IA (content under src/content/docs/docs/), designed CUJ-first
+covers_nav_tab: docs
+excludes: [website, pricing, blog, changelog, free_tools, jobs]
+derived_from: docs/content_strategy/journeys/
+companion: ia-gap-analysis.md
+---
+
+# Proposed Information Architecture — Docs tab
+
+**Scope:** A proposed structure for the **Docs tab only** (content under
+`src/content/docs/docs/`, served at `/docs`). It does not touch the website, pricing, blog,
+changelog, free-tools, or jobs sections of [site-navigation.ts](../../../src/lib/site-navigation.ts).
+
+**Method — CUJ-first, not content-first.** This IA is designed from the
+[critical user journeys](../journeys/_overview.md) — what the five
+[personas](../personas/_overview.md) need to *accomplish* — **not** from the topics that
+happen to have pages today. Where a journey needs content that doesn't exist yet, the section
+appears here anyway and is flagged `[NEW]`. The mapping of these gaps to current content is in
+[ia-gap-analysis.md](ia-gap-analysis.md). **Surfacing those gaps is the goal of this exercise.**
+
+**Design principles (from the corpus):**
+1. **Follow the backbone journey.** The top-level order mirrors how accounts actually move:
+   start → connect → tune → work the queue → get outcomes → scale → (migrate) → secure →
+   measure. Security runs in parallel for enterprise.
+2. **Lead with the make-or-break steps.** Calibration (noise/timing) and the review queue —
+   where pilots are won or lost — get first-class sections instead of being buried in
+   "configuring" and "how-to."
+3. **Outcome sections, not feature sections.** "Keep screenshots current," "Generate release
+   notes," "Make docs agent-friendly" are jobs users came for; reference detail sits behind them.
+4. **Forwardable security.** Security/deployment is its own standalone tree because non-docs
+   reviewers read it.
+
+## Proposed structure
+
+```
+/docs
+├── Start here                              ← cuj-evaluate-pilot, cuj-oss-onboarding
+│   ├── Welcome
+│   ├── How Promptless works (concepts: triggers, context, doc locations)
+│   ├── Run a pilot (scope + success criteria)        [NEW: success rubric]
+│   ├── Quickstart
+│   └── Open-source quickstart (free program)
+│
+├── Connect your stack                      ← cuj-connect-sources
+│   ├── Source control & access scope (GitHub, GitHub Enterprise, Bitbucket)  [NEW: access-scope]
+│   ├── Triggers (PRs, commits, issues, Slack, Teams, Intercom, API)
+│   ├── Context sources (Jira, Linear, Notion, Confluence)
+│   ├── Doc locations & collections
+│   └── Connection health & troubleshooting           [NEW]
+│
+├── Tune what Promptless suggests           ← cuj-calibrate-suggestions
+│   ├── Noise & relevance filtering                   [NEW]
+│   ├── Release timing & feature flags (incl. LaunchDarkly)  [NEW: general model]
+│   ├── Notifications
+│   └── Teaching conventions with feedback
+│
+├── Work the queue                          ← cuj-triage-review-queue
+│   ├── The web interface / inbox
+│   ├── Reviewing & editing Promptless PRs
+│   ├── Assignment & routing (auto-assign)            [NEW]
+│   └── Reviewing from Slack / Teams
+│
+├── Get the most out of Promptless          ← outcome jobs
+│   ├── Keep screenshots current (Promptless Capture) ← cuj-screenshots  [NEW: auth/env/annotation depth]
+│   ├── Pay down docs debt (Deep Analysis)            ← cuj-backfill-debt
+│   ├── Generate release notes & changelogs           ← cuj-release-notes [NEW]
+│   ├── Make docs agent-friendly (llms.txt + Doc Detective)  ← cuj-agent-friendly-docs [NEW: llms.txt, SDK accuracy]
+│   ├── Keep translations current (localization)      ← cuj-localization [NEW]
+│   └── Build an agent knowledge base
+│
+├── Scale across teams                      ← cuj-multi-repo-routing
+│   ├── Multi-repo routing                            [NEW]
+│   ├── Versioned docs                                [NEW]
+│   └── Managing environment variables
+│
+├── Maintain a large / brownfield corpus    ← cuj-remediate-legacy-content, cuj-overhaul-ia  [NEW section]
+│   ├── Audit existing content for staleness          [NEW]
+│   ├── Remediate & restandardize legacy pages        [NEW]
+│   └── Restructure your information architecture     [NEW]
+│
+├── Migrate to docs-as-code                 ← cuj-migrate-to-docs-as-code  [NEW section]
+│   ├── Why docs-as-code (the prerequisite)
+│   ├── Choosing a platform (Mintlify, Starlight, VitePress)
+│   ├── From Doc360 / ReadMe / Fern / HubSpot / RoboHelp
+│   └── Preserving URLs & redirects
+│
+├── Security & deployment                   ← cuj-enterprise-security-review
+│   ├── Compliance & certifications
+│   ├── Data handling & classification
+│   ├── Network architecture
+│   ├── Subprocessors & privacy
+│   ├── Single sign-on (SSO)
+│   ├── Self-hosting (Kubernetes / Helm)
+│   └── Access & permissions (read-only posture)      [NEW]
+│
+├── Measure impact                          ← cuj-prove-value  [NEW section]
+│   └── Reporting & ROI
+│
+└── Reference & help
+    ├── Integrations reference (per-integration detail)
+    ├── FAQ
+    ├── Account management
+    └── Getting help
+```
+
+## CUJ → section coverage
+
+Every CUJ has a home; no journey is orphaned.
+
+| CUJ | Primary section |
+|-----|-----------------|
+| cuj-evaluate-pilot | Start here |
+| cuj-oss-onboarding | Start here → Open-source quickstart |
+| cuj-connect-sources | Connect your stack |
+| cuj-calibrate-suggestions | Tune what Promptless suggests |
+| cuj-triage-review-queue | Work the queue |
+| cuj-screenshots | Get the most out of → screenshots |
+| cuj-backfill-debt | Get the most out of → Deep Analysis |
+| cuj-release-notes | Get the most out of → release notes |
+| cuj-agent-friendly-docs | Get the most out of → agent-friendly |
+| cuj-localization | Get the most out of → localization |
+| cuj-multi-repo-routing | Scale across teams |
+| cuj-remediate-legacy-content | Maintain a large / brownfield corpus |
+| cuj-overhaul-ia | Maintain a large / brownfield corpus |
+| cuj-migrate-to-docs-as-code | Migrate to docs-as-code |
+| cuj-enterprise-security-review | Security & deployment |
+| cuj-prove-value | Measure impact |
+
+## What changes vs. today (summary)
+
+- **Promotes** calibration and the review queue from buried sub-pages to top-level sections
+  (they decide pilot success).
+- **Reframes** "How to use Promptless" as outcome-oriented jobs ("Get the most out of…").
+- **Adds** journey-driven areas that don't exist today: Migrate to docs-as-code, Measure
+  impact, **Maintain a large / brownfield corpus** (audit, remediate/restandardize, restructure
+  IA), and (as pages) noise/timing tuning, assignment/routing, multi-repo & versioned routing,
+  localization, agent-friendliness, and connection-health troubleshooting.
+- **Keeps** the strong Security & deployment tree largely intact (best-covered journey).
+
+See [ia-gap-analysis.md](ia-gap-analysis.md) for the page-level current→proposed mapping and the
+full gap list.

--- a/docs/content_strategy/journeys/_overview.md
+++ b/docs/content_strategy/journeys/_overview.md
@@ -1,0 +1,73 @@
+---
+id: journeys-overview
+type: overview
+scope: Critical user journeys (CUJs) derived from customer & prospect calls, mapped to personas
+journeys:
+  - cuj-evaluate-pilot
+  - cuj-connect-sources
+  - cuj-calibrate-suggestions
+  - cuj-triage-review-queue
+  - cuj-screenshots
+  - cuj-backfill-debt
+  - cuj-release-notes
+  - cuj-multi-repo-routing
+  - cuj-oss-onboarding
+  - cuj-localization
+  - cuj-agent-friendly-docs
+  - cuj-migrate-to-docs-as-code
+  - cuj-enterprise-security-review
+  - cuj-prove-value
+  - cuj-remediate-legacy-content
+  - cuj-overhaul-ia
+---
+
+# Critical User Journeys — Overview
+
+**Scope:** The critical journeys users take *with Promptless*, derived from the call corpus.
+Each CUJ has a file here with a trigger, entry point, success criteria, and ordered steps that
+map to documentation touchpoints. These journeys are the **input to the proposed Docs IA**
+([`../information_architecture/`](../information_architecture/proposed-ia.md)) — the IA exists
+to serve them. Touchpoints reference real doc routes where they exist; missing routes are
+flagged there as gaps (the point of the exercise), not errors.
+
+Does **not** cover internal/product-development journeys — only user-facing journeys through
+the product and its docs.
+
+## CUJ → persona coverage matrix
+
+Every persona has at least one primary journey. ● primary · ○ secondary.
+
+`brownfield-lead` is a cross-cutting persona (often also `enterprise-lead`).
+
+| CUJ | enterprise-lead | scaleup-writer | eng-owner | oss-maintainer | devrel-owner | brownfield-lead |
+|-----|:---:|:---:|:---:|:---:|:---:|:---:|
+| [evaluate-pilot](cuj-evaluate-pilot.md) | ● | ● | ● | ○ | ● | ○ |
+| [connect-sources](cuj-connect-sources.md) | ● | ● | ● | ● | ● | ○ |
+| [calibrate-suggestions](cuj-calibrate-suggestions.md) | ● | ● | ● | ○ | ● | ● |
+| [triage-review-queue](cuj-triage-review-queue.md) | ○ | ● | ● | ○ | ○ | ○ |
+| [screenshots](cuj-screenshots.md) | ● | ● | ○ | ○ | ○ | ○ |
+| [backfill-debt](cuj-backfill-debt.md) | ● | ○ | ● | ● | ○ | ● |
+| [release-notes](cuj-release-notes.md) | ○ | ○ | ● | ○ | ○ | ○ |
+| [multi-repo-routing](cuj-multi-repo-routing.md) | ● | ○ | ○ | ● | ● | ● |
+| [oss-onboarding](cuj-oss-onboarding.md) | | | | ● | ○ | |
+| [localization](cuj-localization.md) | ● | | | ● | ○ | ○ |
+| [agent-friendly-docs](cuj-agent-friendly-docs.md) | ○ | ○ | | ○ | ● | ○ |
+| [migrate-to-docs-as-code](cuj-migrate-to-docs-as-code.md) | ● | ● | ○ | | ○ | ● |
+| [enterprise-security-review](cuj-enterprise-security-review.md) | ● | ○ | | | | ○ |
+| [prove-value](cuj-prove-value.md) | ● | ● | ○ | | ○ | ● |
+| [remediate-legacy-content](cuj-remediate-legacy-content.md) | ● | | | | | ● |
+| [overhaul-ia](cuj-overhaul-ia.md) | ● | | | | | ● |
+
+## The backbone journey
+
+Most accounts traverse the same spine: **evaluate/pilot → connect sources → calibrate noise →
+triage/review the queue → (screenshots, backfill) → prove value → expand.** Security review
+runs in parallel for enterprise; OSS onboarding is the open-source variant of connect-sources;
+migration is a frequent on-ramp. Calibration (noise/volume/release-timing) is where pilots are
+won or lost — it appears in nearly every customer call.
+
+**Brownfield branch.** Teams with a large legacy corpus
+([aud-brownfield-docs-team](../audiences/brownfield-docs-team.md)) add a parallel track —
+**remediate-legacy-content** and **overhaul-ia** — to fix and restructure what already exists.
+These differ from `backfill-debt` (which fills *gaps*): they repair and reorganize *existing*
+pages at scale.

--- a/docs/content_strategy/journeys/cuj-agent-friendly-docs.md
+++ b/docs/content_strategy/journeys/cuj-agent-friendly-docs.md
@@ -1,0 +1,34 @@
+---
+id: cuj-agent-friendly-docs
+type: cuj
+title: Make docs accurate and discoverable for AI agents
+personas: [persona-devrel-owner, persona-enterprise-docs-lead, persona-oss-maintainer, persona-scaleup-solo-writer]
+trigger: "AI coding agents are a primary docs consumer, but the docs aren't discoverable (no llms.txt) or accurate enough for agents to implement the product correctly."
+entry_point: /docs/configuring-promptless/doc-collections/doc-detective-integration
+success_criteria: "Docs expose agent-friendly artifacts (e.g. llms.txt) and code examples are validated, so AI agents recommend and correctly implement the product."
+steps:
+  - { stage: "Validate code examples (Doc Detective)", doc: /docs/configuring-promptless/doc-collections/doc-detective-integration, exists: true }
+  - { stage: "Generate agent-friendly artifacts (llms.txt)", doc: "/docs/how-to-use-promptless/agent-friendly-docs", exists: false, note: "[GAP] llms.txt / agent-discoverability requested by several customers" }
+  - { stage: "Keep SDK/API reference accurate", doc: "/docs/how-to-use-promptless/sdk-api-accuracy", exists: false, note: "[GAP] No SDK/API-accuracy use-case page" }
+  - { stage: "Treat doc feedback as a trigger", doc: /docs/configuring-promptless/triggers, exists: partial, note: "one customer wanted to trigger off doc feedback" }
+---
+
+# CUJ: Make docs accurate and discoverable for AI agents
+
+**Scope:** Optimizing docs for AI-agent consumption — accuracy *and* discoverability. Primary
+for DevRel/DevEx, increasingly raised by everyone.
+
+**Trigger.** Teams recognize agents now read their docs: some customers wanted docs "accurate
+and complete so agents recommend and correctly implement the SDK"; others wanted docs
+"agent-friendly" or flagged API-reference accuracy "for AI agents"; still others raised
+discoverability.
+
+**Narrative.** This journey has two halves. **Discoverability** — exposing `llms.txt` and
+agent-readable structure so agents can find and use the docs. **Accuracy** — validating code
+examples (Doc Detective is the existing, resonant artifact) and keeping SDK/API reference
+correct so agents don't implement the product wrong. It's the newest journey in the corpus and
+trending upward.
+
+**Current friction / gap.** Doc Detective integration exists, but **agent-friendliness/`llms.txt`
+and SDK/API-accuracy have no pages** — a forward-looking gap aligned with where the market is
+moving (and with Promptless's own positioning).

--- a/docs/content_strategy/journeys/cuj-backfill-debt.md
+++ b/docs/content_strategy/journeys/cuj-backfill-debt.md
@@ -1,0 +1,34 @@
+---
+id: cuj-backfill-debt
+type: cuj
+title: Pay down existing docs debt with Deep Analysis
+personas: [persona-enterprise-docs-lead, persona-eng-docs-owner, persona-oss-maintainer, persona-scaleup-solo-writer, persona-devrel-owner, persona-brownfield-docs-lead]
+trigger: "Large mature areas are undocumented, stale, or scattered; go-forward drafting alone won't catch up."
+entry_point: /docs/how-to-use-promptless/deep-analysis
+success_criteria: "Targeted backfill of a mature/undocumented area produces a batch of accurate drafts that close known gaps, without flooding the normal queue."
+steps:
+  - { stage: "Understand Deep Analysis vs go-forward suggestions", doc: /docs/how-to-use-promptless/deep-analysis, exists: true }
+  - { stage: "Scope a one-off / per-section backfill task", doc: "/docs/how-to-use-promptless/deep-analysis#scoping-a-task", exists: partial }
+  - { stage: "Provide context for areas code can't explain", doc: /docs/configuring-promptless/context-sources, exists: true }
+  - { stage: "Review the batch without overwhelming the queue", doc: /docs/how-to-use-promptless/interacting-with-promptless-p-rs, exists: true }
+---
+
+# CUJ: Pay down existing docs debt with Deep Analysis
+
+**Scope:** Catching up on accumulated debt in mature areas, distinct from ongoing
+change-driven drafting. Specifically about **gaps / undocumented areas**; for fixing content
+that *already exists but is stale/inconsistent*, see the brownfield journey
+[cuj-remediate-legacy-content](cuj-remediate-legacy-content.md).
+
+**Trigger.** A team confronts a backlog — undocumented integrations, legacy base APIs, thin or
+scattered content — that go-forward drafting will never reach.
+
+**Narrative.** Many accounts split work into two modes: keep up with new changes *and* backfill
+the old. One customer ran **per-section deep-analysis rewrites**; another needed to batch-update huge
+gaps in legacy base APIs; a third had low-reliability scattered docs to fill. The key tension is
+doing this **without flooding the normal review queue** — backfill is a deliberate, scoped
+campaign, not a firehose.
+
+**Current friction / gap.** Deep Analysis is documented, but **scoping a bounded backfill task**
+(per-section, per-area) and keeping its output separate from the day-to-day queue are
+under-specified.

--- a/docs/content_strategy/journeys/cuj-calibrate-suggestions.md
+++ b/docs/content_strategy/journeys/cuj-calibrate-suggestions.md
@@ -1,0 +1,34 @@
+---
+id: cuj-calibrate-suggestions
+type: cuj
+title: Calibrate suggestion noise, volume, and release timing
+personas: [persona-scaleup-solo-writer, persona-eng-docs-owner, persona-enterprise-docs-lead, persona-devrel-owner, persona-brownfield-docs-lead]
+trigger: "First suggestions are too noisy, too early, or firing on the wrong changes; the champion needs to tune signal-to-noise before trust erodes."
+entry_point: /docs/how-to-use-promptless/providing-feedback
+success_criteria: "Suggestions arrive at the right time (after a feature actually ships), at a manageable volume, scoped to externally-relevant changes — and the team trusts the queue."
+steps:
+  - { stage: "Suppress internal-only / irrelevant changes", doc: "/docs/configuring-promptless/suggestion-filtering", exists: false, note: "[GAP] No dedicated noise/relevance-tuning page" }
+  - { stage: "Align drafting to release timing / feature flags", doc: /docs/integrations/launchdarkly-integration-beta, exists: partial, note: "LaunchDarkly exists; general release-timing/feature-flag model not documented" }
+  - { stage: "Map release stage to suggestion status", doc: "/docs/configuring-promptless/release-timing", exists: false, note: "[GAP] Recurring unsolved workflow across many accounts" }
+  - { stage: "Teach conventions via feedback", doc: /docs/how-to-use-promptless/providing-feedback, exists: true }
+  - { stage: "Tune notification volume/routing", doc: /docs/configuring-promptless/customizing-notifications, exists: true }
+---
+
+# CUJ: Calibrate suggestion noise, volume, and release timing
+
+**Scope:** Tuning signal-to-noise after first suggestions appear. **This is where pilots are
+won or lost** — it recurs in nearly every customer call.
+
+**Trigger.** The first batch is noisy (self-evident UI changes, refactors flagged as "new",
+internal-only PRs), arrives before a feature ships, or buries the team.
+
+**Narrative.** Two distinct problems dominate the corpus. (1) **Noise**: false positives and
+internal-vs-external changes overwhelm the team — some customers wanted internal-only changes
+suppressed; others wanted merge-only triggers or feature-flagged content excluded. (2)
+**Release timing**: drafting must fire when a feature *actually ships*, not when code merges
+behind a flag — one enterprise customer drafted release notes "too early"; mapping **release stage →
+suggestion status** is the most-cited unsolved workflow problem in the entire dataset.
+
+**Current friction / gap.** There is **no noise/relevance-tuning page and no release-timing /
+feature-flag model page.** The LaunchDarkly integration is the closest artifact but doesn't
+cover the general pattern. These are the highest-value content gaps for retention.

--- a/docs/content_strategy/journeys/cuj-connect-sources.md
+++ b/docs/content_strategy/journeys/cuj-connect-sources.md
@@ -1,0 +1,34 @@
+---
+id: cuj-connect-sources
+type: cuj
+title: Connect source control, triggers, and context sources
+personas: [persona-scaleup-solo-writer, persona-eng-docs-owner, persona-enterprise-docs-lead, persona-oss-maintainer, persona-devrel-owner]
+trigger: "Champion is ready to wire Promptless into their repos and the systems where change signal lives."
+entry_point: /docs/getting-started/setup-quickstart
+success_criteria: "Source control connected (with appropriate access scope), triggers firing on real change events, and doc locations resolved — without a silent auth failure."
+steps:
+  - { stage: "Install source-control app", doc: /docs/integrations/github-integration, exists: true, note: "Also github-enterprise-integration, bitbucket-integration" }
+  - { stage: "Choose access scope (read-only / repo selection)", doc: "/docs/integrations/github-integration#permissions-and-scope", exists: partial, note: "Access-scope guidance scattered; OSS read-only path lives elsewhere" }
+  - { stage: "Configure triggers", doc: /docs/configuring-promptless/triggers, exists: true, note: "PRs, commits, issues, Slack, Intercom, Teams, API" }
+  - { stage: "Connect context sources", doc: /docs/configuring-promptless/context-sources, exists: true, note: "Jira, Linear, Notion, Confluence" }
+  - { stage: "Tell Promptless where docs live", doc: /docs/configuring-promptless/doc-collections/git-hub-repos-docs-as-code, exists: true }
+  - { stage: "Verify the connection is live (no expired token)", doc: "/docs/configuring-promptless/connection-health", exists: false, note: "[GAP] No troubleshooting page for silent auth/token failures" }
+---
+
+# CUJ: Connect source control, triggers, and context sources
+
+**Scope:** Wiring Promptless into the systems where change signal originates. The commercial
+on-ramp; OSS has its own variant ([cuj-oss-onboarding](cuj-oss-onboarding.md)).
+
+**Trigger.** The champion is ready to connect repos and the tools (Jira, Linear, Slack, etc.)
+that carry the "why" behind changes.
+
+**Narrative.** This is the step where pilots silently die. One customer ran with **zero suggestions
+because of an expired GitLab token**; others hit repo-scoping confusion or needed read-only
+access for public repos only. Context sources matter as much as triggers — engineers' code PRs
+"lack the full feature picture and the why," so connecting Jira/Linear/Slack is what makes
+drafts good.
+
+**Current friction / gap.** Access-scope decisions (read-only vs write, repo selection,
+public-only) are scattered, and there is **no connection-health / silent-failure
+troubleshooting page** — the single most damaging gap because failures are invisible.

--- a/docs/content_strategy/journeys/cuj-enterprise-security-review.md
+++ b/docs/content_strategy/journeys/cuj-enterprise-security-review.md
@@ -1,0 +1,36 @@
+---
+id: cuj-enterprise-security-review
+type: cuj
+title: Pass security, self-host, and SSO review
+personas: [persona-enterprise-docs-lead, persona-scaleup-solo-writer]
+trigger: "IT/security/procurement must approve Promptless before a pilot can proceed."
+entry_point: /docs/security-and-privacy/compliance-and-certifications
+success_criteria: "Security/IT signs off — the champion can forward complete, standalone docs on data handling, deployment, SSO, and subprocessors, and self-hosting is available where required."
+steps:
+  - { stage: "Compliance & certifications", doc: /docs/security-and-privacy/compliance-and-certifications, exists: true }
+  - { stage: "Data handling & classification", doc: /docs/security-and-privacy/data-handling-and-classification, exists: true }
+  - { stage: "Network architecture", doc: /docs/security-and-privacy/network-architecture, exists: true }
+  - { stage: "Subprocessors & privacy", doc: /docs/security-and-privacy/promptless-subprocessors, exists: true }
+  - { stage: "Single sign-on setup", doc: /docs/security-and-privacy/single-sign-on-sso-setup, exists: true }
+  - { stage: "Self-hosting / on-prem deployment", doc: /docs/self-hosting, exists: true }
+  - { stage: "Repo access scope for security review", doc: "/docs/security-and-privacy/access-and-permissions", exists: false, note: "[GAP] read-only / least-privilege access posture not consolidated" }
+---
+
+# CUJ: Pass security, self-host, and SSO review
+
+**Scope:** The parallel gating journey for enterprise (and security-sensitive scale-up)
+accounts. Runs alongside the pilot, not after it.
+
+**Trigger.** Before any pilot, IT/security/procurement must approve — a formal gauntlet for
+enterprise customers. The most common pilot blocker named after access itself (one prospect
+reportedly declined over integration discomfort; another's pilot waited on security sign-off).
+
+**Narrative.** The champion becomes an internal advocate who must **forward standalone
+documentation** to reviewers: data handling, network architecture, subprocessors, compliance
+certs, SSO, and—often decisively—**self-hosting/on-prem**. The corpus shows these docs are
+read by non-docs stakeholders and must stand on their own.
+
+**Current coverage / gap.** This is the **best-covered journey today** (security-and-privacy/*,
+self-hosting, SSO all exist). The one gap: a consolidated **repo access / least-privilege
+(read-only) posture** page that ties the access-scope decision from
+[cuj-connect-sources](cuj-connect-sources.md) to the security narrative.

--- a/docs/content_strategy/journeys/cuj-evaluate-pilot.md
+++ b/docs/content_strategy/journeys/cuj-evaluate-pilot.md
@@ -1,0 +1,34 @@
+---
+id: cuj-evaluate-pilot
+type: cuj
+title: Evaluate Promptless and run a pilot
+personas: [persona-scaleup-solo-writer, persona-eng-docs-owner, persona-enterprise-docs-lead, persona-devrel-owner]
+trigger: "Docs are slipping behind eng velocity; a champion wants to test whether Promptless helps before committing."
+entry_point: /docs/getting-started/welcome
+success_criteria: "Within the first session(s), Promptless surfaces a real change the team missed and drafts a usable doc PR the champion would merge."
+steps:
+  - { stage: "Understand the model", doc: /docs/getting-started/core-concepts, exists: true }
+  - { stage: "Scope the pilot", doc: /docs/getting-started/pilot-overview, exists: true }
+  - { stage: "Connect a repo & sources", doc: /docs/getting-started/setup-quickstart, exists: true }
+  - { stage: "See first suggestions", doc: /docs/how-to-use-promptless/using-the-web-interface, exists: true }
+  - { stage: "Judge & give feedback on quality", doc: /docs/how-to-use-promptless/providing-feedback, exists: true }
+  - { stage: "Define what 'success' means for this pilot", doc: "/docs/getting-started/pilot-overview#defining-success", exists: partial, note: "Pilot success criteria / exit metrics not explicit" }
+---
+
+# CUJ: Evaluate Promptless and run a pilot
+
+**Scope:** The first-run evaluation journey common to nearly every account. Ends when the
+champion has enough signal to advocate internally; expansion and procurement are downstream.
+
+**Trigger.** A champion (solo writer, eng owner, docs lead, or DevRel) feels docs slipping and
+wants proof Promptless helps before committing time or budget.
+
+**Narrative.** The make-or-break moment is **time-to-first-useful-suggestion.** Across calls,
+champions decided based on whether the first batch caught something real they'd have missed and
+drafted something they'd actually merge — one customer's docs owner rated suggestions "7–8 vs
+our 4–5"; another's sole writer rated the first batch 8/10. Conversely, a noisy or empty first batch (e.g.
+an expired token producing zero suggestions) stalls the evaluation. Pilots also need an
+explicit definition of success and an exit metric, which the corpus shows is often left vague.
+
+**Current friction / gap.** "What does a good pilot look like and how is it measured" is only
+partially documented; enterprise buyers especially want a crisp pilot success rubric.

--- a/docs/content_strategy/journeys/cuj-localization.md
+++ b/docs/content_strategy/journeys/cuj-localization.md
@@ -1,0 +1,31 @@
+---
+id: cuj-localization
+type: cuj
+title: Keep translations current across locales
+personas: [persona-oss-maintainer, persona-enterprise-docs-lead, persona-devrel-owner]
+trigger: "Source docs change but translated/localized versions fall months or years behind."
+entry_point: /docs/configuring-promptless/doc-collections/how-promptless-learns-your-docs
+success_criteria: "When source docs change, the corresponding localized versions are updated (or flagged for update) per locale, integrating with the team's TMS where one exists."
+steps:
+  - { stage: "Model localized docs as collections/locales", doc: "/docs/configuring-promptless/doc-collections/localization", exists: false, note: "[GAP] No localization page" }
+  - { stage: "Propagate source changes to each locale", doc: "/docs/configuring-promptless/localization/propagation", exists: false, note: "[GAP] one OSS project's translations years behind; others needed locale upkeep" }
+  - { stage: "Integrate with a TMS (e.g. Phrase)", doc: "/docs/integrations/tms", exists: false, note: "[GAP] one enterprise team requires a TMS hook" }
+  - { stage: "Human-review machine translations", doc: /docs/how-to-use-promptless/providing-feedback, exists: partial }
+---
+
+# CUJ: Keep translations current across locales
+
+**Scope:** Maintaining localized/translated docs in sync with source — a real need for OSS
+projects with community translations and enterprise teams with localization functions.
+
+**Trigger.** Source docs change; translations lag badly (one OSS project's translations were
+"years behind"; others needed locale upkeep; one enterprise team was accelerating Japanese
+localization; another needed its Translation Management System integrated).
+
+**Narrative.** Localization is a recurring secondary journey, strongest in OSS and enterprise.
+Teams want source changes to **propagate to each locale** (or at least flag the locale as
+stale) and, where a Translation Management System exists, to **hook into it** rather than bypass
+it. Machine translation is distrusted, so human review must stay in the loop.
+
+**Current friction / gap.** **Localization is entirely undocumented** — no locale-modeling,
+propagation, or TMS-integration content exists. A clear gap for two priority segments.

--- a/docs/content_strategy/journeys/cuj-migrate-to-docs-as-code.md
+++ b/docs/content_strategy/journeys/cuj-migrate-to-docs-as-code.md
@@ -1,0 +1,33 @@
+---
+id: cuj-migrate-to-docs-as-code
+type: cuj
+title: Migrate off a hosted/legacy platform to docs-as-code
+personas: [persona-scaleup-solo-writer, persona-enterprise-docs-lead, persona-devrel-owner, persona-eng-docs-owner, persona-brownfield-docs-lead]
+trigger: "The team is on a hosted or legacy platform (Doc360, ReadMe, Fern, HubSpot, RoboHelp) that blocks adoption, and wants to move to docs-as-code to use Promptless."
+entry_point: /docs/configuring-promptless/doc-collections/git-hub-repos-docs-as-code
+success_criteria: "Docs are migrated to a Git-based docs-as-code stack Promptless supports, with content, structure, and redirects intact."
+steps:
+  - { stage: "Confirm docs-as-code is the prerequisite", doc: /docs/configuring-promptless/doc-collections/git-hub-repos-docs-as-code, exists: true }
+  - { stage: "Choose a target SSG (Mintlify, Starlight, VitePress)", doc: "/docs/migrations/choosing-a-platform", exists: false, note: "[GAP] No migration guidance" }
+  - { stage: "Migrate from a specific source platform", doc: "/docs/migrations/from-doc360", exists: false, note: "[GAP] Doc360/ReadMe/Fern/HubSpot/RoboHelp all named; none documented" }
+  - { stage: "Preserve URLs / redirects", doc: "/docs/migrations/redirects", exists: false, note: "[GAP]" }
+---
+
+# CUJ: Migrate off a hosted/legacy platform to docs-as-code
+
+**Scope:** The frequent *on-ramp* journey: getting onto a Git-based stack so Promptless can be
+used at all. Docs-as-code is a hard product prerequisite.
+
+**Trigger.** The team is locked into or frustrated by a hosted/legacy platform that blocks
+Promptless: Doc360 (where Promptless dropped support), ReadMe, Fern (post-acquisition collapse),
+HubSpot, RoboHelp. Many explicitly treat the migration as part of adopting Promptless (a
+Starlight migration offer surfaced repeatedly).
+
+**Narrative.** Prospects often *want* Promptless but can't use it until they leave their current
+platform. The journey: confirm the prerequisite, pick a supported SSG, migrate content from a
+named source platform, and preserve URLs/redirects. This is as much a sales-unblocking journey
+as a usage one.
+
+**Current friction / gap.** **No migration content exists at all** — not platform selection,
+not per-source guides, not redirect handling. Given how many deals hinge on it, this is a
+high-leverage gap.

--- a/docs/content_strategy/journeys/cuj-multi-repo-routing.md
+++ b/docs/content_strategy/journeys/cuj-multi-repo-routing.md
@@ -1,0 +1,31 @@
+---
+id: cuj-multi-repo-routing
+type: cuj
+title: Route changes across many repos and versioned docs
+personas: [persona-enterprise-docs-lead, persona-oss-maintainer, persona-devrel-owner, persona-scaleup-solo-writer, persona-brownfield-docs-lead]
+trigger: "Changes span many code repos and must land in the right docs repo, collection, and version."
+entry_point: /docs/configuring-promptless/doc-collections/how-promptless-learns-your-docs
+success_criteria: "A change in any of N code repos is correctly routed to the right docs collection and the right versioned docs set, with no cross-routing errors."
+steps:
+  - { stage: "Define doc collections", doc: /docs/configuring-promptless/doc-collections/how-promptless-learns-your-docs, exists: true }
+  - { stage: "Map code repos → docs locations", doc: /docs/configuring-promptless/doc-collections/git-hub-repos-docs-as-code, exists: true }
+  - { stage: "Route across multiple repos / monorepo vs many", doc: "/docs/configuring-promptless/doc-collections/multi-repo-routing", exists: false, note: "[GAP] one customer hit a cross-collection routing/memory bug; no routing page" }
+  - { stage: "Handle versioned docs (v3 vs v4)", doc: "/docs/configuring-promptless/doc-collections/versioned-docs", exists: false, note: "[GAP] Versioned-docs mapping requested by OSS + enterprise" }
+---
+
+# CUJ: Route changes across many repos and versioned docs
+
+**Scope:** Correctly directing change signal in multi-repo and multi-version environments —
+the structural reality for enterprise and OSS accounts.
+
+**Trigger.** Code lives in many repos (some customers span 6+ GitHub orgs or 16–20 eng teams)
+and docs span multiple collections and versions; a change must land in exactly the right place.
+
+**Narrative.** Two related problems. **Routing**: one customer hit a cross-collection
+routing/memory bug; large orgs need deterministic mapping of code repos to docs collections.
+**Versioning**: some customers needed changes mapped to the correct versioned docs set
+(e.g. v3 vs v4), and enterprise teams maintain parallel versions. Mis-routing erodes trust fast.
+
+**Current friction / gap.** Doc-collections basics are documented, but **multi-repo routing and
+versioned-docs mapping have no dedicated pages** — a structural gap for the two segments with
+the most repos.

--- a/docs/content_strategy/journeys/cuj-oss-onboarding.md
+++ b/docs/content_strategy/journeys/cuj-oss-onboarding.md
@@ -8,7 +8,7 @@ entry_point: /docs/getting-started/promptless-oss
 success_criteria: "The project is connected via a read-only app across its repos, with doc updates auto-drafted for changes contributors skipped — at no cost to the project."
 steps:
   - { stage: "Understand the OSS program & eligibility", doc: /docs/getting-started/promptless-oss, exists: true }
-  - { stage: "Install the read-only GitHub app", doc: "/docs/integrations/github#read-only-oss", exists: partial, note: "Read-only/public-repo path under-documented vs commercial install" }
+  - { stage: "Install the read-only GitHub app", doc: "/docs/getting-started/promptless-oss#install-the-github-app", exists: true, note: "OSS quickstart documents the read-only (public-repo) GitHub app" }
   - { stage: "Connect multiple project repos", doc: /docs/configuring-promptless/doc-collections/git-hub-repos-docs-as-code, exists: true }
   - { stage: "Route across versions (see multi-repo-routing)", doc: cuj-multi-repo-routing, exists: ref }
   - { stage: "Set up localization (see localization)", doc: cuj-localization, exists: ref }

--- a/docs/content_strategy/journeys/cuj-oss-onboarding.md
+++ b/docs/content_strategy/journeys/cuj-oss-onboarding.md
@@ -1,0 +1,34 @@
+---
+id: cuj-oss-onboarding
+type: cuj
+title: Onboard an open-source project on the free program
+personas: [persona-oss-maintainer, persona-devrel-owner]
+trigger: "An OSS maintainer wants Promptless on their project via the free OSS program."
+entry_point: /docs/getting-started/promptless-oss
+success_criteria: "The project is connected via a read-only app across its repos, with doc updates auto-drafted for changes contributors skipped — at no cost to the project."
+steps:
+  - { stage: "Understand the OSS program & eligibility", doc: /docs/getting-started/promptless-oss, exists: true }
+  - { stage: "Install the read-only GitHub app", doc: "/docs/integrations/github#read-only-oss", exists: partial, note: "Read-only/public-repo path under-documented vs commercial install" }
+  - { stage: "Connect multiple project repos", doc: /docs/configuring-promptless/doc-collections/git-hub-repos-docs-as-code, exists: true }
+  - { stage: "Route across versions (see multi-repo-routing)", doc: cuj-multi-repo-routing, exists: ref }
+  - { stage: "Set up localization (see localization)", doc: cuj-localization, exists: ref }
+---
+
+# CUJ: Onboard an open-source project on the free program
+
+**Scope:** The open-source on-ramp — the OSS variant of
+[cuj-connect-sources](cuj-connect-sources.md). Strategic for brand/community (recognizable
+foundation/project logos), not revenue.
+
+**Trigger.** A maintainer of a well-known open-source project wants Promptless on
+their project via the free program.
+
+**Narrative.** Onboarding differs from commercial in three ways: it uses a **read-only GitHub
+app** (maintainers grant access to public repos only), governance is **diffuse** (no single
+decision-maker to approve), and the project is usually **multi-repo and versioned** from day
+one, often with **localization** needs. The promise that resonates: catch the doc updates
+contributors skip, so maintainers spend time on code.
+
+**Current friction / gap.** The OSS program page exists, but the **read-only/public-repo install
+path** is under-documented relative to the commercial install, and it depends on the
+multi-repo-routing and localization gaps flagged elsewhere.

--- a/docs/content_strategy/journeys/cuj-overhaul-ia.md
+++ b/docs/content_strategy/journeys/cuj-overhaul-ia.md
@@ -1,0 +1,36 @@
+---
+id: cuj-overhaul-ia
+type: cuj
+title: Restructure the information architecture of an existing doc set
+personas: [persona-brownfield-docs-lead, persona-enterprise-docs-lead]
+trigger: "The doc set's navigation/structure reflects an older product shape and no longer maps to how the product or its users work."
+entry_point: /docs/configuring-promptless/doc-collections/how-promptless-learns-your-docs
+success_criteria: "The corpus is reorganized into an IA that matches today's product (e.g. capability-based), with content moved/merged/retitled and URLs preserved — without losing or stranding pages."
+steps:
+  - { stage: "Map the current corpus & its structure", doc: "/docs/how-to-use-promptless/content-audit", exists: false, note: "[GAP] shared with cuj-remediate-legacy-content" }
+  - { stage: "Design the target IA (e.g. capability-based)", doc: "/docs/how-to-use-promptless/restructuring-your-docs", exists: false, note: "[GAP] one customer's capability-based 'v3.0' rebuild; another's template/IA refactor" }
+  - { stage: "Move, merge, and retitle pages into the new IA", doc: "/docs/how-to-use-promptless/restructuring-your-docs#executing", exists: false, note: "[GAP]" }
+  - { stage: "Preserve URLs / redirects", doc: "/docs/migrations/redirects", exists: false, note: "[GAP] shared with cuj-migrate-to-docs-as-code" }
+  - { stage: "Keep new content flowing into the new structure", doc: /docs/configuring-promptless/doc-collections/how-promptless-learns-your-docs, exists: true }
+---
+
+# CUJ: Restructure the information architecture of an existing doc set
+
+**Scope:** A larger, less frequent brownfield journey: reorganizing the *structure* of an
+existing corpus, not just fixing individual pages. Distinct from
+[cuj-remediate-legacy-content](cuj-remediate-legacy-content.md) (page-level health) and from
+[cuj-migrate-to-docs-as-code](cuj-migrate-to-docs-as-code.md) (changing platform).
+
+**Trigger.** The navigation reflects an older product shape. One customer wanted a
+**capability-based IA rebuild ("v3.0")**; another carried a **big template/IA refactor
+backlog**; a third needed to **unify two divergent doc structures** as the product went SaaS.
+
+**Narrative.** The team audits the current corpus, designs a target IA that matches the product
+as it is now, then **moves, merges, and retitles** pages into it while preserving URLs — and
+ensures new content keeps flowing into the new structure rather than the old. This is the
+docs-team equivalent of a refactor: high value, high risk, easy to strand pages or break links.
+
+**Current friction / gap.** Promptless can learn an existing docs structure, but there is **no
+guidance for restructuring one** — no content map, no target-IA design, no move/merge execution,
+and redirect handling is the same gap migration faces. (This very `docs/content_strategy/` exercise is
+an example of the upstream thinking such an overhaul requires.)

--- a/docs/content_strategy/journeys/cuj-prove-value.md
+++ b/docs/content_strategy/journeys/cuj-prove-value.md
@@ -1,0 +1,31 @@
+---
+id: cuj-prove-value
+type: cuj
+title: Demonstrate docs-team value and ROI to leadership
+personas: [persona-scaleup-solo-writer, persona-enterprise-docs-lead, persona-devrel-owner, persona-eng-docs-owner, persona-brownfield-docs-lead]
+trigger: "The champion needs to show leadership that Promptless (and the docs function) delivers measurable leverage—to justify spend, headcount, or the role itself."
+entry_point: /docs/how-to-use-promptless/using-the-web-interface
+success_criteria: "The champion can report concrete outcomes—doc PRs merged, coverage/freshness gains, time saved—drawn from Promptless, in a form leadership accepts."
+steps:
+  - { stage: "See activity (PRs drafted/merged, coverage)", doc: /docs/how-to-use-promptless/using-the-web-interface, exists: partial, note: "Activity visible; reporting/metrics view unclear" }
+  - { stage: "Quantify impact (time saved, freshness, % of doc PRs)", doc: "/docs/how-to-use-promptless/reporting-and-roi", exists: false, note: "[GAP] one customer cited Promptless as ~40% of doc PRs—no built-in reporting page" }
+  - { stage: "Export / share results with leadership", doc: "/docs/how-to-use-promptless/reporting-and-roi#sharing", exists: false, note: "[GAP]" }
+---
+
+# CUJ: Demonstrate docs-team value and ROI to leadership
+
+**Scope:** The "make the case upward" journey. Cuts across champions who must justify spend,
+headcount, or their own role as orgs automate around docs.
+
+**Trigger.** Leadership wants proof. One customer's head of customer education wanted to **prove
+docs-team efficiency before adding headcount**; another needed a case to **expand** after the
+champion left; a third could point to Promptless authoring **~40% of doc PRs**; another's
+management literally asked to "automate the job away."
+
+**Narrative.** Champions need outcome data — PRs drafted/merged, coverage and freshness gains,
+time saved, share of doc PRs automated — in a form they can present. Today they reconstruct
+this manually from activity views.
+
+**Current friction / gap.** There is **no reporting/ROI view or page.** Given that value-proof
+gates both expansion and (for some) the champion's job security, a reporting capability + doc is
+a high-leverage gap.

--- a/docs/content_strategy/journeys/cuj-release-notes.md
+++ b/docs/content_strategy/journeys/cuj-release-notes.md
@@ -1,0 +1,31 @@
+---
+id: cuj-release-notes
+type: cuj
+title: Generate release notes and changelogs from change signal
+personas: [persona-eng-docs-owner, persona-scaleup-solo-writer, persona-enterprise-docs-lead]
+trigger: "The product ships continuously but there's no reliable release-notes/changelog process; updates go unannounced."
+entry_point: /docs/configuring-promptless/triggers/git-hub-p-rs
+success_criteria: "Release notes / changelog entries are drafted automatically from PRs (and Slack/Jira context) on the team's cadence, published after release."
+steps:
+  - { stage: "Trigger on merged PRs", doc: /docs/configuring-promptless/triggers/git-hub-p-rs, exists: true }
+  - { stage: "Pull the 'why' from Slack/Jira/Linear", doc: /docs/configuring-promptless/context-sources, exists: true }
+  - { stage: "Draft release notes / changelog", doc: "/docs/how-to-use-promptless/release-notes", exists: false, note: "[GAP] No release-notes use-case page despite recurring demand" }
+  - { stage: "Time publication to release", doc: "/docs/configuring-promptless/release-timing", exists: false, note: "[GAP] shared with cuj-calibrate-suggestions" }
+---
+
+# CUJ: Generate release notes and changelogs from change signal
+
+**Scope:** Producing release notes / changelog entries from the same change signal Promptless
+already watches.
+
+**Trigger.** A team ships continuously with **no release-notes process** — changes (including
+GA promotions and flag flips) go unannounced. Named explicitly by some customers (one wanted
+weekly notes from PRs/Slack); another struggled with drafting notes too early.
+
+**Narrative.** Release notes are a distinct, high-demand output that reuses the trigger +
+context-source machinery. The hard parts are pulling the *why* (not just the diff) and timing
+publication to the actual release, not the merge.
+
+**Current friction / gap.** **No release-notes use-case page exists.** This is a clear content
+gap given how often it surfaces, and it shares the unresolved **release-timing** dependency
+with [cuj-calibrate-suggestions](cuj-calibrate-suggestions.md).

--- a/docs/content_strategy/journeys/cuj-remediate-legacy-content.md
+++ b/docs/content_strategy/journeys/cuj-remediate-legacy-content.md
@@ -1,0 +1,38 @@
+---
+id: cuj-remediate-legacy-content
+type: cuj
+title: Audit and remediate legacy content at scale
+personas: [persona-brownfield-docs-lead, persona-enterprise-docs-lead]
+trigger: "A large existing corpus is full of stale, inconsistent, off-template, or contradictory pages that no one can audit by hand."
+entry_point: /docs/how-to-use-promptless/deep-analysis
+success_criteria: "Existing pages are audited, then updated/consolidated/restandardized in reviewable batches so corpus freshness and consistency measurably improve — without a manual rewrite or a noise flood."
+steps:
+  - { stage: "Audit the corpus for staleness/inconsistency", doc: "/docs/how-to-use-promptless/content-audit", exists: false, note: "[GAP] No way to surface stale/contradictory existing pages at scale (one enterprise's ~4k-page long tail; another's debt-as-noise)" }
+  - { stage: "Run Deep Analysis over an existing area", doc: /docs/how-to-use-promptless/deep-analysis, exists: true }
+  - { stage: "Update & consolidate stale/duplicate pages", doc: "/docs/how-to-use-promptless/remediating-existing-pages", exists: false, note: "[GAP] Remediation of EXISTING pages (vs backfilling gaps) not documented" }
+  - { stage: "Retrofit current standards & templates", doc: "/docs/how-to-use-promptless/standards-enforcement", exists: false, note: "[GAP] Off-style/off-template legacy content; unify divergent processes" }
+  - { stage: "Process the batch without flooding the live queue", doc: /docs/how-to-use-promptless/interacting-with-promptless-p-rs, exists: true }
+---
+
+# CUJ: Audit and remediate legacy content at scale
+
+**Scope:** Bringing an **existing** brownfield corpus back to health — auditing, updating,
+consolidating, and restandardizing pages that already exist. The complement to
+[cuj-backfill-debt](cuj-backfill-debt.md): backfill fills *gaps/undocumented* areas; this
+journey fixes *content that exists but is stale, inconsistent, or off-standard.*
+
+**Trigger.** A docs lead confronts a large corpus where most pages are quietly out of date,
+contradictory, or off-template, and manual auditing is impossible at the scale — one enterprise
+with ~4k pages and long-tail staleness, another with legacy base APIs, a third unifying two
+divergent legacy processes, and others carrying legacy off-style content.
+
+**Narrative.** The work is a deliberate campaign, not a firehose: **find** the stale/inconsistent
+pages, **remediate** them (update, consolidate duplicates, restandardize to current
+templates/style), and do it in **reviewable batches** that don't drown the live change queue.
+The brownfield trust concern is acute — turning a tool loose on a debt-laden corpus must
+*reduce* the felt debt, not amplify it with noise.
+
+**Current friction / gap.** Deep Analysis exists, but there is **no content-audit, no
+existing-page-remediation, and no standards-enforcement content.** Today's docs assume
+go-forward drafting and gap-backfilling; remediating an *existing* corpus at scale is the
+brownfield-specific gap.

--- a/docs/content_strategy/journeys/cuj-screenshots.md
+++ b/docs/content_strategy/journeys/cuj-screenshots.md
@@ -1,0 +1,33 @@
+---
+id: cuj-screenshots
+type: cuj
+title: Set up automated screenshot capture and updates
+personas: [persona-scaleup-solo-writer, persona-enterprise-docs-lead, persona-eng-docs-owner, persona-oss-maintainer, persona-devrel-owner]
+trigger: "A UI/label change just invalidated dozens of screenshots and the team is recapturing them by hand."
+entry_point: /docs/how-to-use-promptless/using-promptless-capture
+success_criteria: "Screenshots in docs are captured and refreshed automatically on UI changes, including behind auth and on firewalled/test environments, with correct annotations."
+steps:
+  - { stage: "Understand Promptless Capture", doc: /docs/how-to-use-promptless/using-promptless-capture, exists: true }
+  - { stage: "Authenticate to the app being captured", doc: "/docs/how-to-use-promptless/using-promptless-capture#authentication", exists: partial, note: "Auth-to-target-app failures reported by one customer; firewalled instances blocked for another" }
+  - { stage: "Capture on test/staging environments", doc: "/docs/how-to-use-promptless/using-promptless-capture#environments", exists: partial }
+  - { stage: "Control annotations (color, callouts)", doc: "/docs/how-to-use-promptless/using-promptless-capture#annotations", exists: partial, note: "Annotation color gap raised by one customer" }
+---
+
+# CUJ: Set up automated screenshot capture and updates
+
+**Scope:** Standing up and tuning automated screenshots. **The most-requested single capability
+across paid segments.**
+
+**Trigger.** A UI or label change just made dozens of screenshots wrong, and someone faces
+manual recapture — a pain named across many accounts, one with hundreds of stale shots.
+
+**Narrative.** Screenshots are both a top activation hook and a top source of friction. Teams
+want capture to "just work," but the corpus surfaces concrete blockers: **authentication to the
+target app** (one customer's screenshot auth failed), **firewalled/private instances** that the
+capture agent can't reach (another customer), **environment selection** (capture on staging before
+release), and **annotation control** (color/callout gaps). Getting screenshots working is
+frequently the difference between an engaged pilot and a stalled one.
+
+**Current friction / gap.** Promptless Capture is documented, but auth-to-target, firewalled
+environments, environment selection, and annotation controls are under-specified relative to
+how often they block teams.

--- a/docs/content_strategy/journeys/cuj-triage-review-queue.md
+++ b/docs/content_strategy/journeys/cuj-triage-review-queue.md
@@ -1,0 +1,32 @@
+---
+id: cuj-triage-review-queue
+type: cuj
+title: Triage and review the suggestion queue
+personas: [persona-eng-docs-owner, persona-scaleup-solo-writer, persona-enterprise-docs-lead, persona-devrel-owner, persona-oss-maintainer]
+trigger: "Suggestions are flowing; someone needs to review, edit, approve, and—critically—own clearing the queue."
+entry_point: /docs/how-to-use-promptless/using-the-web-interface
+success_criteria: "Suggestions are reviewed and merged on a sustainable cadence, with clear ownership/assignment so the queue doesn't pile up unattended."
+steps:
+  - { stage: "See the queue / inbox", doc: /docs/how-to-use-promptless/using-the-web-interface, exists: true }
+  - { stage: "Review & edit a drafted PR", doc: /docs/how-to-use-promptless/interacting-with-promptless-p-rs, exists: true }
+  - { stage: "Assign an owner / auto-assign", doc: "/docs/how-to-use-promptless/assigning-and-routing-suggestions", exists: false, note: "[GAP] Auto-assignment is the #1 ask of engineer-owned teams" }
+  - { stage: "Review from Slack/Teams", doc: /docs/how-to-use-promptless/working-with-slack, exists: true }
+  - { stage: "Give feedback to improve future drafts", doc: /docs/how-to-use-promptless/providing-feedback, exists: true }
+---
+
+# CUJ: Triage and review the suggestion queue
+
+**Scope:** The recurring operational loop after calibration — review, edit, approve, and own
+the queue. Most acute for teams with no dedicated writer.
+
+**Trigger.** Suggestions are flowing and someone must process them sustainably.
+
+**Narrative.** The dominant failure mode for [persona-eng-docs-owner](../personas/eng-docs-owner.md):
+**"no one owns the queue."** One customer explicitly needed auto-assignment and an inbox so engineers
+would clear suggestions; another's new sole writer inherited a multi-item backlog and needed a
+triage routine; diffuse review/approval ownership stalls throughput. Solo writers want a fast
+triage loop; engineer-owned teams want work *pushed and assigned* to them, not pulled.
+
+**Current friction / gap.** The web interface and PR-interaction pages exist, but there is
+**no documented assignment/routing/auto-assign workflow** — the single most-requested capability
+from engineer-owned accounts and a continuity risk when a champion leaves.

--- a/docs/content_strategy/personas/_overview.md
+++ b/docs/content_strategy/personas/_overview.md
@@ -1,0 +1,31 @@
+---
+id: personas-overview
+type: overview
+scope: Minimal personas, one per audience
+personas:
+  - persona-enterprise-docs-lead
+  - persona-scaleup-solo-writer
+  - persona-eng-docs-owner
+  - persona-oss-maintainer
+  - persona-devrel-owner
+  - persona-brownfield-docs-lead
+---
+
+# Personas — Overview
+
+**Scope:** One **minimal** persona per audience in [`../audiences/`](../audiences/_overview.md).
+Each persona names the qualified reader, their goals, pains, and the doc `content_types` they
+need — enough to target content, not a full marketing persona. Journeys in
+[`../journeys/`](../journeys/_overview.md) reference these IDs.
+
+| Persona | Audience | One-liner |
+|---------|----------|-----------|
+| [persona-enterprise-docs-lead](enterprise-docs-lead.md) | aud-enterprise-docs-team | Manages a docs team across many products; gated by security & release timing |
+| [persona-scaleup-solo-writer](scaleup-solo-writer.md) | aud-scaleup-docs-team | The "team of one" writer drowning under eng velocity |
+| [persona-eng-docs-owner](eng-docs-owner.md) | aud-engineer-owned-docs | Engineer/founder who owns docs with no writer |
+| [persona-oss-maintainer](oss-maintainer.md) | aud-oss-maintainer | OSS maintainer keeping community docs alive on the free program |
+| [persona-devrel-owner](devrel-owner.md) | aud-devrel-devex | DevRel/DevEx owner of SDK/API docs, optimizing for agents too |
+| [persona-brownfield-docs-lead](brownfield-docs-lead.md) | aud-brownfield-docs-team | Docs lead remediating & restructuring a large legacy corpus (often also Dana) |
+
+Convention: prerequisites are stated as **qualified-reader knowledge**, not
+beginner/intermediate/advanced labels.

--- a/docs/content_strategy/personas/brownfield-docs-lead.md
+++ b/docs/content_strategy/personas/brownfield-docs-lead.md
@@ -1,0 +1,50 @@
+---
+id: persona-brownfield-docs-lead
+type: persona
+name: "Riley — Docs Lead, Established/Brownfield Corpus"
+audience: aud-brownfield-docs-team
+role: Docs manager or senior technical writer who owns a large, pre-existing doc set
+team_context: an established team (or senior IC within one) maintaining hundreds–thousands of legacy pages
+proficiency: [docs-ops, information-architecture, content-modeling, templates-and-style, git-and-prs]
+prerequisites: [git-and-prs, ia-and-taxonomy-literacy]
+goals:
+  - Restore corpus health (freshness, consistency, coverage) without a manual rewrite
+  - Restructure the IA to match the product as it is today
+  - Retrofit current standards/templates across legacy pages
+  - Pay down long-tail staleness while keeping up with new change
+  - Prove measurable corpus-health gains to leadership
+pains:
+  - Long-tail staleness no one can audit at scale
+  - Dated IA that no longer maps to the product or users
+  - Inconsistent, off-template, contradictory legacy content
+  - Legacy structure/tooling that resists automated upkeep
+  - Remediating the past while keeping pace with the present
+content_types: [content-audit-remediation, ia-overhaul, standards-enforcement, deep-analysis, migration-guide, multi-repo-routing, reporting-and-roi]
+journeys: [cuj-remediate-legacy-content, cuj-overhaul-ia, cuj-backfill-debt, cuj-migrate-to-docs-as-code, cuj-multi-repo-routing, cuj-calibrate-suggestions, cuj-prove-value]
+---
+
+# Persona: Riley — Docs Lead, Established/Brownfield Corpus
+
+**Scope:** The owner persona for [aud-brownfield-docs-team](../audiences/brownfield-docs-team.md).
+A corpus-state lens, so Riley often *also* fits [persona-enterprise-docs-lead](enterprise-docs-lead.md)
+(Dana) at a large company — use this persona when the **legacy corpus itself** is the job.
+
+Riley inherited a large doc set built over years. The team is competent, but the corpus has
+outgrown its structure: topics sprawl, pages contradict each other, screenshots and steps are
+stale across thousands of pages, and the navigation reflects an older product. Riley thinks in
+taxonomies, templates, and content models — not individual pages — and is wary of any tool that
+might flood the team with noise or low-quality edits, because on a brownfield corpus that makes
+the debt *feel worse*, not better.
+
+**What Riley needs from docs:** content-audit/remediation and IA-overhaul guidance scaled to a
+large corpus; standards/template enforcement; Deep Analysis for debt; migration help when the
+legacy platform is the blocker; and reporting that proves corpus-health gains (freshness,
+consistency, coverage), not just drafts produced.
+
+**Secondary role to keep in mind:** the **hands-on remediation IC** — a senior writer executing
+the audit/restandardization — shares these journeys from an execution angle. Both are served by
+the same content; Riley is the decision-maker/owner.
+
+**Success looks like:** a measurable jump in corpus freshness and consistency, an IA that
+matches today's product, and standards retrofitted across legacy pages — achieved without a
+manual rewrite and without drowning the team in noise.

--- a/docs/content_strategy/personas/devrel-owner.md
+++ b/docs/content_strategy/personas/devrel-owner.md
@@ -1,0 +1,41 @@
+---
+id: persona-devrel-owner
+type: persona
+name: "Devon — DevRel / DevEx Owner"
+audience: aud-devrel-devex
+role: Developer advocate or DevEx/DevX engineer who owns docs alongside other duties
+team_context: API-first / SDK-heavy dev-tool company (commercial or open-core)
+proficiency: [api-and-sdk-expert, git, thinks-in-developer-and-agent-consumers]
+prerequisites: [git-and-prs, api-sdk-fluency]
+goals:
+  - Keep large SDK/API docs accurate while focusing on advocacy/DevEx
+  - Make docs discoverable and trustworthy to AI coding agents
+  - Retire an unreliable homegrown AI docs script
+  - Enforce style across docs and technical marketing
+pains:
+  - SDK/API surface too large to chase; constant stale/wrong reports
+  - Docs not structured for agents (no llms.txt); agents implement SDK wrong
+  - Homegrown automation takes input at face value and errors
+  - Style drift across docs + marketing copy
+content_types: [sdk-api-reference-accuracy, agent-friendliness-llms-txt, code-example-validation, cross-repo-triggers, style-enforcement, quickstart]
+journeys: [cuj-evaluate-pilot, cuj-connect-sources, cuj-agent-friendly-docs, cuj-calibrate-suggestions]
+---
+
+# Persona: Devon — DevRel / DevEx Owner
+
+**Scope:** The owner/evaluator persona for [aud-devrel-devex](../audiences/devrel-devex.md).
+
+Devon is a developer advocate or DevEx engineer who owns developer docs as one of several
+hats. The SDK/API surface is large and fast-moving, so reference goes stale faster than Devon
+can chase, and there's a steady drip of "this is wrong" feedback. Devon knows AI coding agents
+are now a primary docs consumer and worries the docs aren't discoverable (no `llms.txt`) or
+accurate enough for agents to implement the product correctly. Devon has probably already
+built a homegrown GitHub-Action docs script that proved unreliable and wants to replace it —
+but will benchmark Promptless against building it in-house, so differentiation
+(code-example validation, cross-repo fidelity) must be clear.
+
+**What Devon needs from docs:** agent-friendliness/`llms.txt`, code-example validation
+(Doc Detective), SDK/API accuracy, and cross-repo triggers — framed for a technical owner.
+
+**Success looks like:** SDK/API docs stay accurate automatically, are agent-discoverable, and
+Devon retires the homegrown script with confidence.

--- a/docs/content_strategy/personas/eng-docs-owner.md
+++ b/docs/content_strategy/personas/eng-docs-owner.md
@@ -1,0 +1,40 @@
+---
+id: persona-eng-docs-owner
+type: persona
+name: "Eli — Engineer / Founder who owns docs"
+audience: aud-engineer-owned-docs
+role: Engineer, eng manager, or founder championing docs with no writer on staff
+team_context: startup/mid-market commercial SaaS, docs-as-code, no technical writer
+proficiency: [git-and-ci-expert, codebase-deep, weak-editorial-vocab]
+prerequisites: [git-and-prs, ci-cd]
+goals:
+  - Maintain customer-facing docs without hiring a writer
+  - Get suggestions auto-assigned and into an inbox someone clears
+  - Pay down existing docs debt in bulk
+  - Generate release notes from PRs/Slack
+pains:
+  - No one owns the queue; debt grows silently
+  - Day-one noise overwhelms the team
+  - Code PRs lack the "why" / full feature picture
+  - No release-notes process
+content_types: [quickstart, review-and-triage, auto-assignment, deep-analysis, release-notes, suggestion-filtering, api-triggers, providing-feedback]
+journeys: [cuj-evaluate-pilot, cuj-calibrate-suggestions, cuj-triage-review-queue, cuj-backfill-debt, cuj-release-notes]
+---
+
+# Persona: Eli — Engineer / Founder who owns docs
+
+**Scope:** The champion/owner persona for [aud-engineer-owned-docs](../audiences/engineer-owned-docs.md).
+
+Eli is an engineer (or founder) at a company with no technical writer. Docs are a shared eng
+responsibility that no one actually owns, so debt accrues quietly until a customer complains.
+Eli is fluent in Git and CI but thinks in code, not editorial process, and wants Promptless to
+detect, draft, and ideally **assign** doc work so engineers approve rather than author. Eli is
+hypersensitive to noise: a loud first batch against a debt-laden repo will make the team
+disengage and the queue will die.
+
+**What Eli needs from docs:** engineer-framed setup; the review/triage loop with
+**auto-assignment**; Deep Analysis for debt paydown; release-notes generation; and clear
+noise/relevance tuning — all assuming no writer exists.
+
+**Success looks like:** a tuned, low-noise queue with owners auto-assigned, mature areas
+backfilled by Deep Analysis, and release notes generated without anyone writing them by hand.

--- a/docs/content_strategy/personas/enterprise-docs-lead.md
+++ b/docs/content_strategy/personas/enterprise-docs-lead.md
@@ -1,0 +1,39 @@
+---
+id: persona-enterprise-docs-lead
+type: persona
+name: "Dana — Documentation Manager"
+audience: aud-enterprise-docs-team
+role: Manager/Director of Documentation (also: Digital CX manager, Docs Engineering lead)
+team_context: leads 3–50 writers across many products and engineering teams
+proficiency: [docs-as-code, ci-release-process, security-compliance-vocab, docs-ops]
+prerequisites: [git-and-prs, their-own-release-process]
+goals:
+  - Keep a large multi-product corpus current without new headcount
+  - Scope drafting to actual releases (avoid pre-ship/feature-flag noise)
+  - Pass security/self-host/SSO review and procurement
+  - Show docs-team efficiency/ROI to leadership
+pains:
+  - Can't see what changed across many products/repos/orgs
+  - AI output trust after an underwhelming in-house pilot
+  - Legacy CCMS / mid-migration off hosted platforms
+content_types: [conceptual, multi-repo-routing, security-and-self-host, sso, deep-analysis, release-timing-config, localization, admin-and-roles, roi-reporting]
+journeys: [cuj-evaluate-pilot, cuj-enterprise-security-review, cuj-multi-repo-routing, cuj-calibrate-suggestions, cuj-prove-value, cuj-migrate-to-docs-as-code]
+---
+
+# Persona: Dana — Documentation Manager (enterprise)
+
+**Scope:** The decision-maker/owner persona for [aud-enterprise-docs-team](../audiences/enterprise-docs-team.md).
+
+Dana runs a documentation organization at a large company. Her writers are spread thin across
+many products shipped by autonomous eng teams, and leadership keeps the headcount flat while
+asking for more. She has likely already run an internal AI experiment that produced
+hallucinations and lost the room, so she evaluates output quality skeptically and needs to
+forward security/self-host/SSO documentation to IT and procurement before anything ships.
+
+**What she needs from docs:** thorough, forwardable security/self-host/SSO references;
+multi-repo routing and release-timing configuration; Deep Analysis for backfilling debt;
+localization; and admin/roles content for governing a team. She reads to *evaluate and de-risk*,
+not to tinker.
+
+**Success looks like:** a scoped pilot that proves trustworthy, release-timed drafts on a
+couple of products, cleared by security, with a story she can tell leadership.

--- a/docs/content_strategy/personas/oss-maintainer.md
+++ b/docs/content_strategy/personas/oss-maintainer.md
@@ -1,0 +1,42 @@
+---
+id: persona-oss-maintainer
+type: persona
+name: "Mara — OSS Maintainer"
+audience: aud-oss-maintainer
+role: Project maintainer / core contributor (sometimes a volunteer docs lead)
+team_context: community or foundation OSS project (often cloud-native-foundation-adjacent), free OSS program
+proficiency: [git-and-oss-workflow-expert, multi-repo, versioning, sometimes-i18n]
+prerequisites: [git-and-prs, public-repo-access]
+goals:
+  - Keep project docs accurate as the code moves fast
+  - Stop backfilling for contributors who skip doc PRs
+  - Route changes to the right repo and versioned docs set
+  - Keep translations from falling years behind
+  - (SDK/protocol) be accurate enough that AI agents implement it correctly
+pains:
+  - Contributors don't write docs
+  - Multi-repo, multi-version routing is fiddly
+  - Localization runs months/years behind
+  - Docs are thin/scattered and need backfill
+content_types: [oss-program-onboarding, read-only-app-setup, multi-repo-routing, versioned-docs, localization, code-example-validation, agent-friendliness]
+journeys: [cuj-oss-onboarding, cuj-multi-repo-routing, cuj-localization, cuj-backfill-debt, cuj-agent-friendly-docs]
+---
+
+# Persona: Mara — OSS Maintainer
+
+**Scope:** The maintainer persona for [aud-oss-maintainer](../audiences/oss-maintainer.md).
+
+Mara maintains an open-source project and inherits the docs burden because contributors merge
+code but skip the doc PRs. She's an expert in Git and multi-repo OSS workflows, manages
+versioned docs, and often juggles community translations that lag badly. She's adopting
+Promptless through the **free OSS program**, so there's no procurement — but she does need a
+**read-only GitHub app** and the comfort to grant access to public repos, and governance is
+diffuse (no single owner to say yes). For SDK/protocol projects she also wants docs accurate
+enough that AI coding agents recommend and correctly implement the project.
+
+**What Mara needs from docs:** OSS-program onboarding, read-only app setup, multi-repo +
+versioned-docs routing, localization, and code-example validation — documented for a
+community context.
+
+**Success looks like:** doc updates auto-drafted for changes contributors forgot, routed to
+the right version, with translations kept current — freeing Mara for code.

--- a/docs/content_strategy/personas/scaleup-solo-writer.md
+++ b/docs/content_strategy/personas/scaleup-solo-writer.md
@@ -1,0 +1,39 @@
+---
+id: persona-scaleup-solo-writer
+type: persona
+name: "Sam — Lead / Solo Technical Writer"
+audience: aud-scaleup-docs-team
+role: Sole or lead technical writer (often reporting into product, support, or eng)
+team_context: 1–3 writers at a high-growth commercial SaaS on a docs-as-code stack
+proficiency: [git-and-prs, markdown, docs-as-code-ssg, ci-basics]
+prerequisites: [git-and-prs, a-docs-as-code-repo]
+goals:
+  - Stop being reactive — get told what shipped that needs docs
+  - Keep up with eng velocity without dropping things
+  - Eliminate manual screenshot recapture
+  - Demonstrate personal leverage / justify the role
+pains:
+  - "I'm underwater; things fall through the cracks"
+  - No reliable signal of what changed
+  - Setup/access friction (tokens, repo scope) silently breaks coverage
+  - Tooling lock-in (a hosted docs platform) mid-migration
+content_types: [quickstart, triggers-setup, context-sources-setup, review-and-triage, screenshots, notifications, migration-guide, faq]
+journeys: [cuj-evaluate-pilot, cuj-connect-sources, cuj-calibrate-suggestions, cuj-triage-review-queue, cuj-screenshots, cuj-migrate-to-docs-as-code, cuj-prove-value]
+---
+
+# Persona: Sam — Lead / Solo Technical Writer (scale-up)
+
+**Scope:** The dominant champion/evaluator persona for [aud-scaleup-docs-team](../audiences/scaleup-docs-team.md).
+
+Sam is the only writer (or one of two) at a fast-growing SaaS company. Engineering ships
+faster than Sam can track, so docs slip and Sam fears what's falling through the cracks. Sam
+already works docs-as-code (or is the one dragging the org onto it) and has zero patience for
+heavy setup. Sam is usually both the champion *and* the buyer — adoption turns on how quickly
+the first genuinely useful, accurate suggestion appears.
+
+**What Sam needs from docs:** a fast quickstart; clear trigger and context-source setup; the
+review/triage loop; screenshots; and migration guidance when moving off a hosted platform.
+Self-serve and quick beats comprehensive.
+
+**Success looks like:** within the first session, Promptless surfaces a real change Sam missed
+and drafts a usable PR — and Sam can point to merged doc PRs as proof of leverage.


### PR DESCRIPTION
## What

Adds a versioned, agent-readable **documentation strategy** under `docs/content_strategy/`:

- **6 audiences** (`audiences/`) — segmented by *who owns docs × company maturity*, plus a cross-cutting **brownfield** segment (teams with a large legacy corpus).
- **6 minimal personas** (`personas/`) — one per audience, using a qualified-reader/prerequisites model.
- **16 critical user journeys** (`journeys/`) — each mapping steps to real `/docs/...` touchpoints, with a persona→CUJ coverage matrix.
- **Proposed Docs-tab IA + gap analysis** (`information_architecture/`) — a CUJ-driven structure for `src/content/docs/docs/`, designed from what users need to accomplish rather than existing topics, with an explicit list of missing content.
- **AGENTS.md** — compressed pointers to the strategy (removes the stale `meta/reference/` section).

Also includes a pre-existing local commit, "Update docs codeowner."

## Why

Promptless had no formal record of who its docs serve. This reconstructs that foundation from customer and prospect interviews so future content, IA, and positioning work can build on it, and so agents can load it on demand. Surfacing the IA gaps (what the journeys need but the docs lack) is an intended deliverable.