### PR TITLE
content: Why Developer Relations Docs Go Stale (And How to Fix It)

### DIFF
--- a/src/content/blog/technical/developer-relations-docs.mdx
+++ b/src/content/blog/technical/developer-relations-docs.mdx
@@ -1,0 +1,63 @@
+---
+title: 'Why Developer Relations Docs Go Stale (And How to Fix It)'
+subtitle: Published June 2026
+description: >-
+  DevRel teams write the docs. Engineering teams change the API. Nobody owns the sync. Here's how to close the gap before developers abandon your platform.
+date: '2026-06-09T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A DevRel team spends two weeks writing a comprehensive quickstart guide. It goes live. Developers use it. Support tickets drop. Six months later, someone on the team notices the guide still references an endpoint that engineering renamed in March. Nobody said anything. The developers who hit that error left without filing a ticket.
+
+That's the failure mode for developer relations docs. The accumulation is quiet, and the damage is invisible until it's already done.
+
+## The ownership gap
+
+Most developer-facing docs drift for an org chart reason. DevRel teams own the documentation. Engineering teams own what the documentation describes. When an API parameter gets renamed or a deprecated endpoint gets removed, the change lives in a pull request that DevRel has no visibility into.
+
+There's no malice in this. Engineers ship at pace, and tagging the docs team on every API-adjacent PR is friction nobody will sustain past the first month. So the change ships, the docs stay wrong, and the mismatch compounds until someone catches it manually.
+
+[Postman's 2024 State of the API report](https://www.postman.com/state-of-api/2024) found that 39% of developers cite inconsistent documentation as their single biggest API onboarding roadblock. Inconsistency between docs and product behavior is almost always a staleness problem. The documentation was accurate at launch. The product moved.
+
+The version of this that stings most is in onboarding. [Developer onboarding documentation breaks on a predictable timeline](https://promptless.ai/blog/technical/developer-onboarding-documentation-fails-after-launch): accurate at launch, quietly wrong by the end of the quarter. The developers who hit the gap don't see a team that writes bad docs. They see a platform that can't be trusted.
+
+## Documentation as distribution
+
+The stakes of stale DevRel docs have risen sharply in the past two years.
+
+Developers increasingly interact with your documentation through AI coding assistants. When a developer asks Cursor or GitHub Copilot to help them integrate your SDK, those tools consume your docs as context. They don't skim for warnings or notice that a note at the bottom is outdated. They ingest what's there and generate code against it.
+
+Stale docs no longer just frustrate the developer who reads them directly. They produce stale code in every AI-assisted integration until the doc gets fixed. Sixty-five percent of developers report that their AI coding assistant misses relevant context during code review and integration work. That missing context comes from gaps and inaccuracies in documentation.
+
+[Context engineering research](https://promptless.ai/blog/technical/agent-context-engineering) makes the failure mode explicit: when an agent reads a context document that says a field lives in one table and it was actually migrated three weeks ago, the agent doesn't figure it out. It confidently operates on whatever the doc says. Each step in the agent's execution uses the outputs of prior steps as inputs, so a stale API reference retrieved in step two becomes the assumption underlying every step that follows.
+
+AI-assisted coding is the default workflow for a large and growing share of your developer audience. How accurately your API is represented in the docs that developers feed to their tools affects every integration they build with those tools. Documentation strategy has become distribution strategy.
+
+<BlogNewsletterCTA />
+
+## Why the problem stays invisible
+
+When a developer hits broken documentation, they usually don't file a support ticket. They try a few things, get blocked, and move on. [Research consistently finds](https://userguiding.com/blog/user-onboarding-statistics) that around 50% of developers abandon an API when documentation fails them. They leave without signaling failure.
+
+This is what makes stale DevRel docs so durable. The evidence of failure is a signal that never arrives. Your dashboards stay clean. The broken quickstart stays up. The next developer who finds it hits the same wall.
+
+Meanwhile, a trust spiral takes hold. The same [Postman report](https://www.postman.com/state-of-api/2024) found that 68% of developers cite outdated documentation as their top frustration when working with APIs. Engineers stop updating docs they believe developers have already given up on. Developers stop trusting docs that have already shown them they're wrong. Both behaviors are rational responses to the situation, and together they make the situation worse.
+
+[Documentation debt follows this pattern exactly](https://promptless.ai/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it): it accrues precisely where teams have no visibility, which is why it doesn't surface in normal backlog prioritization. The people bearing the cost of stale DevRel docs are the developers trying to integrate your platform. They have no seat at the table when sprint priorities get set.
+
+## Closing the structural gap
+
+Checklists don't fix this. Asking engineers to notify DevRel on every API-affecting change will get followed for two sprints and then quietly dropped.
+
+The fix is structural: connect your documentation to the source of truth it describes. That means monitoring your codebase and API surface for changes, then surfacing those changes as possible doc gaps to the team that owns the documentation. When an endpoint gets renamed, every doc that references that endpoint should be flagged for review automatically. DevRel doesn't need to read every PR. They need a list of docs that might now be wrong, surfaced at the moment the underlying thing changed.
+
+The goal is to collapse the lag between when engineering ships a change and when DevRel knows to update the docs. Right now, most teams measure that lag in months. A lag measured in months means a developer who found your platform today has a meaningful chance of hitting documentation that's already wrong.
+
+DevRel teams are generally good at writing documentation. What breaks is the feedback loop between what engineering ships and what DevRel knows to update. Close that feedback loop, and the docs stay current.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer relations docs`

## Article plan

**Thesis:** Developer relations docs drift because the team that writes them doesn't own what those docs describe, and the fix is connecting documentation to its source of truth automatically.

**Target reader:** DevRel leads and developer advocates who feel the pain of stale docs but haven't named the structural cause.

**Key points:**
1. Org chart gap: DevRel writes docs, engineering ships changes, nobody owns the sync between the two
2. AI multiplier: AI coding assistants consume docs as context, so stale docs produce stale code at scale across every AI-assisted integration
3. Silent abandonment hides the damage: ~50% of developers abandon an API without signaling failure
4. Trust death spiral: stale docs erode trust, eroded trust reduces incentive to update, repeat
5. Structural fix: connect docs to the codebase/API surface so changes surface as doc gaps automatically

**Promptless connection:** Promptless monitors the codebase and API surface for changes and surfaces them as potential documentation gaps to the team that owns the docs — directly closing the structural gap described in the article.

## File

`src/content/blog/technical/developer-relations-docs.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Atu1m4b4dP8tgvd1w9jwy5)_