### PR TITLE
content: API Documentation Automation: What the Tools Solve and What They Don't

### DIFF
--- a/src/content/blog/technical/api-documentation-automation.mdx
+++ b/src/content/blog/technical/api-documentation-automation.mdx
@@ -1,0 +1,79 @@
+---
+title: 'API Documentation Automation: What the Tools Solve and What They Don\'t'
+subtitle: Published June 2026
+description: >-
+  Generation tools handle the easy part. Here's why 55% of API teams still report inconsistent docs, and what automation actually needs to solve.
+date: '2026-06-16T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer calls your API. They get a 400 error. They check the request body format in your docs. Everything looks right. They try again. Same error.
+
+They ping your support channel. The response: that parameter was renamed three sprints ago. The docs were generated from an OpenAPI spec. The spec was never updated.
+
+The generation tool did its job correctly. The problem was upstream.
+
+## Two different problems, one name
+
+When teams talk about automating API documentation, they usually have one of two distinct problems in mind.
+
+The first is generation: take a machine-readable spec (typically an OpenAPI file) and render it into a formatted reference site. This is a well-understood problem. Mintlify, ReadMe, Redocly, and Stoplight all do it reliably. Maintain one spec file; the rendered docs update automatically. The tooling here is mature.
+
+The second is maintenance: keep documentation accurate as the API evolves. This means detecting when code changes diverge from the published spec and surfacing which pages need attention before developers find the problem themselves.
+
+Most tooling solves the first problem. Most documentation failures come from the second.
+
+## What generation actually delivers
+
+Generation from a spec is genuinely useful. Modern tools handle rendering, search, multi-language code samples, versioning, and interactive try-it consoles. If your OpenAPI file is accurate and complete, these tools produce usable reference documentation with modest effort.
+
+The constraint is the spec itself.
+
+A [report on API drift](https://zivodoc.com/blog/api-documentation-drift-prevention/) found that 75% of APIs don't conform to their own specifications. Engineers add a required field. The spec isn't updated that sprint. A PR merges without a matching spec change. Over time, the gap between what the code does and what the spec says widens. The generation tool faithfully renders the outdated spec into polished documentation.
+
+The problem sits upstream of the tool. The renderer works as designed. The source is wrong.
+
+## Why maintenance resists automation
+
+Accurate documentation requires knowledge that doesn't live in the spec file.
+
+It requires knowing that a field was renamed but the old name is still accepted for legacy clients, or that a deprecated authentication flow hasn't been marked in the spec yet. This context exists in commit messages, Slack threads, PR descriptions, and the heads of the engineers who shipped the change.
+
+According to the [Postman 2025 State of the API report](https://www.postman.com/state-of-api/), 55% of API teams report struggling with inconsistent documentation. The State of Docs Report 2025 found that keeping documentation current is the top challenge for more than half of all documentation teams. These numbers hold despite years of investment in generation tooling, because generation doesn't touch the maintenance problem.
+
+LLM-based tools can draft descriptions and fill gaps in coverage. They cannot verify that what they write matches what the API actually does. A language model given an outdated spec will produce fluent documentation for endpoints that no longer work as described. The output looks correct. The inaccuracy is invisible until a developer hits it.
+
+<BlogNewsletterCTA />
+
+## Where detection fits in
+
+The bottleneck in documentation maintenance is detection, not drafting. Before any documentation can be updated, something has to surface that it needs updating.
+
+Docs-as-code workflows help once detection has already happened. A PR template that asks "did you update the docs?" works when the developer knows which docs are affected. It fails when the change touched something the developer didn't flag as documentation-relevant, or when the impact showed up indirectly through a behavior change rather than a schema change.
+
+The [documentation drift problem](/blog/technical/documentation-drift-detection-problem) is fundamentally about this gap. Most teams discover outdated docs through developer complaints or support tickets. By then, developers have already encountered the lie and may have stopped trusting the docs entirely. Rebuilding that trust takes longer than the original oversight cost.
+
+Some teams run documentation checks in CI. A test that validates the OpenAPI spec against the live service catches drift at the source: if the spec doesn't match actual API responses, the build fails. This forces spec accuracy before documentation is ever generated.
+
+This approach works, but it requires engineering buy-in to treat spec changes as a required part of every feature delivery, not a post-shipping cleanup item.
+
+## What useful automation actually does
+
+The automation that moves the documentation accuracy metric in practice does two things teams currently do manually.
+
+It surfaces when documentation needs attention. That means watching the signals where changes happen (pull requests, commit history, support ticket volume, search queries with no results) and flagging which documentation pages are at risk before developers discover the problem.
+
+It reduces the cost of acting on those signals. A system that detects a spec divergence and drafts the updated section for human review is more useful than one that only files the alert. Drafting removes the blank page problem. Accuracy judgment still requires a human who understands the product.
+
+A useful framing from changelog work applies here: developers need to know what changed and what they have to do differently, not just that something changed. As covered in [API changelog best practices](/blog/technical/api-changelog-best-practices), the failure mode is often that a change gets announced without the actionable context developers need to adapt. The same failure mode shows up in stale reference documentation.
+
+The teams making progress on documentation accuracy treat it as a continuous process rather than a post-shipping phase. Automation handles detection and initial drafting. Judgment on accuracy still requires someone who understands the product. The goal is to make that judgment faster and cheaper, not to eliminate it.
+
+For the 55% of API teams still reporting inconsistent documentation, the generation tooling is probably adequate. The gap is on the maintenance side: detecting what changed, identifying which docs are affected, and acting on it quickly enough that developers don't encounter the inaccuracy first.
+
+<BlogRequestDemo />

--- a/src/content/blog/technical/api-documentation-automation.mdx
+++ b/src/content/blog/technical/api-documentation-automation.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'API Documentation Automation: What the Tools Solve and What They Don\'t'
+title: "API Documentation Automation: What the Tools Solve and What They Don't"
 subtitle: Published June 2026
 description: >-
   Generation tools handle the easy part. Here's why 55% of API teams still report inconsistent docs, and what automation actually needs to solve.

--- a/src/content/blog/technical/api-documentation-automation.mdx
+++ b/src/content/blog/technical/api-documentation-automation.mdx
@@ -14,7 +14,7 @@ import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
 A developer calls your API. They get a 400 error. They check the request body format in your docs. Everything looks right. They try again. Same error.
 
-They ping your support channel. The response: that parameter was renamed three sprints ago. The docs were generated from an OpenAPI spec. The spec was never updated.
+They ping your support channel. The response: that parameter was renamed three sprints ago. A tool generated the docs from an OpenAPI spec. No one updated the spec.
 
 The generation tool did its job correctly. The problem was upstream.
 
@@ -22,57 +22,55 @@ The generation tool did its job correctly. The problem was upstream.
 
 When teams talk about automating API documentation, they usually have one of two distinct problems in mind.
 
-The first is generation: take a machine-readable spec (typically an OpenAPI file) and render it into a formatted reference site. This is a well-understood problem. Mintlify, ReadMe, Redocly, and Stoplight all do it reliably. Maintain one spec file; the rendered docs update automatically. The tooling here is mature.
+The first is generation. A tool takes a machine-readable spec, usually an OpenAPI file. It renders that spec into a formatted reference site. This is a well-understood problem. Mintlify, ReadMe, Redocly, and Stoplight all do it reliably. You maintain one spec file. The rendered docs update on their own. The tooling here is mature.
 
-The second is maintenance: keep documentation accurate as the API evolves. This means detecting when code changes diverge from the published spec and surfacing which pages need attention before developers find the problem themselves.
+The second is maintenance. You keep documentation accurate as the API changes. This means you detect when code changes diverge from the published spec. It also means you surface which pages need attention before developers find the problem themselves.
 
 Most tooling solves the first problem. Most documentation failures come from the second.
 
 ## What generation actually delivers
 
-Generation from a spec is genuinely useful. Modern tools handle rendering, search, multi-language code samples, versioning, and interactive try-it consoles. If your OpenAPI file is accurate and complete, these tools produce usable reference documentation with modest effort.
+Generation from a spec is useful. Modern tools handle rendering. They add search. They produce multi-language code samples. They manage versioning. They provide interactive try-it consoles. If your OpenAPI file is accurate and complete, these tools produce usable reference documentation with little effort.
 
 The constraint is the spec itself.
 
-A [report on API drift](https://zivodoc.com/blog/api-documentation-drift-prevention/) found that 75% of APIs don't conform to their own specifications. Engineers add a required field. The spec isn't updated that sprint. A PR merges without a matching spec change. Over time, the gap between what the code does and what the spec says widens. The generation tool faithfully renders the outdated spec into polished documentation.
-
-The problem sits upstream of the tool. The renderer works as designed. The source is wrong.
+A [report on API drift](https://zivodoc.com/blog/api-documentation-drift-prevention/) found that 75% of APIs don't conform to their own specifications. Engineers add a required field. No one updates the spec that sprint. A PR merges without a matching spec change. Over time, the gap between what the code does and what the spec says widens. The tool renders the outdated spec into polished documentation, exactly as designed. The source is wrong, not the renderer.
 
 ## Why maintenance resists automation
 
 Accurate documentation requires knowledge that doesn't live in the spec file.
 
-It requires knowing that a field was renamed but the old name is still accepted for legacy clients, or that a deprecated authentication flow hasn't been marked in the spec yet. This context exists in commit messages, Slack threads, PR descriptions, and the heads of the engineers who shipped the change.
+Take a field that was renamed. The spec still accepts the old name for legacy clients. Or take a deprecated authentication flow. No one marks it in the spec yet. This context lives in commit messages, Slack threads, and PR descriptions. It also lives in the heads of the engineers who shipped the change.
 
 According to the [Postman 2025 State of the API report](https://www.postman.com/state-of-api/), 55% of API teams report struggling with inconsistent documentation. The State of Docs Report 2025 found that keeping documentation current is the top challenge for more than half of all documentation teams. These numbers hold despite years of investment in generation tooling, because generation doesn't touch the maintenance problem.
 
-LLM-based tools can draft descriptions and fill gaps in coverage. They cannot verify that what they write matches what the API actually does. A language model given an outdated spec will produce fluent documentation for endpoints that no longer work as described. The output looks correct. The inaccuracy is invisible until a developer hits it.
+LLM-based tools can draft descriptions and fill gaps in coverage. They cannot verify that what they write matches what the API actually does. Fed an outdated spec, a language model produces fluent documentation for endpoints that no longer work as described. The output looks correct. The inaccuracy stays hidden until a developer hits it.
 
 <BlogNewsletterCTA />
 
 ## Where detection fits in
 
-The bottleneck in documentation maintenance is detection, not drafting. Before any documentation can be updated, something has to surface that it needs updating.
+The bottleneck in documentation maintenance is detection, not drafting. Before anyone can update documentation, something has to surface that it needs updating.
 
-Docs-as-code workflows help once detection has already happened. A PR template that asks "did you update the docs?" works when the developer knows which docs are affected. It fails when the change touched something the developer didn't flag as documentation-relevant, or when the impact showed up indirectly through a behavior change rather than a schema change.
+Docs-as-code workflows help once detection has already happened. A PR template asks "did you update the docs?" This works when the developer knows which docs are affected. It fails when the change touches something the developer didn't flag as documentation-relevant. It also fails when the impact shows up through a behavior change rather than a schema change.
 
-The [documentation drift problem](/blog/technical/documentation-drift-detection-problem) is fundamentally about this gap. Most teams discover outdated docs through developer complaints or support tickets. By then, developers have already encountered the lie and may have stopped trusting the docs entirely. Rebuilding that trust takes longer than the original oversight cost.
+The [documentation drift problem](/blog/technical/documentation-drift-detection-problem) is about this gap. Most teams discover outdated docs through developer complaints or support tickets. By then, developers have already hit the inaccuracy. Some stop trusting the docs entirely. Rebuilding that trust takes longer than preventing the original oversight would have.
 
-Some teams run documentation checks in CI. A test that validates the OpenAPI spec against the live service catches drift at the source: if the spec doesn't match actual API responses, the build fails. This forces spec accuracy before documentation is ever generated.
+Some teams run documentation checks in CI. A test validates the OpenAPI spec against the live service. This catches drift at the source. If the spec doesn't match actual API responses, the build fails. Spec accuracy comes before anyone generates documentation.
 
-This approach works, but it requires engineering buy-in to treat spec changes as a required part of every feature delivery, not a post-shipping cleanup item.
+This approach works. It also needs engineering buy-in. The team has to treat spec changes as a required part of every feature delivery, not a post-shipping cleanup item.
 
 ## What useful automation actually does
 
-The automation that moves the documentation accuracy metric in practice does two things teams currently do manually.
+The automation that improves documentation accuracy does two things teams currently do manually.
 
-It surfaces when documentation needs attention. That means watching the signals where changes happen (pull requests, commit history, support ticket volume, search queries with no results) and flagging which documentation pages are at risk before developers discover the problem.
+It surfaces when documentation needs attention. It watches where change happens: pull requests, commit history, support ticket volume, and search queries with no results. It then flags which documentation pages are at risk before developers discover the problem.
 
-It reduces the cost of acting on those signals. A system that detects a spec divergence and drafts the updated section for human review is more useful than one that only files the alert. Drafting removes the blank page problem. Accuracy judgment still requires a human who understands the product.
+It reduces the cost of acting on those signals. One system detects a spec divergence and drafts the updated section for human review. Another only files the alert. The first is more useful. Drafting removes the blank page problem.
 
-A useful framing from changelog work applies here: developers need to know what changed and what they have to do differently, not just that something changed. As covered in [API changelog best practices](/blog/technical/api-changelog-best-practices), the failure mode is often that a change gets announced without the actionable context developers need to adapt. The same failure mode shows up in stale reference documentation.
+A useful framing from changelog work applies here: developers need to know what changed and what they have to do differently, not just that something changed. As covered in [API changelog best practices](/blog/technical/api-changelog-best-practices), the failure mode is often that a team announces a change without the actionable context developers need to adapt. The same failure mode shows up in stale reference documentation.
 
-The teams making progress on documentation accuracy treat it as a continuous process rather than a post-shipping phase. Automation handles detection and initial drafting. Judgment on accuracy still requires someone who understands the product. The goal is to make that judgment faster and cheaper, not to eliminate it.
+The teams making progress on documentation accuracy treat it as a continuous process, not a post-shipping phase. Automation handles detection and initial drafting. Judgment on accuracy still requires someone who understands the product. The goal is to make that judgment faster and cheaper, not to remove it.
 
 For the 55% of API teams still reporting inconsistent documentation, the generation tooling is probably adequate. The gap is on the maintenance side: detecting what changed, identifying which docs are affected, and acting on it quickly enough that developers don't encounter the inaccuracy first.
 


### PR DESCRIPTION
**Keyword:** `API documentation automation`

> **Update (STE rework):** The article prose has been rewritten in Simplified Technical English at Isaiah's request — shorter single-idea sentences, plainer word choices, active voice, and less over-explaining. This is a style/readability pass only: the substance, structure, all factual claims and statistics, all links, and both CTA components are preserved.
>
> Requested by: Isaiah Bell

## Article plan

**Thesis:** API documentation automation is a two-phase problem. Generation from OpenAPI specs is mature and mostly solved. Keeping generated docs accurate as the API evolves is not.

**Target reader:** Technical writers and developer advocates at API-first companies who've invested in doc tooling but still find their docs going stale.

**Key points:**
- Generation from specs (Mintlify, ReadMe, Redocly, Stoplight) is a solved problem
- But 75% of APIs don't conform to their own specs — the source goes stale before the renderer runs
- 55% of API teams report inconsistent documentation (Postman 2025); keeping docs current is the #1 challenge for >50% of doc teams (State of Docs 2025)
- LLMs can draft but can't verify accuracy — they confidently describe deprecated behavior
- CI/CD doc checks and continuous drift detection are the emerging approach for the maintenance side
- Promptless connection: continuous monitoring for divergence between product behavior and docs

**Internal links:** documentation-drift-detection-problem, api-changelog-best-practices

## File

`src/content/blog/technical/api-documentation-automation.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9yNA5MTdPN7xtrBNNcZrw)_
