### PR TITLE
content: Why Documentation Translations Break After Launch

### DIFF
--- a/src/content/blog/technical/why-documentation-translations-break-after-launch.mdx
+++ b/src/content/blog/technical/why-documentation-translations-break-after-launch.mdx
@@ -1,0 +1,77 @@
+---
+title: 'Why Documentation Translations Break After Launch'
+subtitle: Published June 2026
+description: >-
+  Translating your docs is a project. Keeping translated docs accurate as your product evolves is a system. Most teams build the first thing and skip the second.
+date: '2026-06-10T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A Japanese developer follows your quickstart. The translation looks complete and professional. But the page was last updated five months ago, before you renamed the primary authentication endpoint and moved the SDK configuration step to a prerequisites guide. The Japanese page reflects none of this.
+
+The error they hit doesn't mention documentation. They spend an hour assuming they misconfigured something.
+
+This happens constantly at developer-facing companies that have localized their docs. The English source gets maintained. The translated versions quietly age out.
+
+## Why translated docs drift differently
+
+English documentation drifts when your product changes and no one updates the page. Teams have some visibility into this. Their own developers read the English docs. Support tickets sometimes trace back to specific pages.
+
+Translated documentation drifts the same way, but without the feedback loops. Nobody on your team reads your Japanese docs regularly. Support tickets from Japanese-speaking developers often go to a different queue, handled by an agency that isn't connected to your documentation workflow. The signals that help catch English drift don't exist for secondary languages.
+
+The result is predictable. English docs stay relatively current because they're monitored. Translated docs fall further behind with every product update. A year after launch, your French and German pages may describe a product that no longer exists.
+
+One stale source page causes one problem. Translate that page into four languages and you have four problems. Ship an update without retranslating and you've created four new problems at once, each compounding independently. A docs site with 200 pages, translated into five languages, produces over 1,000 pages of translated content that each need to stay in sync with a product that ships bi-weekly.
+
+That's the translation maintenance problem. Most teams don't scope for it when they decide to localize.
+
+## How translation memory hides the problem
+
+Professional localization workflows use translation memory (TM): a database of previously translated segments, matched against new source content. When source text changes, the TM system assigns a match percentage. A 95% match means a word or two changed. A 75% match means more substantial edits.
+
+The problem is that a 75% match still looks like a minor update. Localization teams are trained to handle these efficiently: review the diff and apply the translation. But the changed portion of a technical sentence is often the part that matters most: a renamed parameter, or an endpoint that moved.
+
+TM systems optimize for translation throughput. They aren't designed to flag semantic risk. A segment that drops from 95% to a 72% match could be a trivial rewording, or it could be a breaking change that will cause every developer who follows that translation to hit an error. Without visibility into what changed on the source side, localization teams can't tell the difference.
+
+Maintenance of translation memory databases tends to be a manual process in most organizations. Terminology changes over time, and keeping the TM in sync with current product language requires active effort that rarely gets resourced.
+
+<BlogNewsletterCTA />
+
+## The continuous localization gap
+
+The localization industry has a term for the right model: continuous localization. Rather than batching translation work into infrequent large projects, you run translation workflows in parallel with development, updating translations as source content changes.
+
+The ROI case for localization is strong. Research by Lokalise found that 65% of B2B leaders report a return of 3x or greater on localization investment, and at least one documented case study showed a 345% ROI from automation. Enterprise translation costs range from $0.08 to $0.25 per word, making the cost of ignoring ongoing retranslation needs real. AI translation tools have reduced per-word costs by 40-60% for first-pass work, which changes the economics of continuous localization in teams' favor.
+
+But continuous localization requires a trigger. Translators and localization managers need to know which pages changed and how significantly, so they can prioritize what to retranslate. That trigger is what most documentation workflows are missing.
+
+A basic version is tracking which source pages were updated after a given date. This is useful but incomplete. A page can change substantially without a reliable last-modified timestamp, and word count differences don't tell you whether the change was a typo fix or a breaking API update.
+
+More useful signals:
+
+- Which source pages changed in the last sprint
+- Whether those changes affected code samples or endpoint references (higher semantic risk than prose edits)
+- Whether the translated version predates the most recent source update
+
+Some localization platforms surface partial versions of this. Lokalise, Crowdin, and others track translation completeness and TM match degradation over time. But these signals live inside the localization platform, disconnected from the documentation platform and the engineering workflow where the original changes originated.
+
+Closing that gap means connecting your documentation pipeline to your localization pipeline, with a consistent signal when retranslation is needed.
+
+## The detection problem, applied to translation
+
+[Documentation drift is fundamentally a detection problem](https://promptless.ai/blog/technical/documentation-drift-detection-problem). The writing and translation work is tractable once you know what needs doing. The bottleneck is knowing it in the first place.
+
+For single-language documentation, this means monitoring your docs against your product to catch when a page drifts from current behavior. For multilingual documentation, that same detection step doubles as the input to your localization queue. When you know which source pages changed and what specifically changed, you know what needs to go back to translation.
+
+Most teams currently discover translation staleness through customer complaints or manual audits. A developer support ticket mentions that your French quickstart references an endpoint that was deprecated six months ago. An audit reveals that three of your five localized languages haven't been touched since the last major product release.
+
+By that point, the stale translations have already been served to developers, agents, and integration tools reading your docs in those languages. [AI coding agents that retrieve your documentation](https://promptless.ai/blog/technical/agent-friendly-docs-necessary-not-sufficient) take translated pages at face value the same way they take English pages at face value. They don't notice that the Japanese version describes an old auth flow. They generate code from whatever they read.
+
+The fix requires catching drift at the source before it propagates through translations. A team that knows a source page changed the moment it changes can route that page to retranslation immediately, rather than discovering the problem after it has already reached users in multiple languages.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `documentation translations`

## Article plan

- **Target keywords:** documentation translations, continuous localization
- **Thesis:** Translating docs is a project. Keeping translated docs accurate as your product evolves is a system. Most teams build the first thing and skip the second.
- **Target reader:** Technical writers, developer advocates, and localization managers at software companies with developer-facing docs in multiple languages
- **Key points:**
  1. Translated docs drift the same way English docs do, but without the feedback loops that help teams catch English drift
  2. Translation memory fuzzy matches mask the problem: a 75% TM match looks manageable, but the changed portion is often the technically critical part
  3. One stale source page creates N stale translated pages simultaneously (the multiplier effect)
  4. Continuous localization is the right model but requires a trigger signal that most doc workflows are missing
  5. AI translation tools lowered the cost per word but didn't solve the "what needs retranslation" detection problem
- **Promptless connection:** Detecting when source docs drift is the exact trigger needed to kick off retranslation — turning doc drift detection into a localization queue input

## File

`src/content/blog/technical/why-documentation-translations-break-after-launch.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_016wbtPFuPQoBJwSrtLqnyJN)_