### PR TITLE
content: Developer Education Has a Maintenance Problem

### DIFF
--- a/src/content/blog/technical/developer-education-maintenance-problem.mdx
+++ b/src/content/blog/technical/developer-education-maintenance-problem.mdx
@@ -1,0 +1,79 @@
+---
+title: 'Developer Education Has a Maintenance Problem'
+subtitle: Published June 2026
+description: >-
+  Outdated tutorials cost as much developer goodwill as missing docs. Why DevRel teams that invest heavily in content creation often miss the harder problem.
+date: '2026-06-26T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer follows your "Getting Started" guide step by step. At step four, they run the authentication call. The parameter name changed three months ago. The guide still shows the old one. They get a 401, retrace their steps, find nothing wrong in the code they wrote, and close the browser.
+
+Your support queue stays clean. Your analytics show the guide got thousands of reads. The guide is broken.
+
+This is developer education's maintenance problem, and most teams running DevRel programs are watching the wrong metric to find it.
+
+## Creation is the wrong constraint
+
+The 2023 State of Developer Relations Report found that 44.8% of DevRel practitioners cite "ongoing content creation" as their top challenge. Content production is where DevRel spends most of its time, and it's the primary lens through which programs get evaluated.
+
+That framing is partially correct. Creating good tutorials, workshops, sandbox environments, and code samples takes sustained effort. But when creation becomes the primary constraint, teams optimize for output volume rather than output accuracy. More tutorials, more guides, more code examples.
+
+Each page that ships is a page that needs to stay accurate.
+
+[Postman's 2024 State of the API report](https://www.postman.com/state-of-api/2024), which surveyed over 5,600 developers and API professionals, found that 68% of developers cite outdated documentation as their top frustration when working with APIs. That frustration covers more than API reference pages. It covers the tutorial that walked a developer through your quickstart three months before you renamed the endpoint.
+
+## Tutorial content drifts differently
+
+Reference documentation (endpoint listings, parameter definitions, error code tables) is generated from or at least closely tied to the underlying code. Some teams auto-generate it from OpenAPI specs. Others maintain it alongside the spec and get pull request reminders when the API changes. It is not a perfect system, but there is a structural connection between the code and the page.
+
+Tutorial content does not have that connection. A getting-started guide is a hand-written narrative. It describes a sequence of steps a developer takes to accomplish something real. When the product changes, the guide does not update itself. No one sends a pull request to "step 4: authenticate your request" when the token format changes.
+
+The result is silent drift. The guide is live. Developers are reading it. Some percentage of them are hitting the broken step. The team does not see it because the failure mode is invisible: the developer leaves without filing a ticket.
+
+Research consistently finds that [around 50% of developers abandon an API](https://userguiding.com/blog/user-onboarding-statistics) when documentation fails them. That figure covers documentation that was accurate six months ago just as much as documentation that was never written.
+
+<BlogNewsletterCTA />
+
+## AI coding agents amplify the problem
+
+The maintenance problem is sharper now because of how developers use educational content.
+
+When a developer reads a tutorial and hits an error, they can sometimes recognize a deprecated parameter and adapt. That is friction, but not necessarily a blocker. When an AI coding assistant reads the same tutorial, it follows the instructions literally. It generates code that uses the old parameter format. The developer runs the AI-generated code, gets a 401, and debugs the wrong problem.
+
+Stale tutorial content becomes more expensive when it feeds into AI-assisted workflows. The developer does not just encounter the error. The AI compounds it by generating plausible-looking code from inaccurate source material. What was a rough edge in developer experience becomes a reliability problem in an AI-assisted workflow.
+
+[This pattern shows up in onboarding data](https://promptless.ai/blog/technical/developer-onboarding-documentation-fails-after-launch): stale documentation is less forgiving when agents amplify whatever they read. Developer education content needs the same accuracy monitoring that reference documentation gets. The stakes are higher now.
+
+## What most programs actually monitor
+
+DevRel programs track reach metrics: page views, tutorial completion rates, workshop attendance, certification exam pass rates. These metrics matter for demonstrating program value and securing budget. They do not tell you whether the content developers are consuming is accurate.
+
+A tutorial with 10,000 monthly views that covers a deprecated flow is creating more developer frustration than a tutorial nobody reads. Traffic data tells you about reach. It does not tell you about accuracy. The two are independent.
+
+Most DevRel teams have no systematic way to know which tutorials have drifted since they were published. The common method is manual: a writer or advocate walks through older guides periodically to check whether they still work. This happens quarterly at best, and it is the first thing that slips when the team is heads-down on a product launch.
+
+[Documentation debt accrues where teams cannot see it](https://promptless.ai/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it), and tutorial pages are among the least monitored. Reference docs sit closer to the engineers who ship changes. Tutorial content lives in DevRel's lane, and there is often no structured handoff when a product team makes a breaking change.
+
+## Treating education content as infrastructure
+
+Tutorials and guides are load-bearing infrastructure for developer success. A team that ships a breaking API change without updating its getting-started guide has taken on debt that external developers will pay.
+
+The practical implication is that developer education programs need maintenance workflows alongside publishing workflows. A few specific ones:
+
+**Connect content to the features it covers.** When an API endpoint changes, the tutorials referencing that endpoint should be in scope for the change review. This requires tagging content to features at publish time, before the drift accumulates.
+
+**Prioritize by traffic times change frequency.** A popular getting-started guide for a frequently-updated auth flow is the highest-priority item to keep current. A page with 5,000 monthly views covering a stable, rarely-touched feature is lower priority. Age alone is a poor signal; [blast radius is more useful](https://promptless.ai/blog/technical/documentation-drift-detection-problem).
+
+**Make silent abandonment visible.** Exit rates on specific tutorial steps, combined with API call failure patterns, can surface where developers are hitting broken guides. The developer who closes the browser at step four is sending a signal. It just requires instrumentation to read it.
+
+Developer education programs succeed when developers finish what they started. The tutorial that worked perfectly when it was written and still works six months later is the goal. The one that launched a conference talk and quietly broke in the next release is a liability.
+
+The maintenance problem is solvable. It requires treating educational content with the same accuracy standards as reference documentation, and building monitoring into the publishing workflow rather than scheduling it as a quarterly afterthought.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer education`

## Article plan

**Thesis:** DevRel programs optimize for content creation, but a stale tutorial costs more developer goodwill than a missing one. The real bottleneck is accuracy monitoring after publish.

**Target reader:** Developer advocates, DevRel engineers, and EMs at API companies who invest in developer education but struggle to keep it current.

**Key angles:**
- 44.8% of DevRel teams cite creation as their top challenge (State of DevRel 2023) — but creation volume makes the maintenance problem larger
- Tutorial content is structurally more fragile than reference docs: it's narrative, hand-written, with no tie to the code it describes
- ~50% of developers abandon APIs when docs fail them; 68% cite outdated docs as top frustration (Postman 2024)
- AI coding agents amplify stale tutorial content into broken generated code
- Most programs monitor reach, not accuracy — traffic data and accuracy are independent

**Promptless connection:** Monitoring docs against the product includes tutorial and educational content, not just API reference pages.

## File

`src/content/blog/technical/developer-education-maintenance-problem.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUWaprVyYFkmbzDEVAZwJp)_