### PR TITLE
content: Launch post — Microsoft Teams notification channel

### DIFF
--- a/src/content/blog/product-updates/microsoft-teams-notifications.mdx
+++ b/src/content/blog/product-updates/microsoft-teams-notifications.mdx
@@ -1,0 +1,58 @@
+---
+title: 'Documentation Suggestion Notifications in Microsoft Teams'
+subtitle: Published June 2026
+description: >-
+  Promptless can now post documentation suggestion notifications to a Microsoft Teams channel. Configure a Teams channel in your notification policy alongside, or instead of, Slack.
+date: '2026-06-29T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Promptless can now post documentation suggestion notifications to a Microsoft Teams channel. Add `msteams_channel` to your notification policy with a channel conversation ID, and suggestions will appear in Teams the same way they would in Slack.
+
+## The problem
+
+Until now, Promptless notification policies only supported Slack channels. For organizations that run on Teams, that was a real gap. Suggestions still got created and documentation PRs still got opened, but there was no native way to surface them where the team was already paying attention. Teams customers either had to route Promptless notifications through a separate Slack workspace they maintained for tools, or skip notification routing entirely and check the Promptless dashboard directly.
+
+## What it does now
+
+The notification policy in your `promptless.yaml` now accepts `msteams_channel` as a delivery target. When configured, Promptless announces new documentation suggestions in the specified Teams channel, including the suggestion title, a link to review it, and action buttons for creating a docs PR or opening it in the dashboard.
+
+Slack and Teams are independent options. You can configure one, the other, or both in the same policy. For orgs in a mixed environment where some teams use Slack and others use Teams, this lets you notify both channels without duplicating work.
+
+To find the conversation ID for a Teams channel, go to the channel in Teams, select the ellipsis menu, and choose **Get link to channel**. The conversation ID appears in the URL as the value of the `threadId` parameter, in the format `19:…@thread.tacv2`.
+
+<BlogNewsletterCTA />
+
+## Who benefits most
+
+Organizations that standardize on Microsoft Teams and want Promptless notifications to land where their team already works. This is also relevant for companies with a strong IT policy preference for Teams over Slack, or for teams that have resisted adopting Promptless because the Slack-only notification path didn't fit.
+
+## How to use it
+
+Update the notification policy in your `promptless.yaml`:
+
+```yaml
+policies:
+  - notification:
+      msteams_channel: "19:your-channel-id@thread.tacv2"
+```
+
+To notify both Slack and Teams:
+
+```yaml
+policies:
+  - notification:
+      slack_channel: "your-slack-channel"
+      msteams_channel: "19:your-channel-id@thread.tacv2"
+```
+
+You can also configure this on the [Configuration page](https://app.gopromptless.ai/configuration) in the Promptless dashboard, which will commit the change to your `promptless.yaml` automatically.
+
+Microsoft Teams must first be connected on the [Integrations page](https://app.gopromptless.ai/integrations). If you haven't connected Teams yet, start there.
+
+<BlogRequestDemo />

--- a/src/content/blog/product-updates/microsoft-teams-notifications.mdx
+++ b/src/content/blog/product-updates/microsoft-teams-notifications.mdx
@@ -12,25 +12,25 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-Promptless can now post documentation suggestion notifications to a Microsoft Teams channel. Add `msteams_channel` to your notification policy with a channel conversation ID, and suggestions will appear in Teams the same way they would in Slack.
+Promptless can now post documentation suggestion notifications to a Microsoft Teams channel. Add `msteams_channel` to your notification policy with a channel conversation ID. Suggestions then appear in Teams the same way they appear in Slack.
 
 ## The problem
 
-Until now, Promptless notification policies only supported Slack channels. For organizations that run on Teams, that was a real gap. Suggestions still got created and documentation PRs still got opened, but there was no native way to surface them where the team was already paying attention. Teams customers either had to route Promptless notifications through a separate Slack workspace they maintained for tools, or skip notification routing entirely and check the Promptless dashboard directly.
+Until now, Promptless notification policies only supported Slack channels. This was a problem for organizations that run on Microsoft Teams. Promptless still created suggestions and opened documentation PRs. But there was no way to show them where the team already worked. Teams customers had two options. They could route Promptless notifications through a separate Slack workspace kept just for tools. Or they could skip notification routing and check the Promptless dashboard directly.
 
 ## What it does now
 
-The notification policy in your `promptless.yaml` now accepts `msteams_channel` as a delivery target. When configured, Promptless announces new documentation suggestions in the specified Teams channel, including the suggestion title, a link to review it, and action buttons for creating a docs PR or opening it in the dashboard.
+The notification policy in your `promptless.yaml` now accepts `msteams_channel` as a delivery target. When you configure it, Promptless announces new documentation suggestions in that Teams channel. Each notification includes the suggestion title, a link to review it, and action buttons for creating a docs PR or opening it in the dashboard.
 
-Slack and Teams are independent options. You can configure one, the other, or both in the same policy. For orgs in a mixed environment where some teams use Slack and others use Teams, this lets you notify both channels without duplicating work.
+Slack and Teams are independent options. You can configure one, the other, or both in the same policy. Some organizations have teams that use Slack and teams that use Teams. In that mixed environment, you can notify both channels without duplicating work.
 
-To find the conversation ID for a Teams channel, go to the channel in Teams, select the ellipsis menu, and choose **Get link to channel**. The conversation ID appears in the URL as the value of the `threadId` parameter, in the format `19:…@thread.tacv2`.
+To find the conversation ID, go to the channel in Teams and select the ellipsis menu. Then choose **Get link to channel**. The conversation ID appears in the URL as the value of the `threadId` parameter, in the format `19:…@thread.tacv2`.
 
 <BlogNewsletterCTA />
 
 ## Who benefits most
 
-Organizations that standardize on Microsoft Teams and want Promptless notifications to land where their team already works. This is also relevant for companies with a strong IT policy preference for Teams over Slack, or for teams that have resisted adopting Promptless because the Slack-only notification path didn't fit.
+This feature helps organizations that standardize on Microsoft Teams. It also helps companies whose IT policy favors Teams over Slack. Some teams avoided Promptless before because the Slack-only notification path didn't fit them. Now that barrier is gone.
 
 ## How to use it
 
@@ -51,7 +51,7 @@ policies:
       msteams_channel: "19:your-channel-id@thread.tacv2"
 ```
 
-You can also configure this on the [Configuration page](https://app.gopromptless.ai/configuration) in the Promptless dashboard, which will commit the change to your `promptless.yaml` automatically.
+You can also configure this on the [Configuration page](https://app.gopromptless.ai/configuration) in the Promptless dashboard. This commits the change to your `promptless.yaml` automatically.
 
 Microsoft Teams must first be connected on the [Integrations page](https://app.gopromptless.ai/integrations). If you haven't connected Teams yet, start there.
 


### PR DESCRIPTION
## Feature

Promptless can now post documentation suggestion notifications to a Microsoft Teams channel. Add `msteams_channel` to the notification policy in `promptless.yaml` with a channel conversation ID. Slack and Teams are independent options; configure one, the other, or both.

## Entries considered this run

Window: 2026-06-22 → 2026-06-29.

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **Google Drive as a context source** — new read-only integration | QUALIFIES | New integration with major platform (separate PR) |
| 2 | **Microsoft Teams notification channel** — `msteams_channel` in notification policy | QUALIFIES | New notification platform; opens Teams-first orgs to Promptless |
| 3 | **Doc agents use your existing skills** — skills auto-discovered from `.claude/skills/` etc. | SKIP — borderline | Capability enhancement; at 3+ qualifiers, default NO per bar |
| 4 | **Structured configuration editor** — Form editor for `promptless.yaml` | SKIP — borderline | UX improvement to existing feature |
| 5 | **Backfill suggestions for PR triggers** — retroactive PR processing | SKIP — borderline | Niche; adoption-stage feature |
| 6 | **@promptless mention in PR title/description** | SKIP — borderline | Overlaps with existing `request-docs-via-pr-comments` post |
| 7 | **Slite integration** | SKIP — duplicate | PR #629 already open |
| 8 | **File-first promptless.yaml configuration** | SKIP — duplicate | PR #630 already open |
| 9 | **GitLab source code reading** | SKIP — borderline | Deepens existing integration, not a new platform |
| 10 | **Rebuilt onboarding as connect-only flow** | SKIP — onboarding UX | One-time flow |
| 11 | **Multiple doc collections during onboarding** | SKIP — onboarding UX | Onboarding enhancement |
| 12 | **Vale prose linting** | SKIP — existing feature | Changelog: "been able to do this for a while" |
| 13 | **Inline citations in Slack research replies** | SKIP — improvement | Enhancement to existing capability |
| 14 | Provider-branded status pills, trigger event timeline, always-on bulk selection, sort control, PR number search | SKIP — UI polish | Dashboard UI refinements |
| 15 | Responsive sidebar, sidebar suggestion count, docs target chip | SKIP — UI polish | Minor UI |
| 16 | Triggers page grouping and date filtering | SKIP — UI improvement | Management page UI |
| 17 | Admin-only AKB editing, config page access for all members | SKIP — permissions change | Not new capability |
| 18 | Reconnect Slack to update permissions | SKIP — admin utility | Admin workflow utility |
| 19 | Filter by Unassigned, org-aware link previews, dynamic Slack status, rich Slack suggestion previews | SKIP — improvement | Improvements to existing features |
| 20 | API access for doc collection management | SKIP — borderline | New but small API-first audience |
| 21 | GitHub pending install visibility | SKIP — onboarding edge case | Admin-approval edge case UX |
| 22 | All bug fixes | SKIP — bug fix | Bug fixes belong in changelog |

27 commit(s) in window. ~24 entries considered, 2 qualified.

## Covered entry (full text)

> **Microsoft Teams notification channel:** Promptless can now announce documentation suggestions in a Microsoft Teams channel, not just Slack. Add `msteams_channel` to your notification policy with the channel's conversation ID (e.g. `19:…@thread.tacv2`) on the [Configuration page](https://app.gopromptless.ai/configuration). Slack and Teams channels are independent, so you can notify either or both. See [Customizing Notifications](/docs/configuring-promptless/customizing-notifications) for details.

Source: commit [ba3b501](https://github.com/Promptless/promptless.ai/commit/ba3b501e163ad098824102ee14230f2ce5c1d334).

## PR(s) researched

Changelog entry references Promptless/promptless#3651 (Microsoft Teams notification channel and Slite YAML context source).

## File

`src/content/blog/product-updates/microsoft-teams-notifications.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UafUWo4QNBaV61gitMW1rT)_