### PR TITLE
content: Why Developer Education Content Goes Stale Faster Than Your Docs

### DIFF
--- a/src/content/blog/technical/why-developer-education-content-goes-stale-faster-than-your-docs.mdx
+++ b/src/content/blog/technical/why-developer-education-content-goes-stale-faster-than-your-docs.mdx
@@ -1,0 +1,73 @@
+---
+title: 'Why Developer Education Content Goes Stale Faster Than Your Docs'
+subtitle: Published June 2026
+description: >-
+  Tutorial blog posts, sample apps, and workshop code live outside the docs pipeline. When they drift, no one notices until developers stop converting.
+date: '2026-06-12T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer finds a tutorial on your blog. It has 200 GitHub stars, a link from the official quickstart guide, and a clear step-by-step walkthrough. They follow it exactly. The sample app doesn't build. The auth endpoint returns a 401. The SDK method referenced in step three was removed in version 4.0.
+
+The tutorial was published twenty months ago. Nothing on the page says so.
+
+## The two-tier content problem
+
+Most developer-facing teams produce two categories of technical content.
+
+The first is documentation: reference pages, API specifications, quickstart guides. This content lives in a docs repository, flows through PR review, gets version-tagged, and has at least nominal ownership. When an endpoint changes, there is (in theory) a process for updating the relevant pages.
+
+The second is developer education content: tutorial blog posts, video walkthroughs, workshop materials, sample applications, conference demos. Developer advocates, DevRel engineers, and technical writers produce most of this content, often published outside the docs pipeline on company blogs, personal YouTube channels, GitHub repositories, and community forums.
+
+Both tiers have the same relationship with product changes. Both reference specific endpoints, authentication flows, SDK methods, and data structures. When the product changes, both become inaccurate. The difference is that the first tier has some chance of being caught in a review process. The second tier has none.
+
+## Why tutorials go stale faster
+
+Reference documentation describes the current API surface. A tutorial describes a specific path through that surface at a specific moment in time.
+
+A reference page for `POST /tokens` tells developers what parameters the endpoint accepts today. A tutorial titled "How to authenticate with the v2 API" tells developers exactly which parameters to use, in which order, with which headers, in which SDK version, on the date the tutorial was written.
+
+Every product change that doesn't break the API can still break the tutorial. A renamed response field. An added required parameter with a non-obvious default. A change in how errors are formatted. A deprecation that didn't surface clearly in the changelog. Each represents a gap between what the tutorial says and what the product does.
+
+The more concrete the tutorial, the more surface area for drift. That specificity is also what makes tutorials useful: the exactness that helps a developer get unstuck is the same exactness that makes the tutorial fragile.
+
+<BlogNewsletterCTA />
+
+## The failure is invisible
+
+When reference documentation drifts, it sometimes surfaces in support tickets. A developer notices an inconsistency between the changelog and the reference page and asks about it.
+
+Tutorial failures produce a different signal. [Research consistently estimates that around 50% of developers abandon an integration when documentation fails them](https://userguiding.com/blog/user-onboarding-statistics). They don't file a ticket saying "your blog post from last year has the wrong auth header." They leave. The failure appears not in the support queue but as a missing conversion that looks identical to a developer who never tried.
+
+Search engines compound this. A tutorial published two years ago continues to rank for "how to authenticate with [your product]." Developers following the recommended search result hit a tutorial that was accurate for a product version that no longer exists. The traffic keeps coming; the breakage continues.
+
+The [Postman 2024 State of the API report](https://www.postman.com/state-of-api/2024) found that 44% of developers dig through source code to understand an API because the documentation doesn't give them what they need. A significant portion of those developers followed tutorial code that pointed them at the wrong version of the product.
+
+## AI coding agents amplify the problem
+
+In 2026, developers don't just read tutorial code. They paste it into AI coding assistants. Copilot, Cursor, and similar tools complete code based on patterns they've seen, including patterns from documentation and tutorials indexed across the web.
+
+A stale tutorial doesn't only mislead the developer who reads it. When that developer pastes the outdated code into an AI tool, the agent extends the pattern. It confidently completes the next method call using the version 3.1 SDK signature, because that's the pattern in the code it was given. The developer gets a plausible-looking, correctly structured result that fails at runtime.
+
+Stale tutorials seed bad patterns into AI-assisted workflows. The blast radius of a single outdated blog post is larger than it was when developers had to type every line themselves.
+
+## Treating education content as a documentation artifact
+
+The detection problem is the same as it is for reference docs: someone has to know what product surfaces a piece of content covers, and someone has to know when those surfaces change.
+
+For reference docs, teams have partial solutions. Docs-as-code workflows surface affected pages in PR reviews. Some teams run automated link checks. Coverage is incomplete, but there's a system.
+
+For developer education content, there is usually no system. The tutorial repository isn't linked to the product repository. The blog post has no metadata about which API version it was written for. The workshop sample app has no designated owner.
+
+The minimal intervention is annotating educational content with the context that makes it auditable: the API version the tutorial targets, the SDK version used, a last-verified date. This doesn't prevent drift, but it tells the next developer reading the tutorial when to be skeptical, and it gives the team a surface to monitor.
+
+The more complete intervention is treating tutorials as documentation artifacts: tracking which product surfaces each tutorial covers and applying the same drift detection that teams apply to reference documentation. When `POST /tokens` gets a new required field, the process that surfaces the reference doc for update should also surface the three tutorials that walk through the authentication flow.
+
+[Documentation drift is a detection problem.](https://promptless.ai/blog/technical/documentation-drift-detection-problem) For reference docs, teams are starting to build detection systems. For developer education content, most teams are still at the stage of discovering the problem exists.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer education`

## Article plan

**Thesis:** Developer education content (tutorials, sample apps, workshop code) goes stale faster than reference docs and stays wrong longer, because it lives outside the systems teams use to detect drift.

**Target reader:** Developer advocates, DevRel engineers, and technical writers at companies with developer-facing APIs who produce tutorial content alongside official docs.

**Key points:**
1. Most teams have two tiers of content: docs (with a review pipeline) and education content (with none)
2. Tutorials go stale faster because they're highly specific to a moment — exact SDK version, exact auth flow, exact parameter names
3. Tutorial failures are invisible — developers leave rather than filing tickets; 50% abandon integrations when docs fail them
4. AI coding assistants amplify stale tutorial patterns, spreading wrong code into AI-assisted workflows
5. The fix is treating tutorial content as a documentation artifact with drift detection

**Promptless connection:** The same detection problem Promptless solves for reference docs exists — unaddressed — in tutorial and educational content.

## File

`src/content/blog/technical/why-developer-education-content-goes-stale-faster-than-your-docs.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_013ewVVCf7qUHWNmr4zgfN4i)_