### PR TITLE
content: Developer Experience Documentation: Why Docs Fail Before Developers Complain

### DIFF
--- a/src/content/blog/technical/developer-experience-documentation.mdx
+++ b/src/content/blog/technical/developer-experience-documentation.mdx
@@ -1,0 +1,65 @@
+---
+title: 'Developer Experience Documentation: Why Docs Fail Before Developers Complain'
+subtitle: Published June 2026
+description: >-
+  84% of developers learn from docs before trying the product. DX documentation fails silently: developers leave without complaining. Here is the structural fix.
+date: '2026-06-04T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer lands on your quickstart guide at 10pm. They follow step three and get a 422 error. The endpoint parameter was renamed six weeks ago, but the guide still shows the old name. They spend forty minutes on it before closing the tab.
+
+They don't file a support ticket. You never find out.
+
+This is a developer experience failure. It happened entirely in your documentation.
+
+## Documentation is the primary DX surface
+
+Developer experience is usually framed as a product design problem: how clean the API is, how intuitive the SDK is. Those things matter. But before a developer touches either, they go to your docs.
+
+[Surveys find that 84% of developers learn about and evaluate APIs primarily through documentation](https://www.cherryleaf.com/2024/07/survey-shows-documentation-is-the-no-1-way-that-developers-learn-about-your-api/), well ahead of any other learning resource. Documentation is the interface developers reach first and rely on most. For a developer evaluating your product for the first time, it largely is the developer experience.
+
+The practical consequence is that Time to First Call (TTFC), the primary DX barometer for most DevRel teams, is in large part a documentation quality metric. [Young Copy's benchmark research](https://www.youngcopy.com/insights/how-fast-is-your-api-onboarding-benchmark-your-first-call-time-in-five-minutes) puts top-tier TTFC under two minutes. Getting there is mostly a documentation problem: clear authentication instructions and accurate parameter names. A great API with a confusing quickstart will clock a poor TTFC.
+
+Developers also spend roughly 20% of their working time searching for and digesting API information. Most of that time goes to documentation problems.
+
+## The failure is invisible
+
+When a product feature breaks, you get error logs and activation drops. When documentation breaks, you get nothing.
+
+A developer who hits a broken page rarely complains. [Around 50% of developers abandon an API](https://userguiding.com/blog/user-onboarding-statistics) when documentation fails them. They don't submit a ticket and wait for a fix. They leave. Your support queue stays clean and dashboards look normal. The failure is completely invisible.
+
+The structural problem with developer experience documentation is that the feedback loop is broken. With code, errors surface immediately. With documentation, the failure lands on the developer, who absorbs it silently and disappears. The only signal is absence: a developer who signed up and never made their first API call, a conversion that fell out of the funnel without explanation.
+
+[Documentation debt accrues precisely because the people bearing its cost don't show up in your standups](/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it). The developer who spent 40 minutes on a stale quickstart doesn't file a ticket. They close the tab.
+
+<BlogNewsletterCTA />
+
+## The root cause: drift without signals
+
+Documentation drift explains most developer experience documentation failures. Drift is the gap between what your docs say and what your product does. Code ships on a continuous clock. Documentation updates when someone notices a gap.
+
+At launch, your documentation is accurate. Six weeks later, a parameter has been renamed and an endpoint deprecated. A required field got added to two payloads. None of these changes produced a documentation ticket. The writer didn't know. The docs are now a liability.
+
+Documentation drift is primarily a detection problem. Writing capacity exists at most companies. The missing piece is knowing what changed. And because the failure is invisible, drift accumulates for months before anyone inside the company notices.
+
+The 68% of developers who cite outdated documentation as their top API frustration ([Postman State of the API 2024](https://www.postman.com/state-of-api/2024)) are not dealing with teams that don't care about docs. They are dealing with documentation that was accurate at launch and has since drifted. The [deeper analysis of why drift is a detection problem](/blog/technical/documentation-drift-detection-problem) explains why the standard fixes (quarterly audits, documentation sprints) don't address the actual bottleneck.
+
+## What to measure instead
+
+Support ticket volume is the metric most teams use to evaluate documentation quality. It captures the fraction of developers who hit a problem and complained. It misses everyone who hit the same problem and left.
+
+A better measurement framework starts with TTFC as a documentation quality proxy. If your TTFC is high, look first at the quickstart, not the API design. Then track activation through specific flows: where do developers drop off? Dropoffs during authentication or the first successful call almost always point to documentation problems.
+
+Research from the Developer Experience Index (DXI) framework finds that each one-point improvement in a team's documentation score correlates to 13 minutes saved per developer per week. For a developer community of a thousand, a documentation improvement that saves 13 minutes per week recovers the equivalent of five full-time engineers annually. The [ROI case for developer documentation](/blog/technical/developer-documentation-roi) is significantly larger than most teams realize, and support ticket deflection captures only a fraction of it.
+
+Freshness tracking closes the remaining gap. Completeness counts (does a page exist for each feature?) don't tell you whether existing pages are accurate. What teams need is a signal when product changes happen, which docs cover those features, and which pages haven't been reviewed since. That mechanism catches drift before developers hit it.
+
+Stale documentation is the primary driver of developer experience documentation failure. The teams that get this right write efficiently. But more importantly, they know what needs to change.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer experience documentation`

## Article plan

**Keyword targeted:** developer experience documentation (secondary: time to first call, documentation friction)

**Key ideas:**
1. Documentation is the primary DX surface — 84% of developers learn from docs before touching the product. TTFC is, in large part, a documentation quality metric.
2. DX documentation failures are invisible by design: ~50% of developers abandon an API when docs fail, but they don't complain — they leave silently.

**Thesis:** Documentation quality is the most direct DX driver, but it degrades invisibly because failures produce silent exits rather than error logs.

**Target reader:** DevRel engineers and technical writers at API/SDK companies who know docs matter but need a sharper diagnosis for why they keep failing.

**Key points:**
- Docs are the first and most-used DX surface (84% stat, 20% of time spent searching)
- TTFC is a documentation quality proxy, not just a product complexity metric
- DX documentation failures produce silent exits, not complaint tickets
- Root cause: product ships continuously, docs update when someone notices
- Measure freshness and TTFC, not just completeness and ticket volume

**Internal links:** documentation drift article, documentation debt article, developer documentation ROI article

## File

`src/content/blog/technical/developer-experience-documentation.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsguX21GvpFkTvSK2SCxED)_