### PR TITLE
content: Why DevRel Documentation Falls Behind the Product

### DIFF
--- a/src/content/blog/technical/developer-relations-docs-maintenance-problem.mdx
+++ b/src/content/blog/technical/developer-relations-docs-maintenance-problem.mdx
@@ -1,0 +1,69 @@
+---
+title: 'Why DevRel Documentation Falls Behind the Product'
+subtitle: Published June 2026
+description: >-
+  DevRel teams are optimized for shipping tutorials, not maintaining them. Here's the structural gap that makes developer relations documentation go stale.
+date: '2026-06-17T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer advocate publishes a tutorial showing how to integrate your OAuth flow with a popular frontend framework. It ranks well, gets referenced in the community Discord, and drives real activations in the first month.
+
+Six months later, your team ships a revised token format. The tutorial still shows the old request body. Nobody owns the update. The DevRel engineer who wrote it is three conference talks deep into the next quarter. The tutorial still surfaces in search and still gets clicked. Most developers who try to follow it get a 401 error on step four.
+
+This is the documentation problem specific to developer relations teams: not that they write too little, but that they write in a way that scales the liability faster than the maintenance capacity.
+
+## What DevRel documentation actually is
+
+Product teams own the reference documentation. API specs, parameter tables, error code glossaries: these live in version-controlled repos and get updated as part of the engineering workflow.
+
+DevRel documentation is a different layer. Tutorials. Integration guides. Sample applications. Blog posts with embedded code. Quickstarts targeted at specific frameworks or use cases. These are explanatory and opinionated, built around a specific version of the product at a specific moment.
+
+That distinction matters because the two types of documentation have very different maintenance mechanics.
+
+Reference docs are part of the engineering cycle. When the auth endpoint changes, the spec gets updated alongside the code. There's a PR, a reviewer, and a record of the change. The tooling enforces it.
+
+DevRel documentation has none of that. It lives outside the version-controlled docs repo. It doesn't go through engineering review. A product change that triggers a spec update does not automatically surface the tutorials built around the old behavior. The path from "product changed" to "tutorial updated" runs entirely through human awareness and human memory.
+
+[Documentation drift](https://promptless.ai/blog/technical/documentation-drift-detection-problem) is a detection problem across all documentation. For DevRel content, the detection gap is wider than anywhere else.
+
+## The content factory trap
+
+DevRel output is typically measured on creation. New tutorials published. New sample apps shipped. New blog posts with code examples. New integration guides for the partnerships team. These are the deliverables that get counted in quarterly reviews and justify headcount.
+
+What doesn't get counted: maintaining the existing library. Auditing tutorials for accuracy. Testing code samples against the current SDK version. Retiring guides that cover deprecated features.
+
+This creates a predictable dynamic. Each new piece of content becomes a liability the moment it's published, because the product will continue shipping and the content will not update itself. Over a two-year run, a DevRel team producing a tutorial per week has 100 tutorials in various states of accuracy, most of which nobody is systematically checking.
+
+The developers who encounter these tutorials don't distinguish between a stale DevRel tutorial and accurate product documentation. They see a piece of content from the company with a working code block, and they trust it. When it produces an error, they lose trust in everything. [Research consistently finds that around half of developers abandon an API](https://userguiding.com/blog/user-onboarding-statistics) when documentation fails them. A stale tutorial with high traffic generates that abandonment at scale.
+
+<BlogNewsletterCTA />
+
+## Where the ownership gap is sharpest
+
+DevRel teams sit organizationally between engineering and marketing. They produce content that is technical in nature but often lives in a CMS, not a code repository. The dedicated documentation team, if one exists, owns the reference docs. Engineering owns the code. Marketing owns the blog. DevRel content falls between all three.
+
+When an engineering team ships a breaking change, nobody's workflow automatically includes "check the DevRel tutorials that touch this feature." The engineering PR might have a checklist for updating the spec. It will not have a checklist for the three tutorials the developer advocate wrote about that feature last year.
+
+This is compounded by turnover. Developer advocates move around. When a DevRel engineer leaves, their tutorials stay. The company retains the liability without retaining the context. A stale tutorial left behind by a departed advocate is like [undocumented onboarding content](https://promptless.ai/blog/technical/developer-onboarding-documentation-fails-after-launch): the artifact exists, but the institutional knowledge that would let someone update it accurately is gone.
+
+The 2024 Stack Overflow Developer Survey found that technical debt is the top frustration for 63% of professional developers. DevRel documentation debt is a specific variant of that problem, concentrated in the surface area most likely to be a developer's first contact with the product.
+
+## What a working maintenance process looks like
+
+Fixing this requires treating DevRel documentation as a first-class asset with an explicit freshness requirement, not a library of one-time deliverables.
+
+**An inventory.** Most DevRel teams don't have a single list of all their published tutorials mapped to the product surfaces each one covers. A content inventory that tags each asset to the features, endpoints, or SDK methods it demonstrates gives you a starting point. Without this map, you can't connect product changes to the content that needs updating. A spreadsheet is sufficient to start.
+
+**Change signals routed to content.** The product changelog should trigger a check of the content inventory. If authentication changes, someone looks at the list of tutorials tagged "authentication" and confirms each one is still accurate. This is the same principle that makes [API changelog communication](https://promptless.ai/blog/technical/api-changelog-best-practices) useful for external developers: the change surfaces the gap, rather than the gap surfacing later through support tickets.
+
+**A freshness date and an owner on every piece.** An asset without an owner and a last-verified date is unowned in practice. The fix is explicit assignment: this tutorial was last verified against SDK version X on this date, and this person is responsible for the next verification. Unowned docs become stale docs.
+
+None of this is expensive to start. A content inventory that takes two hours to build is more useful than three years without one. The DevRel teams that manage documentation effectively over time treat the existing library as a maintenance commitment, not a finished archive.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer relations docs`

## Article plan

**Thesis:** DevRel teams produce documentation at product velocity but maintain it at human memory velocity. The result is a growing library of tutorials that degrade as the product ships.

**Target reader:** Developer advocates and DevRel leads at companies with API/SDK products who've felt the tutorial-staleness pain but haven't connected it to a structural root cause.

**Key points:**
1. DevRel docs (tutorials, integration guides, sample apps) have fundamentally different maintenance mechanics than reference docs — they live outside version control and are invisible to the engineering workflow
2. The content factory trap: DevRel output is measured on creation, not maintenance — each new tutorial is a liability that compounds over time
3. The ownership gap: product changes don't route to DevRel content, and turnover makes stale tutorials permanent
4. A working maintenance process: content inventory, change signals routed to content, freshness dates and named owners

**Promptless connection:** Connecting code change signals to documentation assets — the same mechanism that makes Promptless useful for reference docs applies directly to DevRel content libraries.

## File

`src/content/blog/technical/developer-relations-docs-maintenance-problem.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQH3PgNg7Gb8pMDJWssNHf)_