### PR TITLE
content: Customer Education for Developer Products: The Maintenance Problem Nobody Plans For

### DIFF
--- a/src/content/blog/technical/customer-education-content-maintenance.mdx
+++ b/src/content/blog/technical/customer-education-content-maintenance.mdx
@@ -1,0 +1,75 @@
+---
+title: 'Customer Education for Developer Products: The Maintenance Problem Nobody Plans For'
+subtitle: Published June 2026
+description: >-
+  Most customer education programs invest heavily in content creation and almost nothing in content maintenance. For developer products, that gap compounds fast.
+date: '2026-06-23T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A customer follows your onboarding course. Step four shows a screenshot of the authentication flow. That flow was redesigned two sprints ago. The customer opens a support ticket instead of finishing the course.
+
+This is the hidden failure mode of customer education programs: the content was accurate when it was made, the product moved on, and no one connected the two.
+
+For developer-facing products, this problem is worse than average. APIs add parameters and deprecate endpoints mid-cycle. SDK method signatures change. Developer portal interfaces can shift significantly between releases. A customer education program built in Q1 can be substantially wrong by Q3, without anyone on the team noticing.
+
+## Why maintenance gets skipped
+
+Customer education content is expensive to produce. A text tutorial takes hours. A screen-recording walkthrough takes a full day to script, record, edit, and publish. A structured course on an LMS platform can take weeks. Those production costs make teams treat education content like infrastructure: something you build once and maintain reluctantly.
+
+The economics push toward creation. It is easier to justify a budget for new content ("we need a course for our new webhooks feature") than for maintenance ("we need to update the existing webhooks course because the event schema changed"). New content has a clear deliverable. Maintenance has a vague ROI.
+
+The result, described consistently across customer success teams, is what some call the "content graveyard": an LMS library that accumulates content over time, where newer modules are accurate and older ones quietly fall out of date. Developers encounter stale walkthroughs, lose confidence in the material, and stop trusting the education program as a resource.
+
+Once that trust breaks, rebuilding it requires more than updated content. It requires demonstrating accuracy consistently over time, which is harder to do with an audit-and-fix approach than with ongoing maintenance.
+
+## UI drift is the most visible failure
+
+For text documentation, stale content can be subtle. A renamed parameter or a changed response format may not immediately register as wrong. A developer might proceed, hit an error, and spend time debugging before tracing it to incorrect documentation.
+
+For screen-recording tutorials and UI walkthroughs, the failure is immediate. The tutorial shows a button in the top-right corner. The current interface has no such button. The developer pauses, looks at their screen, looks at the video, and concludes that the material is out of date. They close the tutorial. They open a support ticket or start searching Stack Overflow.
+
+This is what makes video-based customer education particularly fragile for developer products. A UI change or a redesigned flow creates a visible mismatch. A text tutorial can survive a minor interface change. A screen recording cannot.
+
+The production cost of fixing a screen recording compounds this problem. Updating a text guide takes minutes. Updating a recorded walkthrough means re-recording the affected sections, editing, and republishing. Teams defer those updates because the cost of each update is high, which means the deferrals accumulate, which means the gap between the video and reality grows wider.
+
+<BlogNewsletterCTA />
+
+## The release cycle is the right trigger
+
+Teams that maintain accurate, current education content at scale share one practice: they treat content review as part of the release process, not a separate quarterly audit.
+
+When a release ships, someone on the education or customer success team reviews the release notes against the current content library. If a release changes an API endpoint that appears in a tutorial, that tutorial goes into the update queue before the release goes live. The connection is explicit and immediate, rather than discovered weeks later by a customer who hits the discrepancy.
+
+The LMS platforms that teams use for customer education are built for content creation and delivery. They manage enrollments and track completion. They do not have alerts for "this module covers a feature that changed in last week's release."
+
+That signal has to come from outside the LMS. It comes from monitoring what actually changed in the product and cross-referencing it against the content that covers that area. For teams already running a [docs-as-code workflow](/blog/technical/help-center-to-docs-as-code), this is a natural extension: the same PR review that triggers a documentation update should also surface education content that covers the same feature.
+
+## Developer products change faster than most teams plan for
+
+Traditional SaaS products might ship meaningful UI changes quarterly. Developer-facing platforms (APIs, SDKs, developer portals) can ship significant changes weekly. A new required parameter in a request body. A deprecated authentication method with a hard removal date.
+
+Each of those changes can invalidate education content. A "Getting Started with the API" course that was accurate six months ago may now include code samples that produce errors, or reference an authentication flow that no longer exists.
+
+The Postman 2025 State of the API report found that 55% of API teams cite inconsistent or outdated documentation as their top collaboration blocker. Customer education content faces the same problem, with less visibility because it lives in an LMS rather than in a version-controlled documentation system.
+
+The developers who encounter stale education content do not always file feedback. Many conclude that the platform is poorly documented and reduce their engagement. The customer success metric that registers this is churn, which is a lagging indicator. By the time churn shows up, the stale content has been failing customers for months.
+
+## What a maintenance-oriented education program looks like
+
+The difference between education programs that stay current and those that degrade is whether content ownership is connected to product changes.
+
+**Assign content owners by product area, not by content type.** The person who owns the webhooks course should be the same person (or team) that gets notified when the webhooks API changes. This makes the connection between product changes and content updates direct and personal, rather than mediated by a process that someone has to remember to run.
+
+**Map content to product features explicitly.** Knowing that a given tutorial covers endpoints A, B, and C means that when endpoint B changes, the tutorial is surfaced automatically rather than discovered by accident. This mapping does not need to be elaborate. A spreadsheet is sufficient. The point is having it.
+
+**Treat "review required" as a release deliverable.** If a feature changes, the corresponding education content should enter a review state before the next customer encounters it. This is similar to how well-run documentation teams treat reference page updates: [shipped with the release, not queued for later](/blog/technical/api-changelog-best-practices).
+
+Customer education for developer products is an ongoing maintenance commitment. The content that exists today is accurate today. What it looks like next quarter depends entirely on whether a process connects product changes to content reviews.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `customer education`

## Article plan

**Thesis:** Customer education programs for developer products fail not because the content is bad at launch, but because no process connects product changes to education content updates.

**Target reader:** DevRel engineers, customer success leads, and technical writers at developer-facing companies who own tutorials, LMS courses, and onboarding guides.

**Key points:**
1. Customer education content has higher production cost than docs — teams treat it like infrastructure and defer maintenance
2. The "content graveyard" effect: LMS libraries accumulate older, stale modules alongside current ones
3. UI drift in screen recordings is the most visible failure mode for developer products
4. Treating content review as part of the release cycle (not a separate quarterly audit) is the fix that works
5. Developer-facing products change faster than traditional SaaS, compounding the problem

**Promptless connection:** Documentation monitoring surfaces the product changes that customer education teams need to act on — the same signal that triggers a docs update should trigger an education content review.

## File

`src/content/blog/technical/customer-education-content-maintenance.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by edu campaign skill_

---
_Generated by [Claude Code](https://claude.ai/code/session_018qvuqE7Avda8apjB2KLxup)_