### PR TITLE
content: Launch post — Slite context source integration

### DIFF
--- a/src/content/blog/product-updates/slite-context-source.mdx
+++ b/src/content/blog/product-updates/slite-context-source.mdx
@@ -2,7 +2,7 @@
 title: 'Connect Your Slite Knowledge Base to Promptless'
 subtitle: Published June 2026
 description: >-
-  Promptless now supports Slite as a context source. Connect your Slite workspace via API key and Promptless will pull relevant notes when generating documentation suggestions.
+  Slite is now a supported context source. Connect your workspace via API key and Promptless will search your notes when generating documentation suggestions.
 date: '2026-06-15T00:00:00.000Z'
 author: Frances
 tag: Product Updates
@@ -12,34 +12,41 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-Promptless now supports Slite as a context source. Connect your Slite workspace and Promptless will search it for relevant notes whenever it generates a documentation suggestion.
+Promptless can now read your Slite workspace when generating documentation suggestions. Connect via API key from the Integrations page, and Promptless will search your Slite notes for context each time it creates a suggestion.
 
 ## The problem
 
-Documentation suggestions improve when Promptless can see the internal context behind a code change. For many teams, that context lives in Slite: the PRD that defined the feature, the notes from the design review, the decision log that explains why the API works the way it does.
+Teams that scope and plan in Slite have had to keep that context separate from their documentation workflow. When Promptless generated a suggestion from a merged PR, it could read the diff and pull context from Jira or Linear if those were connected. Anything that lived in Slite stayed invisible.
 
-Without Slite access, Promptless infers terminology and behavior from the code diff and PR description alone. That is often enough, but when the agreed-upon feature name or a specific behavior was decided in a Slite note that nobody copied into the PR, the resulting documentation has to guess.
+That gap mattered when the details that made it into code didn't fully represent the decisions your team had already documented. The official feature name, a retry limit that was debated and settled in a design thread, the reasoning your product team wrote down before engineering started. All of that lived in Slite. When Promptless generated documentation, it inferred those details from the diff instead of reading the spec.
 
-## What changed
+The result was documentation that needed more revision than it should have. Terminology that didn't match the rest of the product. Descriptions that missed context the team had already worked out.
 
-When Slite is connected, Promptless searches your workspace for notes relevant to the PR it is processing. It also resolves any Slite note URLs referenced in the PR description, reading the linked note directly. The result is a suggestion that reflects what your team actually decided, not a reconstruction from the diff.
+## What it does now
 
-Slite access is read-only. Promptless queries notes on demand and does not store any Slite content. Search results are cached briefly during a single documentation session, then discarded.
+When Slite is connected as a context source, Promptless searches your workspace for notes relevant to the current suggestion. It looks for internal documentation that might inform what is being described: product specs, RFCs, design threads, or any notes that overlap with the code being documented.
+
+If a PR description links to a Slite note, Promptless fetches that note's content directly. You can point the agent at a specific spec by including the link, and it will read it as part of creating the suggestion.
+
+Promptless never writes to Slite. It reads in real time, caches results briefly for the duration of a single documentation session, then discards them. No Slite content is stored by Promptless.
 
 <BlogNewsletterCTA />
 
 ## Who benefits most
 
-Teams that maintain a product knowledge base in Slite. The clearest case: a developer merges a PR for a feature that was specced in a Slite PRD. The PRD has the official feature name, the default values, and the design rationale. With Slite connected, Promptless reads that PRD and carries its details into the documentation suggestion instead of inferring them from the code.
+Teams that use Slite as their primary internal knowledge base. If your team writes a spec in Slite before building a feature, the agreed-upon feature name, constraints, and rationale can now reach the documentation Promptless generates. The agent reads the spec rather than inferring those details from the diff alone.
 
-Teams that do not regularly document decisions in Slite before or alongside development will see less benefit.
+This also helps teams maintain consistent terminology across documentation. When a feature has an official name that was decided in a Slite thread, that name is more likely to appear in Promptless's output once the workspace is connected.
 
-## How to set it up
+## How to connect
 
-1. In Slite, go to **Settings > API** and create an API key. A service account is recommended so access scope is predictable.
-2. In the Promptless dashboard, go to the [Integrations page](https://app.gopromptless.ai/integrations).
-3. Click **Connect** on the Slite card, enter your API key, and click **Connect**.
+Slite uses API key authentication rather than OAuth.
 
-Promptless will start using your Slite workspace as context on the next trigger.
+1. In Slite, go to **Settings > API** and create a new API key. The key grants read access to all notes visible to that account. A service account with appropriate scope is recommended.
+2. Go to the [Integrations page](https://app.gopromptless.ai/integrations) in your Promptless dashboard.
+3. Click **Connect** on the Slite integration card.
+4. Enter your API key and click **Connect**.
+
+Once connected, Slite appears as an available context source in your `promptless.yaml`, and Promptless starts drawing on your workspace for new suggestions.
 
 <BlogRequestDemo />

--- a/src/content/blog/product-updates/slite-context-source.mdx
+++ b/src/content/blog/product-updates/slite-context-source.mdx
@@ -1,0 +1,45 @@
+---
+title: 'Connect Your Slite Knowledge Base to Promptless'
+subtitle: Published June 2026
+description: >-
+  Promptless now supports Slite as a context source. Connect your Slite workspace via API key and Promptless will pull relevant notes when generating documentation suggestions.
+date: '2026-06-15T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Promptless now supports Slite as a context source. Connect your Slite workspace and Promptless will search it for relevant notes whenever it generates a documentation suggestion.
+
+## The problem
+
+Documentation suggestions improve when Promptless can see the internal context behind a code change. For many teams, that context lives in Slite: the PRD that defined the feature, the notes from the design review, the decision log that explains why the API works the way it does.
+
+Without Slite access, Promptless infers terminology and behavior from the code diff and PR description alone. That is often enough, but when the agreed-upon feature name or a specific behavior was decided in a Slite note that nobody copied into the PR, the resulting documentation has to guess.
+
+## What changed
+
+When Slite is connected, Promptless searches your workspace for notes relevant to the PR it is processing. It also resolves any Slite note URLs referenced in the PR description, reading the linked note directly. The result is a suggestion that reflects what your team actually decided, not a reconstruction from the diff.
+
+Slite access is read-only. Promptless queries notes on demand and does not store any Slite content. Search results are cached briefly during a single documentation session, then discarded.
+
+<BlogNewsletterCTA />
+
+## Who benefits most
+
+Teams that maintain a product knowledge base in Slite. The clearest case: a developer merges a PR for a feature that was specced in a Slite PRD. The PRD has the official feature name, the default values, and the design rationale. With Slite connected, Promptless reads that PRD and carries its details into the documentation suggestion instead of inferring them from the code.
+
+Teams that do not regularly document decisions in Slite before or alongside development will see less benefit.
+
+## How to set it up
+
+1. In Slite, go to **Settings > API** and create an API key. A service account is recommended so access scope is predictable.
+2. In the Promptless dashboard, go to the [Integrations page](https://app.gopromptless.ai/integrations).
+3. Click **Connect** on the Slite card, enter your API key, and click **Connect**.
+
+Promptless will start using your Slite workspace as context on the next trigger.
+
+<BlogRequestDemo />

--- a/src/content/blog/product-updates/slite-context-source.mdx
+++ b/src/content/blog/product-updates/slite-context-source.mdx
@@ -12,41 +12,41 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-Promptless can now read your Slite workspace when generating documentation suggestions. Connect via API key from the Integrations page, and Promptless will search your Slite notes for context each time it creates a suggestion.
+Promptless reads your Slite workspace when it generates documentation suggestions. Connect Slite with an API key from the Integrations page. Promptless then searches your Slite notes for context each time it creates a suggestion.
 
 ## The problem
 
-Teams that scope and plan in Slite have had to keep that context separate from their documentation workflow. When Promptless generated a suggestion from a merged PR, it could read the diff and pull context from Jira or Linear if those were connected. Anything that lived in Slite stayed invisible.
+Teams that scope and plan in Slite had to keep that context separate from their documentation workflow. When Promptless generated a suggestion from a merged PR, it could read the diff. It could pull context from Jira or Linear if you connected those tools. Anything stored in Slite stayed invisible.
 
-That gap mattered when the details that made it into code didn't fully represent the decisions your team had already documented. The official feature name, a retry limit that was debated and settled in a design thread, the reasoning your product team wrote down before engineering started. All of that lived in Slite. When Promptless generated documentation, it inferred those details from the diff instead of reading the spec.
+The gap mattered because the code did not always show decisions your team had already documented. Those decisions included the official feature name and the retry limit settled in a design thread. They also included the reasoning your product team wrote down before engineering started. When Promptless generated documentation, it inferred those details from the diff instead of reading the spec.
 
-The result was documentation that needed more revision than it should have. Terminology that didn't match the rest of the product. Descriptions that missed context the team had already worked out.
+The result was documentation that needed more revision than it should have. Some terminology did not match the rest of the product. Some descriptions missed context the team had already worked out.
 
 ## What it does now
 
-When Slite is connected as a context source, Promptless searches your workspace for notes relevant to the current suggestion. It looks for internal documentation that might inform what is being described: product specs, RFCs, design threads, or any notes that overlap with the code being documented.
+When you connect Slite as a context source, Promptless searches your workspace for notes related to the current suggestion. It looks for product specs, RFCs, design threads, and other notes that relate to the code being documented.
 
-If a PR description links to a Slite note, Promptless fetches that note's content directly. You can point the agent at a specific spec by including the link, and it will read it as part of creating the suggestion.
+If a PR description links to a Slite note, Promptless fetches that note's content directly. You can point the agent at a specific spec by including the link. Promptless reads it while creating the suggestion.
 
-Promptless never writes to Slite. It reads in real time, caches results briefly for the duration of a single documentation session, then discards them. No Slite content is stored by Promptless.
+Promptless never writes to Slite. It reads Slite in real time and caches results for the duration of a single documentation session. It then discards the cached results and does not store Slite content.
 
 <BlogNewsletterCTA />
 
 ## Who benefits most
 
-Teams that use Slite as their primary internal knowledge base. If your team writes a spec in Slite before building a feature, the agreed-upon feature name, constraints, and rationale can now reach the documentation Promptless generates. The agent reads the spec rather than inferring those details from the diff alone.
+Teams that use Slite as their primary internal knowledge base benefit most. If your team writes a spec in Slite before building a feature, Promptless can use it. The spec's feature name, constraints, and rationale can reach the documentation Promptless generates. The agent reads the spec. It does not infer those details from the diff alone.
 
-This also helps teams maintain consistent terminology across documentation. When a feature has an official name that was decided in a Slite thread, that name is more likely to appear in Promptless's output once the workspace is connected.
+This also helps teams keep consistent terminology across documentation. A feature can have an official name decided in a Slite thread. Once you connect the workspace, that name is more likely to appear in Promptless's output.
 
 ## How to connect
 
-Slite uses API key authentication rather than OAuth.
+Slite uses API key authentication, not OAuth.
 
-1. In Slite, go to **Settings > API** and create a new API key. The key grants read access to all notes visible to that account. A service account with appropriate scope is recommended.
+1. In Slite, go to **Settings > API** and create a new API key. The key grants read access to all notes visible to that account. We recommend using a service account with appropriate scope.
 2. Go to the [Integrations page](https://app.gopromptless.ai/integrations) in your Promptless dashboard.
 3. Click **Connect** on the Slite integration card.
 4. Enter your API key and click **Connect**.
 
-Once connected, Slite appears as an available context source in your `promptless.yaml`, and Promptless starts drawing on your workspace for new suggestions.
+Once connected, Slite appears as an available context source in your `promptless.yaml`. Promptless then uses your workspace for new suggestions.
 
 <BlogRequestDemo />


### PR DESCRIPTION
## Feature

Promptless now supports Slite as a read-only context source. Connect your Slite workspace via API key and Promptless will search relevant notes when generating documentation suggestions.

## Entries considered this run

Window: 2026-06-15 → 2026-06-22.

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **Documentation PR titles and draft state** — Auto-created docs PRs now use the `docs:` prefix and open as drafts until the source PR merges | SKIP | Bug fix / behavioral consistency fix, not a new capability |
| 2 | **Jira comments in context** — Promptless now includes Jira comments alongside issue summary and description | SKIP | Expands existing Jira capability but does not open a new use case |
| 3 | **Slite integration** — Connect Slite as a read-only context source for documentation suggestions | QUALIFIES | New integration unlocking a previously unavailable context source; meets "adds substantial new capabilities" bar |
| 4 | **File-first `promptless.yaml` configuration** — All Promptless configuration now lives in a single `promptless.yaml` file in the Agent Knowledge Base | QUALIFIES | Major new capability; config-as-code workflow previously unavailable (covered by separate PR) |
| 5 | **Automatic trigger and context source configuration from onboarding** — Setup wizard now auto-populates `promptless.yaml` with triggers and context sources | SKIP | Onboarding improvement, not a new capability |
| 6 | **Configuration page accessible to all members** — All org members can view the Configuration page (read-only) | SKIP | Minor permission change |

4 commits in window. 6 entries considered, 2 qualified.

## Covered entry (full text)

> **Slite integration:** Connect your Slite knowledge base to Promptless as a read-only context source. Once connected, Promptless can search your Slite notes when creating documentation suggestions, ensuring your docs align with internal product knowledge. Connect via API key from the [Integrations page](https://app.gopromptless.ai/integrations).

Source: commit [b2ba6e2](https://github.com/Promptless/promptless.ai/commit/b2ba6e2547088f6dc60ac068ce44af75e7b75434) (PR #583).

## PR(s) researched

- Promptless/promptless.ai#583 — Add Slite integration documentation (merged 2026-06-15)

## File

`src/content/blog/product-updates/slite-context-source.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeBY2jzDj297kTKyQEmDvR)_