### PR TITLE
content: Developer Relations Docs: Why Creation Is the Easy Part

### DIFF
--- a/src/content/blog/technical/developer-relations-docs.mdx
+++ b/src/content/blog/technical/developer-relations-docs.mdx
@@ -1,0 +1,77 @@
+---
+title: 'Developer Relations Docs: Why Creation Is the Easy Part'
+subtitle: Published June 2026
+description: >-
+  DevRel teams build great documentation, then ship new features without updating it. Here's why the maintenance gap is growing and what to do about it.
+date: '2026-06-19T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A DevRel engineer spent three days writing a tutorial. Authentication setup, step-by-step API calls, working code samples. It shipped, ranked, and drove signups for six weeks.
+
+Then product renamed the authentication field. The tutorial stayed unchanged. Developers started hitting 401 errors on step two. Support tickets climbed. The tutorial still ranked.
+
+That sequence plays out constantly across developer-facing products. The creation workflow is good. The maintenance workflow barely exists.
+
+## DevRel docs now serve two audiences
+
+Developer relations teams have always written for human developers. That audience reads a tutorial, runs into a problem, and asks a question in Slack or opens a ticket. The feedback loop is slow but visible.
+
+The second audience arrived more quietly. AI coding assistants now consume developer documentation the same way developers do. When a developer asks Cursor or Copilot how to authenticate against your API, the assistant retrieves your tutorial, your API reference, your quickstart, and uses that content as context. A 2026 AngelHack report found that 65% of developers say their AI coding assistant misses relevant context during code review and refactoring, with the gap traced directly to documentation.
+
+A stale tutorial doesn't just mislead one developer per day anymore. It gets embedded in AI context and misleads developers at scale, invisibly, for as long as the content sits there unupdated.
+
+## The maintenance workflow most DevRel teams don't have
+
+DevRel teams are good at building content creation workflows. Content calendars, sprint planning, tutorial templates, peer review before publish. What most teams don't have is a parallel workflow for maintenance.
+
+The math is simple but brutal. A team shipping weekly generates four to eight user-facing changes per week. Each change typically touches two to five help articles or guides. That's eight to forty articles per week that might need updates. Research from documentation teams tracked by HelpSite found that most teams allocate zero hours explicitly for documentation maintenance. The work gets squeezed out by the next content deadline.
+
+The result is predictable. Tutorials drift. Code samples stop running. Parameters get renamed and the reference page doesn't catch up. The documentation technically exists; it just no longer describes the product.
+
+<BlogNewsletterCTA />
+
+## Where DevRel teams learn about broken docs
+
+Most DevRel teams discover documentation problems the same way: someone tweets about it, a support ticket arrives, or a community member posts in Discord asking why step three doesn't work.
+
+By that point, the broken content has already been live for days or weeks. A high-traffic tutorial can mislead hundreds of developers before anyone with commit access hears about it.
+
+The signal that something changed exists. Engineering teams have pull requests, deployment logs, and release notes. But that signal rarely reaches the DevRel team in a form they can act on. There is no automatic connection between "this PR renamed the `auth_token` field" and "update the authentication tutorial."
+
+The gap is not about effort. DevRel engineers are willing to update docs. They just have no systematic way to know when an update is needed.
+
+## The specific content types that drift fastest
+
+Not all DevRel content drifts at the same rate. Some categories are stable; others need active monitoring.
+
+**Quickstarts and getting-started guides** are the most dangerous category. These are the highest-traffic pages and the ones developers read when they are deciding whether your product is worth the integration effort. A broken quickstart doesn't just create a support ticket. It creates churn before the developer ever becomes a customer.
+
+**Code samples** drift whenever the underlying SDK or API changes. A code sample that fails to run is worse than no sample. It signals that the documentation is unreliable, which puts every other page in question.
+
+**Authentication flows** change less frequently but have a high blast radius when they do. A renamed field or a revised token format breaks every integration built against the old spec.
+
+**Conceptual explainers** are the most stable. They describe how something works in general terms and are less likely to break when a parameter changes. These can be revisited on a quarterly schedule rather than tracked against every release.
+
+## What a maintenance workflow actually looks like
+
+The core change is connecting code changes to documentation review. When a pull request touches the authentication module, the DevRel team should receive a prompt to review the authentication tutorial. When the SDK releases a new version, the getting-started guide should be on a review list, not waiting for a support ticket.
+
+Three practical steps:
+
+**Map your docs to your API surface.** Identify which tutorials reference which endpoints, fields, and SDK methods. This doesn't have to be automated at first (a spreadsheet is enough to start). The goal is knowing that when endpoint X changes, pages A, B, and C are the ones to check.
+
+**Monitor high-traffic content on every release.** The top five pages by developer traffic should be reviewed against every significant product change, not on a quarterly schedule. These pages are where trust gets built or broken.
+
+**Build a detection layer before the editorial process.** The writing workflow already exists. What's missing is the signal that triggers it. Connecting your repository activity to your docs workflow gives writers the information they need to act, instead of waiting for developers to report failures.
+
+The [documentation drift detection problem](/blog/technical/documentation-drift-detection-problem) in engineering teams and the maintenance problem in DevRel teams are the same problem from different angles. The product moved. The docs didn't. Someone downstream paid for it.
+
+The companies with the highest developer satisfaction scores don't write more documentation. They've closed the gap between shipping and updating.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer relations docs`

## Article plan

**Thesis:** DevRel teams are good at creating documentation but have no detection layer for when it goes wrong, and AI consumption of those docs has made that gap much more expensive.

**Target reader:** Developer advocates and DevRel engineers at software companies. They know how to write; they're losing the maintenance battle as the product moves fast.

**Key points:**
1. DevRel docs now serve two audiences: human developers and AI coding assistants. One stale tutorial now misleads thousands of AI-assisted developers.
2. Most DevRel teams have creation workflows but no maintenance workflows — content rarely gets revisited after it ships.
3. Teams discover broken docs reactively (support tickets, tweets), not proactively.
4. Different content types drift at different rates: quickstarts > code samples > auth flows > conceptual explainers.
5. The fix: connect code repository changes to a documentation review signal.

**Promptless connection:** Promptless provides the detection layer between code changes and docs updates that DevRel teams are missing.

## File

`src/content/blog/technical/developer-relations-docs.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVd3rTc9L4TFLPvsBynkAm)_