### PR TITLE
content: Launch post — Google Drive context source

### DIFF
--- a/src/content/blog/product-updates/google-drive-context-source.mdx
+++ b/src/content/blog/product-updates/google-drive-context-source.mdx
@@ -1,0 +1,59 @@
+---
+title: 'Promptless Can Now Read Your Google Drive'
+subtitle: Published June 2026
+description: >-
+  Connect Google Drive as a read-only context source so Promptless can search and read Google Docs, Sheets, and Slides when generating documentation suggestions.
+date: '2026-06-26T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Promptless now reads your Google Drive when generating documentation suggestions. Connect it on the Integrations page and the agent draws on your Docs, Sheets, and Slides the same way it draws on Confluence or Notion.
+
+## The problem
+
+A lot of product knowledge lives in Google Drive. PRDs, architecture notes, API spec drafts, meeting summaries, onboarding guides—teams that use Docs and Sheets heavily tend to put the authoritative version of decisions in Drive rather than in a wiki or code comment. Until now, Promptless couldn't see any of it. When generating suggestions for a code change, the agent worked from the diff, linked Jira or Linear tickets, and any Confluence or Notion pages in your configuration. Anything stored in Drive was invisible.
+
+If your team's internal context was in Drive, suggestions were missing that context.
+
+## What changed
+
+Google Drive is now a supported context source. Connect it on the **Integrations** page and Promptless includes Drive content when pulling context for each suggestion.
+
+The agent can search your Drive and read file content: Google Docs come through as Markdown, Sheets as CSV, and Slides and plain-text formats as plain text. Unsupported types—images, PDFs, compiled files—return metadata only: filename, type, and last modified date.
+
+Access is scoped at your discretion. Leave the integration unscoped for full Drive access, or add `drive_ids` and `folder_ids` to the `google_drive` entry in your `promptless.yaml` to limit access to specific shared drives or folders. The integration card shows which Google account authorized the connection, so you can verify whose access the agent inherits.
+
+Promptless connects with read-only OAuth scopes and never writes to Drive.
+
+<BlogNewsletterCTA />
+
+## Who benefits most
+
+Teams whose internal product knowledge lives in Google Drive. If engineers write architecture decision records in Docs, PMs maintain spec documents in shared drives, and onboarding content lives in a Google Doc—Promptless can now draw on that material when generating documentation for code changes. The agent uses Drive content the same way it uses any context source: to understand what a change is for, what terminology is correct, and what already exists.
+
+This is also relevant to teams that have tried other context sources (Confluence, Notion, Linear) and found their canonical reference material is still in Drive rather than in a structured wiki.
+
+## How to set it up
+
+1. Go to the **Integrations** page in your Promptless dashboard.
+2. Find the **Google Drive** tile and click **Connect**.
+3. Authorize with the Google account that has access to the content you want Promptless to read. The integration card will show which account is connected.
+4. Optionally, add scoping to your `promptless.yaml`:
+
+```yaml
+context_sources:
+  - source_type: google_drive
+    drive_ids:
+      - your-shared-drive-id
+    folder_ids:
+      - your-folder-id
+```
+
+Leave `drive_ids` and `folder_ids` out entirely to allow access to the full Drive. See the [Google Drive context source docs](/docs/configuring-promptless/context-sources/google-drive) for configuration details.
+
+<BlogRequestDemo />

--- a/src/content/blog/product-updates/google-drive-context-source.mdx
+++ b/src/content/blog/product-updates/google-drive-context-source.mdx
@@ -1,9 +1,9 @@
 ---
-title: 'Promptless Can Now Read Your Google Drive'
+title: 'Google Drive as a Context Source for Documentation Suggestions'
 subtitle: Published June 2026
 description: >-
-  Connect Google Drive as a read-only context source so Promptless can search and read Google Docs, Sheets, and Slides when generating documentation suggestions.
-date: '2026-06-26T00:00:00.000Z'
+  Promptless can now read your Google Drive as a context source. Connect Drive on the Integrations page and Promptless searches your Docs, Sheets, and Slides when generating documentation suggestions.
+date: '2026-06-29T00:00:00.000Z'
 author: Frances
 tag: Product Updates
 section: Featured
@@ -12,48 +12,49 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-Promptless now reads your Google Drive when generating documentation suggestions. Connect it on the Integrations page and the agent draws on your Docs, Sheets, and Slides the same way it draws on Confluence or Notion.
+Promptless can now read your Google Drive as a read-only context source. Connect Drive on the Integrations page, and Promptless searches your files when generating documentation suggestions. Google Docs are read as Markdown, Sheets as CSV, and Slides as plain text.
 
 ## The problem
 
-A lot of product knowledge lives in Google Drive. PRDs, architecture notes, API spec drafts, meeting summaries, onboarding guides—teams that use Docs and Sheets heavily tend to put the authoritative version of decisions in Drive rather than in a wiki or code comment. Until now, Promptless couldn't see any of it. When generating suggestions for a code change, the agent worked from the diff, linked Jira or Linear tickets, and any Confluence or Notion pages in your configuration. Anything stored in Drive was invisible.
+A lot of product knowledge lives in Google Drive: specs, design decisions, onboarding guides, internal runbooks. For teams where Drive is the primary working surface, that content wasn't visible to Promptless. When a PR came in and Promptless generated documentation suggestions, it couldn't see what the product was supposed to do according to a Google Doc that described it in detail.
 
-If your team's internal context was in Drive, suggestions were missing that context.
+The result was suggestions that reflected the code change in isolation, missing context that existed in the organization and was simply stored in a different place.
 
-## What changed
+## What it does now
 
-Google Drive is now a supported context source. Connect it on the **Integrations** page and Promptless includes Drive content when pulling context for each suggestion.
+When Drive is connected, Promptless searches your files as part of its normal context-gathering process. It reads file content and uses what it finds to inform suggestions. Files the agent can't read as text (images, PDFs, binary exports) are skipped.
 
-The agent can search your Drive and read file content: Google Docs come through as Markdown, Sheets as CSV, and Slides and plain-text formats as plain text. Unsupported types—images, PDFs, compiled files—return metadata only: filename, type, and last modified date.
+By default, access covers your entire connected Drive. You can narrow it by adding `drive_ids` or `folder_ids` to the `google_drive` context source entry in your `promptless.yaml`. This lets you point Promptless at a specific shared drive for your product team, or a folder where your current-quarter specs live, without granting visibility into unrelated personal files.
 
-Access is scoped at your discretion. Leave the integration unscoped for full Drive access, or add `drive_ids` and `folder_ids` to the `google_drive` entry in your `promptless.yaml` to limit access to specific shared drives or folders. The integration card shows which Google account authorized the connection, so you can verify whose access the agent inherits.
+The integration card on the Integrations page shows which Google account authorized the connection, so you can confirm whose access the agent inherits before going live.
 
-Promptless connects with read-only OAuth scopes and never writes to Drive.
+Promptless connects with read-only scopes and never modifies your Drive.
 
 <BlogNewsletterCTA />
 
 ## Who benefits most
 
-Teams whose internal product knowledge lives in Google Drive. If engineers write architecture decision records in Docs, PMs maintain spec documents in shared drives, and onboarding content lives in a Google Doc—Promptless can now draw on that material when generating documentation for code changes. The agent uses Drive content the same way it uses any context source: to understand what a change is for, what terminology is correct, and what already exists.
+Teams where Google Workspace is the default writing surface for product knowledge. If your spec documents, feature briefs, or API decision records live in Google Docs rather than a wiki or a repo, this closes the gap between what Promptless knows and what your organization has already written down.
 
-This is also relevant to teams that have tried other context sources (Confluence, Notion, Linear) and found their canonical reference material is still in Drive rather than in a structured wiki.
+It's also useful if you maintain a shared Drive folder with evergreen reference content: style decisions, terminology lists, architecture notes. Once connected, Promptless can pull from that material when generating suggestions, instead of reasoning from scratch.
 
-## How to set it up
+## How to use it
 
-1. Go to the **Integrations** page in your Promptless dashboard.
-2. Find the **Google Drive** tile and click **Connect**.
-3. Authorize with the Google account that has access to the content you want Promptless to read. The integration card will show which account is connected.
-4. Optionally, add scoping to your `promptless.yaml`:
+1. Go to the **Integrations page** in the Promptless dashboard.
+2. Connect Google Drive. Authorize with the Google account that has access to the files you want Promptless to read.
+3. Promptless will add an unscoped `google_drive` context source entry to your `promptless.yaml` automatically.
+
+To scope access to specific drives or folders, edit the entry in your configuration:
 
 ```yaml
 context_sources:
-  - source_type: google_drive
+  - type: google_drive
     drive_ids:
-      - your-shared-drive-id
+      - 0AExampleDriveIdUk9PVA
     folder_ids:
-      - your-folder-id
+      - 1BExampleFolderIdXyZ
 ```
 
-Leave `drive_ids` and `folder_ids` out entirely to allow access to the full Drive. See the [Google Drive context source docs](/docs/configuring-promptless/context-sources/google-drive) for configuration details.
+Leave `drive_ids` and `folder_ids` empty (or omit them) to allow access to everything the connected account can read.
 
 <BlogRequestDemo />

--- a/src/content/blog/product-updates/google-drive-context-source.mdx
+++ b/src/content/blog/product-updates/google-drive-context-source.mdx
@@ -12,21 +12,21 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-Promptless can now read your Google Drive as a read-only context source. Connect Drive on the Integrations page, and Promptless searches your files when generating documentation suggestions. Google Docs are read as Markdown, Sheets as CSV, and Slides as plain text.
+Promptless can now read your Google Drive as a read-only context source. Connect Drive on the Integrations page. Promptless searches your files when generating documentation suggestions. Google Docs are read as Markdown, Sheets as CSV, and Slides as plain text.
 
 ## The problem
 
-A lot of product knowledge lives in Google Drive: specs, design decisions, onboarding guides, internal runbooks. For teams where Drive is the primary working surface, that content wasn't visible to Promptless. When a PR came in and Promptless generated documentation suggestions, it couldn't see what the product was supposed to do according to a Google Doc that described it in detail.
+A lot of product knowledge lives in Google Drive, including specs, design decisions, onboarding guides, and internal runbooks. For teams where Drive is the primary working surface, this content was not visible to Promptless. A Google Doc might describe exactly how the product was supposed to work. Promptless could not read it before generating documentation suggestions for a PR.
 
-The result was suggestions that reflected the code change in isolation, missing context that existed in the organization and was simply stored in a different place.
+The result was suggestions that reflected the code change alone, missing context that existed elsewhere in the organization.
 
 ## What it does now
 
-When Drive is connected, Promptless searches your files as part of its normal context-gathering process. It reads file content and uses what it finds to inform suggestions. Files the agent can't read as text (images, PDFs, binary exports) are skipped.
+When Drive is connected, Promptless searches your files as part of its normal context-gathering process. It reads file content and uses what it finds to inform suggestions. The agent skips files it cannot read as text, such as images, PDFs, and binary exports.
 
-By default, access covers your entire connected Drive. You can narrow it by adding `drive_ids` or `folder_ids` to the `google_drive` context source entry in your `promptless.yaml`. This lets you point Promptless at a specific shared drive for your product team, or a folder where your current-quarter specs live, without granting visibility into unrelated personal files.
+By default, access covers your entire connected Drive. Add `drive_ids` or `folder_ids` to the `google_drive` context source entry in your `promptless.yaml` to narrow this. Use this to point Promptless at a specific shared drive, such as one for your product team. You can also point it at a single folder, such as one containing your current-quarter specs. This keeps Promptless from seeing unrelated personal files.
 
-The integration card on the Integrations page shows which Google account authorized the connection, so you can confirm whose access the agent inherits before going live.
+The integration card on the Integrations page shows which Google account authorized the connection. Check it to confirm whose access the agent inherits before going live.
 
 Promptless connects with read-only scopes and never modifies your Drive.
 
@@ -34,15 +34,15 @@ Promptless connects with read-only scopes and never modifies your Drive.
 
 ## Who benefits most
 
-Teams where Google Workspace is the default writing surface for product knowledge. If your spec documents, feature briefs, or API decision records live in Google Docs rather than a wiki or a repo, this closes the gap between what Promptless knows and what your organization has already written down.
+This feature helps teams where Google Workspace is the default writing surface for product knowledge. Your spec documents, feature briefs, or API decision records may live in Google Docs, not a wiki or a repo. Promptless closes the gap between what it knows and what your organization has written down.
 
-It's also useful if you maintain a shared Drive folder with evergreen reference content: style decisions, terminology lists, architecture notes. Once connected, Promptless can pull from that material when generating suggestions, instead of reasoning from scratch.
+This also helps if you maintain a shared Drive folder with evergreen reference content. Examples include style decisions, terminology lists, and architecture notes. Once connected, Promptless can pull from that material when generating suggestions instead of reasoning from scratch.
 
 ## How to use it
 
 1. Go to the **Integrations page** in the Promptless dashboard.
 2. Connect Google Drive. Authorize with the Google account that has access to the files you want Promptless to read.
-3. Promptless will add an unscoped `google_drive` context source entry to your `promptless.yaml` automatically.
+3. Promptless adds an unscoped `google_drive` context source entry to your `promptless.yaml` automatically.
 
 To scope access to specific drives or folders, edit the entry in your configuration:
 
@@ -55,6 +55,6 @@ context_sources:
       - 1BExampleFolderIdXyZ
 ```
 
-Leave `drive_ids` and `folder_ids` empty (or omit them) to allow access to everything the connected account can read.
+Leave `drive_ids` and `folder_ids` empty, or omit them, to allow access to everything the connected account can read.
 
 <BlogRequestDemo />


### PR DESCRIPTION
## Feature
Promptless now reads Google Drive as a read-only context source — Google Docs as Markdown, Sheets as CSV, Slides as plain text. Teams can scope access to specific shared drives or folders via `drive_ids`/`folder_ids` in `promptless.yaml`.

## Entries considered this run

Window: 2026-06-22 → 2026-06-29 (last 7 days).

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **Google Drive as a context source** — Read-only Drive integration; reads Docs as Markdown, Sheets as CSV, Slides as text; scopeable with drive_ids/folder_ids | QUALIFIES | New integration that unlocks a previously impossible workflow for teams whose internal knowledge lives in Drive |
| 2 | **Microsoft Teams notification channel** — `msteams_channel` notification policy for Teams orgs | QUALIFIES | New integration opening a distinct segment (Teams-first orgs) — separate PR |
| 3 | **Doc agents use your existing skills** — Auto-discovers `.claude/skills/`, `.agents/skills/`, `.cursor/skills/` in docs repo | QUALIFIES | Substantially new capability: previously impossible to customize doc agent behavior via skills — separate PR |
| 4 | **Structured configuration editor** | SKIP — duplicate | PR #630 is an open draft launch post for `promptless.yaml configuration` |
| 5 | **Slite integration** | SKIP — duplicate | PR #629 is an open draft launch post for Slite context source |
| 6 | **Backfill suggestions for PR triggers** | SKIP — deprioritized | Qualifies (new capability) but deprioritized to cap total posts this run at 3 |
| 7 | **GitLab source code reading** | SKIP — deprioritized | Qualifies (improves GitLab MR quality) but deprioritized to cap total posts at 3 |
| 8 | **API access for doc collection management** | SKIP — deprioritized | Qualifies (new programmatic capability) but deprioritized |
| 9 | **@promptless mentions in PR title/description** | SKIP — near-duplicate | Existing post `request-docs-via-pr-comments.mdx` covers the same general mechanism; the title/description variant is incremental |
| 10 | **Trigger reviews by mentioning @promptless in a PR** | SKIP — merged with #9 above | Same entry, cross-listed from two commits |
| 11 | **Rich Slack suggestion previews** (May) | SKIP | UX improvement to existing notification format; bar not met |
| 12 | **Rebuilt onboarding as connect-only flow** | SKIP | Onboarding UX change; no new capability |
| 13 | **GitLab source code reading** | SKIP — deprioritized | See #7 |
| 14 | **Inline Citations in Slack Research Replies** | SKIP | Nice UX improvement; bar not met |
| 15 | **Vale Prose Linting** | SKIP | Existing undocumented capability, not a new feature |
| 16 | **Triggers page grouping and date filtering** | SKIP | UI reorganization; no new workflow unlocked |
| 17 | **Multiple doc collections during onboarding** | SKIP | Onboarding improvement; bar not met |
| 18 | **Reconnect Slack in place** | SKIP | Operational UX improvement; not user-facing capability |
| 19 | **Filter suggestions by Unassigned** | SKIP | Minor UI filter enhancement |
| 20 | **GitHub pending install visibility** | SKIP | Onboarding edge case; narrow segment |
| 21 | **Admin-only Agent Knowledge Base editing** | SKIP | Permission governance change; not a capability |
| 22 | **Responsive sidebar on narrower screens** | SKIP | Minor UI polish |
| 23 | **Dynamic Slack status updates** | SKIP | UX transparency improvement; bar not met |
| 24 | **Provider-Branded Status Pills** | SKIP | UI redesign |
| 25 | **Trigger Event Timeline** | SKIP | UI element |
| 26 | **Always-On Bulk Selection** | SKIP | UI convenience change |
| 27 | **Sort Control Relocated** | SKIP | UI tweak |
| 28 | **Search by Docs PR Number** | SKIP | Search qualifier addition |
| 29 | **Sidebar suggestion count** | SKIP | Minor UI |
| 30 | **Docs target chip on suggestions** | SKIP | Minor UI |
| 31 | **Slack "Triggered by" Labels** | SKIP | Bug fix |
| 32 | **Duplicate Slack suggestion cards** | SKIP | Bug fix |
| 33 | **Refresh button on Slack suggestion previews** | SKIP | Bug fix |
| 34 | **Microsoft Teams tenant name display** | SKIP | Bug fix |
| 35 | **@promptless mentions from bots in PR comments** | SKIP | Bug fix |
| 36 | **Slack suggestion card refresh fix** | SKIP | Bug fix |
| 37 | **CLI auth CSP bug fix** | SKIP | Bug fix |
| 38 | **Automatic trigger and context source configuration** | SKIP | Onboarding behavior; no new capability unlocked |
| 39 | **Microsoft Teams connection showed raw tenant ID** | SKIP | Bug fix |

27 commits in window. 33+ entries considered, 3 qualified, 2 open-PR duplicates dropped.

## Covered entry (full text)

> **Google Drive as a context source:** Promptless now reads your Google Drive as a read-only [context source](/docs/configuring-promptless/context-sources/google-drive). Connect Google Drive on the [Integrations page](https://app.gopromptless.ai/integrations), and Promptless searches your Drive and reads file content—Google Docs as Markdown, Sheets as CSV, and Slides as plain text—to inform documentation suggestions. Scope access to specific shared drives or folders with `drive_ids` and `folder_ids` in your `promptless.yaml`, or leave it unscoped for full access. Promptless connects with read-only scopes and never modifies your Drive. The integration card shows which Google account authorized the connection, so you can confirm whose access the agent inherits.

Source: commit [cd31216](https://github.com/Promptless/promptless.ai/commit/cd3121618d98770cd7a0c35c3c22973627bf2a3a).

## PR(s) researched
- Promptless/promptless#3621 — Google Drive context source (GitHub MCP scoped to promptless.ai only; researched from changelog entry)

## File
`src/content/blog/product-updates/google-drive-context-source.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZfQDHxr2pimZqxQty3Bwr)_