### PR TITLE
[codex] Add Founding GTM job posting

### DIFF
--- a/src/content/website/jobs.mdx
+++ b/src/content/website/jobs.mdx
@@ -17,9 +17,46 @@ Read more about [why we're building Promptless](/blog/technical/why-were-buildin
 If you want to do the most impactful work of your career at a company that's growing fast, we'd love to hear from you.
 
 **We're hiring for:**
+- [**Founding GTM**](#founding-gtm): Own customer-facing communications and operations for founder-led sales.
 - [**Founding Engineer**](#founding-engineer): Build the core product—AI agents, integrations, and infrastructure that powers automatic documentation updates.
 
 For all roles, reach out at **founders@promptless.ai**!
+
+{/* I watched session replays and saw that candidates read the job description,
+    scroll to the bottom, and leave without exploring the product. They don't
+    click around on their own. I think understanding what the product does is a
+    key part of deciding to work somewhere, so I'm putting a demo link at every
+    natural break point to give them a nudge. */}
+<div class="pl-jobs-cta pl-jobs-cta-v1">
+  <p class="pl-jobs-cta-context">Curious how the product works?</p>
+  <a href="https://promptless.ai/#demo" data-track-action="watch_demo" data-track-funnel="evaluation" data-track-location="jobs_page">Watch the demo &rarr;</a>
+</div>
+
+## Founding GTM
+
+**San Francisco, CA** · **Full-time**
+
+You'll help turn promising customer conversations into real momentum. Promptless is still founder-led sales, and this role owns the communications and operations around that motion: joining calls, writing crisp follow-up, keeping next steps clean, and building AI-agent workflows that make the system more repeatable.
+
+**What you'll do**
+
+- Join customer calls and turn messy conversations into clear next steps
+- Write internal recaps and customer follow-up that are crisp, specific, and useful
+- Own CRM hygiene, next-step tracking, and lightweight GTM systems
+- Use AI agents for call digests, follow-up drafts, research, and process automation
+
+**What we're looking for**
+
+- Excellent written judgment: you can separate signal from noise without over-explaining
+- Operational reliability: you follow through and keep details straight
+- Comfortable talking to customers, including technical buyers and documentation leaders
+- AI-native: you use LLMs and agents naturally in your own workflow
+
+**Bonus:** Experience in founder-led sales, customer operations, consulting, devtools, technical documentation, DevRel, or sales ops. This is not a traditional AE role with a fixed script and clean handoffs.
+
+**Compensation:** $100k–$160k base + 0.10%–0.50% equity, depending on candidate level.
+
+**Interested?** Reach out at [founders@promptless.ai](mailto:founders@promptless.ai?subject=Founding%20GTM).
 
 {/* I watched session replays and saw that candidates read the job description,
     scroll to the bottom, and leave without exploring the product. They don't

--- a/src/pages/jobs.astro
+++ b/src/pages/jobs.astro
@@ -34,6 +34,28 @@ const jobPostings = [
   {
     "@context": "https://schema.org",
     "@type": "JobPosting",
+    "title": "Founding GTM",
+    "description": "Join Promptless as Founding GTM. Own customer-facing communications and operations for founder-led sales, from call follow-up to CRM hygiene and agent-assisted GTM workflows.",
+    "datePosted": "2026-06-09",
+    "validThrough": "2026-12-31T23:59:59-08:00",
+    "employmentType": "FULL_TIME",
+    "url": "https://promptless.ai/jobs#founding-gtm",
+    "hiringOrganization": org,
+    "jobLocation": location,
+    "baseSalary": {
+      "@type": "MonetaryAmount",
+      "currency": "USD",
+      "value": {
+        "@type": "QuantitativeValue",
+        "minValue": 100000,
+        "maxValue": 160000,
+        "unitText": "YEAR"
+      }
+    }
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "JobPosting",
     "title": "Founding Engineer (All Levels)",
     "description": "Join the Promptless team as a founding engineer. Build AI that keeps documentation in sync with code.",
     "datePosted": "2025-01-01",


### PR DESCRIPTION
## Problem or Objective

- Add a public jobs-page posting for the new Founding GTM role.
- Keep the posting aligned with the existing founder-stage jobs page and proportionate to the Founding Engineer role.

## Solution

- Added Founding GTM to the hiring list and inserted the role before Founding Engineer.
- Added concise role copy covering customer-facing communications, GTM operations, CRM hygiene, and AI-agent leverage.
- Added matching `JobPosting` JSON-LD metadata with SF location, salary range, posting date, and job URL.

## Design Choices

- Preserved the existing jobs-page structure and repeated demo CTA pattern.
- Kept the public posting from mentioning the take-home assessment.
- Used a shorter version of the GTM copy so it is slightly fuller than engineering without feeling out of balance.

## Validation

- `npm run check`
- Refreshed `/jobs#founding-gtm` locally in the in-app browser.
