### PR TITLE
content: Launch post — file-first promptless.yaml configuration

### DIFF
--- a/src/content/blog/product-updates/promptless-yaml-configuration.mdx
+++ b/src/content/blog/product-updates/promptless-yaml-configuration.mdx
@@ -31,21 +31,21 @@ triggers:          # Events that initiate documentation work
 policies:          # Publishing and notification rules
 ```
 
-Edit it in the Configuration page at [app.gopromptless.ai/configuration](https://app.gopromptless.ai/configuration), which provides syntax highlighting, schema-driven completions, and inline validation. Click **Review changes** to see a diff of what you're about to save, then **Save & commit** to apply it.
+Edit it in the Configuration page at [app.gopromptless.ai/configuration](https://app.gopromptless.ai/configuration), which provides syntax highlighting, schema-driven completions, and inline validation. Click **Review changes** to see a diff before saving, then **Save & commit** to apply it.
 
 You can also push changes directly to the file in your Agent Knowledge Base repository. Invalid YAML keeps the last valid configuration active and surfaces the error in the editor.
 
-The editor uses compare-and-swap to prevent overwriting concurrent changes. If someone else modifies the configuration while you're editing, you'll see a conflict warning and can reload to get the latest version.
+The editor uses compare-and-swap to prevent overwriting concurrent changes. If someone else modifies the configuration while you're editing, a conflict warning appears and you can reload to get the latest version.
 
-Changes to `promptless.yaml` take effect immediately for new triggers. Policy changes apply when suggestions are published.
+Changes take effect immediately for new triggers. Policy changes apply when suggestions are published.
 
 <BlogNewsletterCTA />
 
 ## Who benefits most
 
-Teams who want to track configuration changes in version control. When your `promptless.yaml` lives in a repository, you can review configuration changes in PRs, roll back with git, and audit exactly what changed and when.
+Teams who want to track configuration changes in version control. When your `promptless.yaml` lives in a repository, you can review configuration changes in PRs, roll back with git, and audit what changed and when.
 
-It's also useful for anyone debugging unexpected trigger behavior. Instead of clicking through the dashboard to understand what's running, the file is the single source of truth. What's in the file is what's active.
+It's also useful for anyone debugging unexpected trigger behavior. Instead of clicking through the dashboard to understand what's running, the file is the single source of truth.
 
 Teams onboarding for the first time also benefit. Completing the setup wizard now automatically populates `promptless.yaml` with broad triggers and context sources based on the integrations you connected. GitHub connections generate PR and commit triggers covering all repos. Jira, Linear, Notion, and Confluence connections generate unscoped context source entries. Promptless starts listening as soon as onboarding completes, with no manual configuration required.
 

--- a/src/content/blog/product-updates/promptless-yaml-configuration.mdx
+++ b/src/content/blog/product-updates/promptless-yaml-configuration.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Promptless Configuration Now Lives in a YAML File'
+title: 'Promptless Configuration Is Now a File'
 subtitle: Published June 2026
 description: >-
-  All Promptless configuration has moved to a single promptless.yaml file in your Agent Knowledge Base. Triggers, context sources, doc collections, and policies are defined in one place.
+  All Promptless configuration now lives in a single promptless.yaml file. Edit it in the dashboard YAML editor or push changes directly via git.
 date: '2026-06-15T00:00:00.000Z'
 author: Frances
 tag: Product Updates
@@ -12,41 +12,47 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-All Promptless configuration now lives in a `promptless.yaml` file in your organization's Agent Knowledge Base. Triggers, context sources, doc collections, and publishing policies are defined in one place, readable as code.
+All Promptless configuration now lives in a single `promptless.yaml` file in your organization's Agent Knowledge Base. Triggers, doc collections, context sources, and publishing policies are all defined there. The Projects page is replaced by a Configuration page with a YAML editor.
+
+Existing configurations were automatically migrated. If you had projects configured before this change, the same triggers and doc collections are running now, just reflected in `promptless.yaml`.
 
 ## The problem
 
-The previous Projects page worked for getting started. It became awkward for teams managing multiple repositories or wanting to track configuration changes over time. There was no unified view of everything configured, no diff history, and making coordinated changes across triggers and context sources meant navigating between separate pages.
+Promptless was previously configured through a dashboard Projects UI. Changes weren't tracked in version control. There was no diff to review before saving, no way to copy a configuration between environments, and no single file to audit when something was behaving unexpectedly. For teams with several triggers across multiple repositories, understanding what was actually running required navigating the dashboard.
 
-## What changed
+## What it does now
 
-Promptless now reads its configuration from a single `promptless.yaml` file. The file has four top-level sections:
+Your `promptless.yaml` has four sections:
 
 ```yaml
 doc_collections:   # Where documentation lives
-triggers:          # Events that initiate documentation work
 context_sources:   # Integrations for additional context
+triggers:          # Events that initiate documentation work
 policies:          # Publishing and notification rules
 ```
 
-You edit the file in the [Configuration page](https://app.gopromptless.ai/configuration) in the dashboard, which provides a YAML editor with syntax highlighting, schema completions, and inline validation. Click **Review changes** to see a diff before applying. Click **Save & commit** to write the change to your Agent Knowledge Base.
+Edit it in the Configuration page at [app.gopromptless.ai/configuration](https://app.gopromptless.ai/configuration), which provides syntax highlighting, schema-driven completions, and inline validation. Click **Review changes** to see a diff of what you're about to save, then **Save & commit** to apply it.
 
-Configuration changes take effect immediately for new triggers. Policy changes apply when suggestions are finalized.
+You can also push changes directly to the file in your Agent Knowledge Base repository. Invalid YAML keeps the last valid configuration active and surfaces the error in the editor.
 
-Every org member can view the configuration. Only admins can edit and save.
+The editor uses compare-and-swap to prevent overwriting concurrent changes. If someone else modifies the configuration while you're editing, you'll see a conflict warning and can reload to get the latest version.
+
+Changes to `promptless.yaml` take effect immediately for new triggers. Policy changes apply when suggestions are published.
 
 <BlogNewsletterCTA />
 
 ## Who benefits most
 
-Teams that want a complete picture of how Promptless is configured without navigating multiple pages. The YAML format is versionable and diffable, which helps when onboarding new admins or reviewing what changed after a behavior shifts unexpectedly.
+Teams who want to track configuration changes in version control. When your `promptless.yaml` lives in a repository, you can review configuration changes in PRs, roll back with git, and audit exactly what changed and when.
 
-Teams setting up Promptless fresh will start with a `promptless.yaml` that Promptless auto-populates from the integrations they connect during setup. GitHub and GitLab connections generate PR and commit triggers for all repos. Jira, Linear, Notion, and Confluence connections generate unscoped context source entries. Promptless starts listening for documentation-worthy events immediately, with no manual configuration required to get started.
+It's also useful for anyone debugging unexpected trigger behavior. Instead of clicking through the dashboard to understand what's running, the file is the single source of truth. What's in the file is what's active.
 
-## Existing users
+Teams onboarding for the first time also benefit. Completing the setup wizard now automatically populates `promptless.yaml` with broad triggers and context sources based on the integrations you connected. GitHub connections generate PR and commit triggers covering all repos. Jira, Linear, Notion, and Confluence connections generate unscoped context source entries. Promptless starts listening as soon as onboarding completes, with no manual configuration required.
 
-All existing Projects configurations have been automatically migrated to `promptless.yaml`. Your triggers and doc collections continue working without any action.
+## Getting started
 
-You can view your migrated configuration at [app.gopromptless.ai/configuration](https://app.gopromptless.ai/configuration).
+If you had Promptless configured before this change, you're already migrated. Go to [app.gopromptless.ai/configuration](https://app.gopromptless.ai/configuration) to see your current `promptless.yaml`. From there you can narrow scope, add triggers, or adjust policies.
+
+For the full YAML schema, see the [Configuration Reference](/docs/configuring-promptless/configuration-reference).
 
 <BlogRequestDemo />

--- a/src/content/blog/product-updates/promptless-yaml-configuration.mdx
+++ b/src/content/blog/product-updates/promptless-yaml-configuration.mdx
@@ -1,0 +1,52 @@
+---
+title: 'Promptless Configuration Now Lives in a YAML File'
+subtitle: Published June 2026
+description: >-
+  All Promptless configuration has moved to a single promptless.yaml file in your Agent Knowledge Base. Triggers, context sources, doc collections, and policies are defined in one place.
+date: '2026-06-15T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+All Promptless configuration now lives in a `promptless.yaml` file in your organization's Agent Knowledge Base. Triggers, context sources, doc collections, and publishing policies are defined in one place, readable as code.
+
+## The problem
+
+The previous Projects page worked for getting started. It became awkward for teams managing multiple repositories or wanting to track configuration changes over time. There was no unified view of everything configured, no diff history, and making coordinated changes across triggers and context sources meant navigating between separate pages.
+
+## What changed
+
+Promptless now reads its configuration from a single `promptless.yaml` file. The file has four top-level sections:
+
+```yaml
+doc_collections:   # Where documentation lives
+triggers:          # Events that initiate documentation work
+context_sources:   # Integrations for additional context
+policies:          # Publishing and notification rules
+```
+
+You edit the file in the [Configuration page](https://app.gopromptless.ai/configuration) in the dashboard, which provides a YAML editor with syntax highlighting, schema completions, and inline validation. Click **Review changes** to see a diff before applying. Click **Save & commit** to write the change to your Agent Knowledge Base.
+
+Configuration changes take effect immediately for new triggers. Policy changes apply when suggestions are finalized.
+
+Every org member can view the configuration. Only admins can edit and save.
+
+<BlogNewsletterCTA />
+
+## Who benefits most
+
+Teams that want a complete picture of how Promptless is configured without navigating multiple pages. The YAML format is versionable and diffable, which helps when onboarding new admins or reviewing what changed after a behavior shifts unexpectedly.
+
+Teams setting up Promptless fresh will start with a `promptless.yaml` that Promptless auto-populates from the integrations they connect during setup. GitHub and GitLab connections generate PR and commit triggers for all repos. Jira, Linear, Notion, and Confluence connections generate unscoped context source entries. Promptless starts listening for documentation-worthy events immediately, with no manual configuration required to get started.
+
+## Existing users
+
+All existing Projects configurations have been automatically migrated to `promptless.yaml`. Your triggers and doc collections continue working without any action.
+
+You can view your migrated configuration at [app.gopromptless.ai/configuration](https://app.gopromptless.ai/configuration).
+
+<BlogRequestDemo />

--- a/src/content/blog/product-updates/promptless-yaml-configuration.mdx
+++ b/src/content/blog/product-updates/promptless-yaml-configuration.mdx
@@ -12,13 +12,13 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-All Promptless configuration now lives in a single `promptless.yaml` file in your organization's Agent Knowledge Base. Triggers, doc collections, context sources, and publishing policies are all defined there. The Projects page is replaced by a Configuration page with a YAML editor.
+All Promptless configuration now lives in a single `promptless.yaml` file in your organization's Agent Knowledge Base. It defines triggers, doc collections, context sources, and publishing policies. A Configuration page with a YAML editor replaces the Projects page.
 
-Existing configurations were automatically migrated. If you had projects configured before this change, the same triggers and doc collections are running now, just reflected in `promptless.yaml`.
+Promptless migrated existing configurations automatically. If you had projects configured before this change, the same triggers and doc collections run now. They appear in `promptless.yaml`.
 
 ## The problem
 
-Promptless was previously configured through a dashboard Projects UI. Changes weren't tracked in version control. There was no diff to review before saving, no way to copy a configuration between environments, and no single file to audit when something was behaving unexpectedly. For teams with several triggers across multiple repositories, understanding what was actually running required navigating the dashboard.
+Promptless previously used a dashboard Projects UI for configuration. The dashboard did not track changes in version control. You could not review a diff before saving a change. You could not copy a configuration between environments. Auditing a single file was not possible when something misbehaved. Teams with several triggers across multiple repositories had to click through the dashboard to understand what was running.
 
 ## What it does now
 
@@ -31,11 +31,11 @@ triggers:          # Events that initiate documentation work
 policies:          # Publishing and notification rules
 ```
 
-Edit it in the Configuration page at [app.gopromptless.ai/configuration](https://app.gopromptless.ai/configuration), which provides syntax highlighting, schema-driven completions, and inline validation. Click **Review changes** to see a diff before saving, then **Save & commit** to apply it.
+Edit it in the Configuration page at [app.gopromptless.ai/configuration](https://app.gopromptless.ai/configuration). The page provides syntax highlighting, schema-driven completions, and inline validation. Click **Review changes** to see a diff before saving. Click **Save & commit** to apply it.
 
-You can also push changes directly to the file in your Agent Knowledge Base repository. Invalid YAML keeps the last valid configuration active and surfaces the error in the editor.
+You can also push changes directly to the file in your Agent Knowledge Base repository. Invalid YAML keeps the last valid configuration active. The editor shows the error.
 
-The editor uses compare-and-swap to prevent overwriting concurrent changes. If someone else modifies the configuration while you're editing, a conflict warning appears and you can reload to get the latest version.
+The editor uses compare-and-swap to prevent overwriting concurrent changes. If someone else modifies the configuration while you edit it, a conflict warning appears. You can reload to get the latest version.
 
 Changes take effect immediately for new triggers. Policy changes apply when suggestions are published.
 
@@ -43,15 +43,15 @@ Changes take effect immediately for new triggers. Policy changes apply when sugg
 
 ## Who benefits most
 
-Teams who want to track configuration changes in version control. When your `promptless.yaml` lives in a repository, you can review configuration changes in PRs, roll back with git, and audit what changed and when.
+Teams who want to track configuration changes in version control benefit most. Your `promptless.yaml` lives in a repository. You can review configuration changes in PRs, roll back with git, and audit what changed and when.
 
-It's also useful for anyone debugging unexpected trigger behavior. Instead of clicking through the dashboard to understand what's running, the file is the single source of truth.
+It also helps anyone debugging unexpected trigger behavior. The file is the single source of truth. You do not need to click through the dashboard to understand what is running.
 
-Teams onboarding for the first time also benefit. Completing the setup wizard now automatically populates `promptless.yaml` with broad triggers and context sources based on the integrations you connected. GitHub connections generate PR and commit triggers covering all repos. Jira, Linear, Notion, and Confluence connections generate unscoped context source entries. Promptless starts listening as soon as onboarding completes, with no manual configuration required.
+Teams onboarding for the first time also benefit. Completing the setup wizard automatically populates `promptless.yaml` with broad triggers and context sources for the integrations you connected. GitHub connections generate PR and commit triggers covering all repos. Jira, Linear, Notion, and Confluence connections generate unscoped context source entries. Promptless starts listening as soon as onboarding completes. It needs no manual configuration.
 
 ## Getting started
 
-If you had Promptless configured before this change, you're already migrated. Go to [app.gopromptless.ai/configuration](https://app.gopromptless.ai/configuration) to see your current `promptless.yaml`. From there you can narrow scope, add triggers, or adjust policies.
+If you had Promptless configured before this change, you are already migrated. Go to [app.gopromptless.ai/configuration](https://app.gopromptless.ai/configuration) to see your current `promptless.yaml`. From there you can narrow scope, add triggers, or adjust policies.
 
 For the full YAML schema, see the [Configuration Reference](/docs/configuring-promptless/configuration-reference).
 

--- a/src/content/blog/product-updates/promptless-yaml-configuration.mdx
+++ b/src/content/blog/product-updates/promptless-yaml-configuration.mdx
@@ -18,7 +18,7 @@ Promptless migrated existing configurations automatically. If you had projects c
 
 ## The problem
 
-Promptless previously used a dashboard Projects UI for configuration. The dashboard did not track changes in version control. You could not review a diff before saving a change. You could not copy a configuration between environments. Auditing a single file was not possible when something misbehaved. Teams with several triggers across multiple repositories had to click through the dashboard to understand what was running.
+Promptless previously used a dashboard Projects UI for configuration. The dashboard did not track changes in version control. You could not review a diff before saving a change. You could not copy a configuration between environments. No single file existed to audit when something misbehaved. Teams with several triggers across multiple repositories had to click through the dashboard to understand what was running.
 
 ## What it does now
 
@@ -43,7 +43,7 @@ Changes take effect immediately for new triggers. Policy changes apply when sugg
 
 ## Who benefits most
 
-Teams who want to track configuration changes in version control benefit most. Your `promptless.yaml` lives in a repository. You can review configuration changes in PRs, roll back with git, and audit what changed and when.
+Teams who want to track configuration changes in version control benefit most. Once your `promptless.yaml` lives in a repository, you can review configuration changes in PRs, roll back with git, and audit what changed and when.
 
 It also helps anyone debugging unexpected trigger behavior. The file is the single source of truth. You do not need to click through the dashboard to understand what is running.
 


### PR DESCRIPTION
## Feature

All Promptless configuration now lives in a single `promptless.yaml` file in the organization's Agent Knowledge Base. Triggers, context sources, doc collections, and policies are defined in one place. Replaces the previous Projects page. Existing configurations automatically migrated.

## Entries considered this run

Window: 2026-06-15 → 2026-06-22.

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **Documentation PR titles and draft state** — Auto-created docs PRs now use the `docs:` prefix and open as drafts until the source PR merges | SKIP | Bug fix / behavioral consistency fix, not a new capability |
| 2 | **Jira comments in context** — Promptless now includes Jira comments alongside issue summary and description | SKIP | Expands existing Jira capability but does not open a new use case |
| 3 | **Slite integration** — Connect Slite as a read-only context source for documentation suggestions | QUALIFIES | New integration unlocking a previously unavailable context source (covered by separate PR) |
| 4 | **File-first `promptless.yaml` configuration** — All Promptless configuration now lives in a single `promptless.yaml` file in the Agent Knowledge Base | QUALIFIES | Major new capability; config-as-code workflow unlocks versioning, diffing, and unified multi-repo configuration previously unavailable |
| 5 | **Automatic trigger and context source configuration from onboarding** — Setup wizard now auto-populates `promptless.yaml` with triggers and context sources | SKIP | Onboarding improvement, not a new capability |
| 6 | **Configuration page accessible to all members** — All org members can view the Configuration page (read-only) | SKIP | Minor permission change |

4 commits in window. 6 entries considered, 2 qualified.

## Covered entry (full text)

> **File-first `promptless.yaml` configuration:** All Promptless configuration now lives in a single `promptless.yaml` file in your organization's Agent Knowledge Base. This replaces the previous Projects page with a unified [Configuration page](/docs/configuring-promptless/configuration-reference). The file has four sections: `doc_collections` (where docs live), `triggers` (events that initiate work), `context_sources` (integrations for additional context), and `policies` (publishing and notification rules). Existing Projects configurations have been automatically migrated. Your triggers and doc collections continue working without any action required.

Source: commit [2de0003](https://github.com/Promptless/promptless.ai/commit/2de00034c4b46263d100c6c485d246bd4cce1210) (PR #595).

## PR(s) researched

- Promptless/promptless.ai#595 — Document file-first promptless.yaml configuration (merged 2026-06-15)

## File

`src/content/blog/product-updates/promptless-yaml-configuration.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeBY2jzDj297kTKyQEmDvR)_