### PR TITLE
content: Developer Docs Site Search: Two Problems Most Teams Never Fix

### DIFF
--- a/src/content/blog/technical/docs-site-search-optimization.mdx
+++ b/src/content/blog/technical/docs-site-search-optimization.mdx
@@ -1,0 +1,75 @@
+---
+title: 'Developer Docs Site Search: Two Problems Most Teams Never Fix'
+subtitle: Published June 2026
+description: >-
+  Most docs teams install a search engine and move on. The two things that actually determine whether developers find accurate information are rarely touched.
+date: '2026-06-25T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer opens a support ticket asking how to configure webhook signatures. You know the answer is in your docs. You find the page in thirty seconds. They searched your site and got nothing — or found a page describing the flow you retired eight months ago.
+
+That gap between "it's documented" and "developers can find it and trust it" is a search problem. The default assumption is that good content plus a capable search engine produces good search results. Install Algolia, crawl the site, done. In practice, two problems sit between your content and what developers find. Both are about content quality, not search tooling.
+
+## Problem 1: Your docs aren't structured for how developers search
+
+Developers rarely navigate to your docs homepage and explore. They go to a search engine — Google, an AI assistant, GitHub Copilot — and type a specific query. "stripe webhooks signature verification failed." "openai rate limit 429 how to retry." They're searching for an error message, a parameter name, a specific behavior they're debugging.
+
+Your docs surface in those results if the relevant page is structured to match the query. Most docs pages aren't.
+
+Heading structure is the clearest gap. Google uses `<h2>` and `<h3>` headings as primary signals for what a page covers. A page that addresses webhook signature verification under a generic "Authentication" heading will rank below a page with a dedicated section titled "Verifying webhook signatures." The content may be identical. The heading is what Google sees first.
+
+Page titles and meta descriptions compound this. "Getting started with events" is not how developers describe their problem. If that's your page title, you won't appear when a developer searches "webhook event handling" — even if the page answers their question perfectly.
+
+Internal linking is the least obvious lever. Pages that receive more links from other pages on your site carry more authority in Google's ranking model. Reference pages linked only from your nav menu — and nowhere in your actual content — rank below pages that tutorials, guides, and changelogs link to regularly. An orphaned reference page is invisible to Google regardless of how well it's written.
+
+A concrete starting point: open Google Search Console, filter for queries where your site appears in positions 4–15, and look at which pages are close to ranking but not quite there. Improving heading structure and adding internal links to those pages is higher leverage than writing new content.
+
+<BlogNewsletterCTA />
+
+## Problem 2: Stale content outranks current content
+
+The second failure mode is less intuitive and causes more damage.
+
+Your most dangerous search result is a page that exists, ranks well, and is wrong.
+
+Search engines don't know your docs are outdated. They know the page has existed for a long time, that it received links when it was new and accurate, and that developers clicked on it across thousands of sessions. Authority accumulates over time. A page that was accurate eighteen months ago and has since drifted is often more authoritative in search rankings than a fresh page that corrects it.
+
+The result: the wrong page surfaces first. A developer reads a parameter name that was renamed two releases ago, follows an authentication flow that was deprecated, copies a code sample that no longer runs. They trust it because your search served it prominently. When the code fails, they don't conclude your docs are old. They conclude your product is broken.
+
+This is what makes stale content worse than missing content. A gap produces confusion. A stale page produces false confidence, which produces a failed integration, which produces a support ticket and a developer who will verify everything by running the code before trusting anything they read. A Postman survey found 68% of developers cite outdated documentation as their primary frustration with APIs. That frustration is the downstream consequence of stale pages holding search authority.
+
+Google's freshness systems have started penalizing stale content over time. For developer queries — API endpoints, SDK methods, configuration options — pages not updated in six or more months lose ranking. But there's a meaningful lag between when a page goes stale and when search demotes it. During that lag, the wrong page keeps ranking.
+
+AI-powered search compounds the stakes. AI answer engines cite recently-updated content significantly more often than older pages. Content updated in the last 30 to 90 days has meaningfully higher citation rates in AI search results. As developers increasingly use AI assistants to query documentation, freshness becomes a direct factor in whether your docs get surfaced at all.
+
+## What to do about it
+
+### Audit heading structure across your top pages
+
+Take your ten most-trafficked reference pages. For each one, check whether the primary `<h2>` contains the phrase a developer would search to find that content. If the heading reads "Overview" or "Introduction" or "Configuration," that page is not optimized for external discovery. Rewriting those headings to include the specific technical vocabulary is the highest-leverage change most docs sites can make in an afternoon.
+
+### Track zero-result searches
+
+Your docs platform's search analytics show you what developers searched for that returned nothing. Those queries are a direct inventory of your content gaps. Tools like Readme, Fern, Mintlify, and GitBook expose this in their dashboards by default. The top ten zero-result queries, reviewed monthly, give you a prioritized list of what to write next. For a systematic approach to closing those gaps using search analytics alongside other signals, the [documentation coverage guide](/blog/technical/documentation-coverage) has the full breakdown.
+
+### Keep search authority aligned with current content
+
+The deeper fix for stale pages ranking well is keeping content current before it accumulates authority as wrong information. A page that gets updated regularly stays accurate and continues receiving freshness signals that support its ranking.
+
+This requires knowing when something changed in your product before a developer searches for it and finds the old version. [Documentation drift detection](/blog/technical/documentation-drift-detection-problem) covers how to identify those changes upstream — at the moment when the product changes, not after the stale page has already caused damage.
+
+### Treat external search and on-site search as separate signals
+
+Your Algolia dashboard and Google Search Console are telling you different things. Algolia shows what developers search for after they've already arrived at your docs site. Search Console shows how they find your docs externally — which pages Google is surfacing, which queries trigger your results, and where click-through rates are low.
+
+Most docs teams look at one or the other. Both together tell you whether the problem is structure (developers can't find your docs via Google) or content (they find the page but it doesn't deliver).
+
+The goal is a docs site where the first result is always the right result. Getting there is a content problem, not a search engine problem. The search engine will surface whatever you give it.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `docs site search optimization`

## Article plan

**Thesis:** Docs search quality is determined by content structure and content freshness, not search tooling. Most teams treat search as a one-time infrastructure choice and miss both.

**Target reader:** Technical writers and DevRel engineers managing a developer docs site who hear "I can't find anything" despite having invested in content.

**Key points:**
1. Developers discover docs primarily via external search (Google, AI assistants) using specific error messages and parameter names — not by browsing your homepage
2. Heading structure, page titles, and internal links determine external search rank, and most docs pages are optimized for none of these
3. Stale pages are more dangerous than missing pages: they hold authority accumulated when they were accurate, then surface wrong information that developers trust
4. Google's freshness systems penalize pages not updated in 6+ months; AI search engines weight pages updated in the last 30-90 days significantly more
5. On-site search (Algolia) and external search (Google Search Console) are separate signals that tell you different things — most teams only look at one

**Promptless connection:** Keeping docs fresh directly improves both search surfaces. Stale content degrades external rank and on-site search results simultaneously.

## File

`src/content/blog/technical/docs-site-search-optimization.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_015FWAKehHmZj8n7CDnDVTiY)_