### PR TITLE
content: Docs Site Search Optimization: Fix Accuracy, Not Meta Tags

### DIFF
--- a/src/content/blog/technical/docs-site-search-optimization.mdx
+++ b/src/content/blog/technical/docs-site-search-optimization.mdx
@@ -1,0 +1,95 @@
+---
+title: 'Docs Site Search Optimization: Fix Accuracy, Not Meta Tags'
+subtitle: Published June 2026
+description: >-
+  Most docs search problems aren't technical SEO problems. Here's what actually moves the needle for developer documentation search and AI retrieval.
+date: '2026-06-24T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer Googles your product name plus the error message they're getting. Your docs site doesn't appear until page three. They find a six-month-old Stack Overflow answer referencing an endpoint you deprecated in Q1.
+
+That sequence isn't a marketing problem or an SEO campaign problem. It's a documentation maintenance problem that surfaces as a search problem.
+
+Most developer docs teams diagnose search issues as technical: missing meta tags, no sitemap, slow page loads. Some of those matter. But for most developer documentation sites, the biggest search problems come from documentation quality: accuracy, freshness, and structure. Fix those and search improves without touching the sitemap.
+
+## Your docs have two audiences now
+
+Developer documentation used to have one search audience: human developers using your site or finding pages through Google. That's no longer true.
+
+AI systems now retrieve your docs constantly. Coding agents like Claude Code, Cursor, and GitHub Copilot fetch your documentation to help developers use your API. ChatGPT and Google AI Overviews pull from your pages when answering questions about your product. These AI retrievers look for different signals than human readers do, but they penalize the same failures.
+
+Both audiences punish stale content. A developer reading an outdated page wastes time tracing an error back to a deprecated parameter. An AI agent reads the same page, believes it, and generates broken code for hundreds of users before anyone notices.
+
+Both reward specific, accurate answers. Human developers scan for the exact term they searched for. AI retrievers look for pages where the content closely matches the query. They prefer high-precision answers over broad overviews.
+
+Google confirmed in 2026 that its AI search features use the same core ranking systems as traditional Search. The signals that made your docs rank well before still matter. But accuracy has gained weight: a 2025 Ahrefs study found that 14% of AI-generated responses about brands contain factual errors, and that demand for citation transparency is shifting traffic toward documentation that's verifiably current.
+
+Teams that optimize for both audiences get better outcomes. The changes that make your docs easier for humans to find also make them more reliable for AI retrieval.
+
+## Version sprawl is the biggest search problem
+
+If you have versioned API documentation, you likely have a search problem you're not thinking about as a search problem.
+
+Here's how it happens: You ship v1. The docs go live. You ship v2. You publish a new set of docs and keep v1 available for existing customers. Now search engines index two nearly identical sets of pages, each competing for the same keywords. Neither ranks as well as a single authoritative page would.
+
+This is the most common source of diluted search rankings in developer docs. Without a canonical URL strategy, every version you publish splits the link equity and relevance signals across near-duplicate pages.
+
+The fix is a canonical tag on every versioned page pointing to the "latest" or "current" version. If a developer is searching for your API reference, they should land on the current version. Old versions can remain indexed for users who specifically need them, but they should explicitly defer to the canonical.
+
+Versioning also creates broken link chains. API pages link to each other, and when you deprecate an endpoint, the outbound links from other pages stop working. A high volume of 404 errors signals to search engines that a site is not maintained. That signal depresses rankings across the entire domain.
+
+<BlogNewsletterCTA />
+
+## Freshness signals matter more than keyword density
+
+For developer documentation, freshness is a ranking factor most teams ignore.
+
+Search engines use the `lastmod` field in your sitemap and metadata timestamps to estimate how current a page is. A page that hasn't been updated in 18 months gets a lower freshness score, regardless of how well it's written. For queries with clear temporal intent ("how to authenticate with [your product]"), search engines prefer results that appear current.
+
+The data is concrete: 60% of help center articles become outdated within a year. That's a freshness problem at scale. Outdated content doesn't just mislead users. It also signals to search engines that the site isn't actively maintained.
+
+The implication: updating existing pages regularly matters as much as publishing new ones. A technical writer who audits and refreshes high-traffic pages each quarter does more for search than one who publishes new pages on topics nobody searches for.
+
+AI search adds a new failure mode here. AI systems can surface confident wrong answers from pages that rank well but haven't been updated. A well-structured page describing your v2 authentication flow will rank well (including in AI-powered results) long after you shipped v3. The page doesn't degrade visibly. It spreads wrong information at scale, with no error signal.
+
+## Structure is the actual SEO lever
+
+In developer documentation, keyword optimization in the traditional marketing SEO sense mostly doesn't apply. Developers search with specific technical terms. What matters is whether the page structure lets both humans and algorithms find the right answer quickly.
+
+Good structure for docs search:
+
+**One page, one question.** Pages that cover a broad topic dilute search relevance. A page titled "Authentication Overview" ranks for nothing specific. A page titled "OAuth 2.0 Token Exchange for [Product]" ranks for the precise query.
+
+**Headings that mirror how developers search.** If developers search "how to paginate [product] API results," the page should have a heading matching that intent, not one that sounds good in a nav sidebar.
+
+**Code examples that include the actual method names and parameters.** Search engines index code blocks. Developers copy-paste searches directly from error messages. A code block showing the exact function call a developer will search for is a concrete SEO asset.
+
+Information architecture also affects crawlability. A page that isn't linked from anywhere in your site won't get crawled reliably, regardless of content quality. Your internal link structure tells search engines which pages are authoritative.
+
+## What doesn't move the needle
+
+A few common interventions that don't address the root problem:
+
+**Adding more content.** If existing pages are outdated or poorly structured, adding new content dilutes rather than strengthens search presence. More pages on the same topic without clear canonical differentiation splits authority across them.
+
+**Optimizing meta descriptions.** Meta descriptions affect click-through rate in traditional search results, not ranking. A polished meta description on a stale page doesn't improve where the page shows up.
+
+**Rebuilding on a new platform.** Platform choice matters less than content quality. Docs on plain static HTML can outrank ones built on modern documentation platforms if the content is more accurate and well-structured.
+
+## The maintenance connection
+
+Most of what makes developer documentation easy to find (accurate content, low 404 rates, fresh timestamps, non-duplicate pages) is a consequence of documentation maintenance, not search optimization work.
+
+[Documentation drift](/blog/technical/documentation-drift-detection-problem) is the mechanism. When your product changes and your docs don't, every affected page accumulates an accuracy problem and a freshness problem at the same time. The [coverage gaps](/blog/technical/documentation-coverage) that pile up over time reduce both user experience and search performance.
+
+[Versioned docs that aren't canonicalized](/blog/technical/documentation-versioning-maintenance-multiplier) compete with each other. Deprecated endpoints that remain documented create false confidence for developers and AI retrievers alike.
+
+Teams that improve docs search spend more effort on documentation accuracy than on any technical SEO tactic. The search improvements follow from the maintenance.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `docs site search optimization`

## Article plan

**Thesis:** Most docs search problems come from documentation maintenance failures, not from missing technical SEO. Accuracy, freshness, and structure are the real levers.

**Target reader:** Technical writers and DevRel engineers at developer-facing SaaS companies whose docs don't surface well in search.

**Key points:**
1. Developer docs now have two search audiences: human developers and AI systems (coding agents, AI overviews). Both reward accuracy and penalize stale content.
2. Version sprawl is the most common cause of diluted search rankings. Near-duplicate versioned pages split link equity without a canonical URL strategy.
3. Freshness signals (sitemap `lastmod`, metadata timestamps) matter more than keyword density for developer docs. 60% of help center articles go stale within a year.
4. Structure is the real SEO lever: one page per question, headings that mirror search intent, code examples with actual method names.
5. Common interventions that don't help: adding more content, optimizing meta descriptions alone, rebuilding on a new platform.

**Promptless connection:** The biggest docs search lever is documentation accuracy. Stale pages hurt both users and search rankings. Promptless detects docs drift before it degrades search performance.

## File

`src/content/blog/technical/docs-site-search-optimization.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjQ2Vi6TvnbQUwAqJR1RBZ)_