### PR TITLE
content: Developer Education Has a Tutorial Rot Problem

### DIFF
--- a/src/content/blog/technical/developer-education-tutorial-rot.mdx
+++ b/src/content/blog/technical/developer-education-tutorial-rot.mdx
@@ -1,0 +1,65 @@
+---
+title: 'Developer Education Has a Tutorial Rot Problem'
+subtitle: Published June 2026
+description: >-
+  Tutorials break faster than reference docs and nothing alerts you when they do. Here's why developer education content goes stale and how to catch it.
+date: '2026-06-11T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer finds your quickstart tutorial via search. They follow it step by step. On step four, the API returns an error: the parameter name changed eight months ago. They search your public Slack, find nothing helpful, and close the tab.
+
+That developer did not file a support ticket. Your dashboards look clean. But they're gone.
+
+Developer education is how platform companies convert curious developers into active users. Tutorials and quickstarts are the medium. And that content goes stale faster than most teams notice.
+
+## Why tutorials break differently than reference docs
+
+Reference documentation describes a single thing: an endpoint or a response schema. When that thing changes, updating the reference page is a bounded task. The scope is small and the connection to the product change is obvious.
+
+Tutorials describe a goal. A payment integration tutorial covers authentication, the client library, endpoint formatting, error handling, and often a webhook. Each is a potential failure point. One change to any of them can break the tutorial without breaking any individual reference page.
+
+This is what makes tutorials uniquely fragile compared to reference docs. Reference docs cover one part of the product. Tutorials span the whole flow. When something underneath shifts, tutorials are where it shows. No alert fires. No ticket gets created. The tutorial just starts failing developers quietly.
+
+Twilio's developer education model built a community of over 10 million registered developers and is credited with driving the company past [$5 billion in annual revenue](https://www.twilio.com/en-us/blog/5-ways-to-grow-as-a-developer-with-twilio-education). Stripe's documentation is consistently ranked the gold standard for API onboarding. What both required was sustained investment in education content over years. At scale, that investment also created a large surface of tutorials to maintain as the product kept changing underneath them.
+
+<BlogNewsletterCTA />
+
+## Teams measure publication, not accuracy
+
+Developer education teams track completion rates and publication volume. These are publishing metrics. They tell you what developers started, not whether what they read was accurate when they started it.
+
+A tutorial can have a 70% completion rate and still be wrong. Developers who complete a tutorial by working around errors rarely file support tickets explaining what broke. They move on.
+
+Breaking changes don't retire tutorials automatically. An engineering team ships a new authentication flow, updates the API reference, and closes the task. The quickstart tutorial still shows the old flow. Nobody filed an update task for the tutorial because the tutorial is not in the same tracking system as the API change. The tutorial ages in place.
+
+[Around 50% of developers abandon an API when documentation fails them](https://userguiding.com/blog/user-onboarding-statistics). For tutorials, the abandonment tends to happen at exactly the moment the developer is closest to becoming an active user: right in the middle of their first integration. The lost opportunity is at maximum value precisely because the developer was already engaged.
+
+## AI adoption raised the cost of stale tutorials
+
+The way developers consume tutorials shifted in 2024 and 2025. Rather than following a quickstart step by step, many developers paste the tutorial into a coding agent and ask it to generate scaffolding code. The tutorial becomes context for AI, not a checklist for a human.
+
+When the context is accurate, this works. The agent generates a working implementation and the integration succeeds.
+
+When the context is stale, the failure is worse than what happens when a human reads the same tutorial. A human might notice that a parameter name looks unusual and check the reference docs. An agent reading the same tutorial generates code using the deprecated parameter, compiles without error, and then fails at runtime. The developer gets working-looking code that produces an API error they cannot immediately explain.
+
+[41% of code is now AI-generated](https://www.vibecoders.ph/blog/death-of-tutorial-hell) and that share is growing. Developer education content written for human readers is now also serving as context for AI-assisted implementations. The accuracy requirement is unchanged. The cost of inaccuracy is not.
+
+## Detection is the maintenance strategy
+
+Tutorial rot persists because most teams have no signal for when tutorials go stale. Reference docs break in ways that generate tickets: a parameter is removed and the API returns errors. Tutorials fail silently because the failure happens in developer context, not in any system you can monitor.
+
+The practical fix is detection tied to product changes. When the product changes, the tutorials covering that part of the product should surface for review automatically. An engineering team updates an authentication flow; the tutorials walking developers through authentication should appear in the documentation review queue as a direct result of that commit, not as the output of a scheduled audit that runs quarterly if someone schedules it.
+
+[Documentation drift is a detection problem, not a writing problem](/blog/technical/documentation-drift-detection-problem). The investment in high-quality tutorials at launch does not protect those tutorials from going wrong later. What protects them is knowing when the product they describe has changed.
+
+[Promptless](https://promptless.ai) monitors documentation against the product and codebase continuously, flagging content that references features that have since changed. For developer education teams, this means tutorials and code samples surface for review when the product surfaces they cover change, before a developer follows outdated instructions into a broken integration.
+
+Developer education is a real competitive advantage for platform companies. The teams that sustain that advantage are the ones whose tutorials are still accurate the third time a developer finds them, not just the first.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer education`

## Article plan

**Thesis:** Developer education programs fail quietly because tutorials break silently. Teams measure what they publish, not whether it still works.

**Target reader:** Developer advocates, DevRel leads, and technical writers at companies with API/SDK products who've invested in education content and are hitting a maintenance problem.

**Key points:**
- Tutorials span the product horizontally (auth, libraries, endpoints, error handling, webhooks). One change anywhere breaks the whole flow silently.
- Completion rate and publication volume are the wrong metrics. Broken tutorials don't generate tickets — they generate churn.
- Twilio/Stripe built developer communities on education content; at scale, maintaining accuracy became the hard part.
- AI adoption (41% of code now AI-generated) changed the cost of stale tutorials: agents consume tutorial content as context and produce broken implementations without warning.
- Detection tied to product changes is the only scalable maintenance strategy.

**Promptless connection:** Detecting when tutorials go out of date as the product changes is exactly what Promptless does.

## File

`src/content/blog/technical/developer-education-tutorial-rot.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRj3v4M9tqXu88TxnPDn11)_