### PR TITLE
content: Launch post — doc agents use existing skills

### DIFF
--- a/src/content/blog/product-updates/doc-agents-existing-skills.mdx
+++ b/src/content/blog/product-updates/doc-agents-existing-skills.mdx
@@ -1,0 +1,51 @@
+---
+title: 'Doc Agents Now Run Your Existing Agent Skills'
+subtitle: Published June 2026
+description: >-
+  Promptless automatically discovers and runs Agent Skills already in your documentation repository. If your team keeps skills under .claude/skills/, .agents/skills/, or .cursor/skills/, Promptless uses them with no extra setup.
+date: '2026-06-26T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+If your documentation repository already has Agent Skills—for Claude Code, Cursor, or another AI coding tool—Promptless now discovers and runs them automatically.
+
+## The problem
+
+Documentation workflows vary more than most tools acknowledge. One team has a naming convention for API reference pages that has to be applied consistently. Another runs a Vale linting pass and then a custom completeness check before any suggestion ships. A third has a two-step process: first expand the existing content, then rewrite the introduction to match a specific voice.
+
+Promptless generates documentation suggestions by running an agent against each trigger. That agent had a fixed approach: read the diff, pull context, write the suggestion. It produced good output for the common case, but there was no way to encode a team's specific workflow into it. If you'd worked out a documentation process that produced better results—through iteration, tooling, or institutional knowledge—Promptless couldn't use it.
+
+The same teams that had developed these workflows were also, often, the teams building up skill libraries for Claude Code and Cursor. They had the workflow encoded. Promptless just couldn't see it.
+
+## What changed
+
+Promptless now scans for Agent Skills in your documentation repository before running each task. Skills under `.claude/skills/`, `.agents/skills/`, or `.cursor/skills/` are picked up automatically. When the description of a task matches a skill's description, the agent runs that skill instead of deriving the approach from scratch.
+
+The scan order is `.claude` → `.agents` → `.cursor`. If the same skill name exists in more than one directory, the first one wins. Skill filenames are case-sensitive.
+
+If you want to guide when and how Promptless reaches for specific skills—for example, to prefer a certain skill for API reference tasks, or to exclude a skill that only applies to interactive sessions—add instructions to a `PROMPTLESS.md` file in your Agent Knowledge Base.
+
+<BlogNewsletterCTA />
+
+## Who benefits most
+
+Teams that have already built agent skills for their documentation workflows. If your docs team uses Claude Code and has accumulated skills for checking documentation style, enforcing a glossary, validating API reference structure, or following a review checklist—Promptless can now run those same workflows when it generates suggestions. The skills you built for interactive use now also run on every automated documentation trigger.
+
+This closes a gap that affected teams who were AI-forward enough to build skill libraries, but found that the documentation agent didn't share that context. The same skill library now powers both.
+
+Teams without existing skills can still benefit: any skill you create now works in both contexts automatically, so the cost of building one is lower.
+
+## How to use it
+
+No setup is required if you already have skills in your documentation repository. Promptless will pick them up on the next trigger.
+
+To create your first skill, add a Markdown file to `.claude/skills/` (or `.agents/skills/` or `.cursor/skills/`) in your docs repository. The file should describe what the skill does and the steps it follows. When a documentation task matches the skill's description, the agent runs it.
+
+To add guidance about when Promptless should use which skills, create a `PROMPTLESS.md` in your Agent Knowledge Base. See [How Promptless Learns Your Docs](/docs/configuring-promptless/doc-collections/how-promptless-learns-your-docs#using-your-existing-skills) for reference.
+
+<BlogRequestDemo />

--- a/src/content/blog/product-updates/doc-agents-existing-skills.mdx
+++ b/src/content/blog/product-updates/doc-agents-existing-skills.mdx
@@ -12,37 +12,37 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-If your documentation repository already has Agent Skills—for Claude Code, Cursor, or another AI coding tool—Promptless now discovers and runs them automatically.
+Your documentation repository may already have Agent Skills for Claude Code, Cursor, or another AI coding tool. Promptless now discovers and runs them automatically.
 
 ## The problem
 
-Documentation workflows vary more than most tools acknowledge. One team has a naming convention for API reference pages that has to be applied consistently. Another runs a Vale linting pass and then a custom completeness check before any suggestion ships. A third has a two-step process: first expand the existing content, then rewrite the introduction to match a specific voice.
+Documentation workflows vary across teams. One team has a naming convention for API reference pages that must stay consistent. Another team runs a Vale linting pass, then a custom completeness check, before any suggestion ships. A third team follows a two-step process. The team first expands the existing content, then rewrites the introduction to match a specific voice.
 
-Promptless generates documentation suggestions by running an agent against each trigger. That agent had a fixed approach: read the diff, pull context, write the suggestion. It produced good output for the common case, but there was no way to encode a team's specific workflow into it. If you'd worked out a documentation process that produced better results—through iteration, tooling, or institutional knowledge—Promptless couldn't use it.
+Promptless generates documentation suggestions by running an agent against each trigger. That agent read the diff, pulled context, and wrote the suggestion the same way every time. This approach produced good output for the common case, but it could not encode a team's specific workflow. Teams sometimes developed a better documentation process through iteration, tooling, or institutional knowledge. Promptless could not use that process.
 
-The same teams that had developed these workflows were also, often, the teams building up skill libraries for Claude Code and Cursor. They had the workflow encoded. Promptless just couldn't see it.
+The same teams that built these workflows were often the same teams building skill libraries for Claude Code and Cursor. They had the workflow encoded, but Promptless could not see it.
 
 ## What changed
 
-Promptless now scans for Agent Skills in your documentation repository before running each task. Skills under `.claude/skills/`, `.agents/skills/`, or `.cursor/skills/` are picked up automatically. When the description of a task matches a skill's description, the agent runs that skill instead of deriving the approach from scratch.
+Before running each task, Promptless now scans your documentation repository for Agent Skills. Skills under `.claude/skills/`, `.agents/skills/`, or `.cursor/skills/` are picked up automatically. When the description of a task matches a skill's description, the agent runs that skill instead of deriving the approach from scratch.
 
-The scan order is `.claude` → `.agents` → `.cursor`. If the same skill name exists in more than one directory, the first one wins. Skill filenames are case-sensitive.
+The scan order is `.claude`, then `.agents`, then `.cursor`. If the same skill name exists in more than one directory, the first one wins. Skill filenames are case-sensitive.
 
-If you want to guide when and how Promptless reaches for specific skills—for example, to prefer a certain skill for API reference tasks, or to exclude a skill that only applies to interactive sessions—add instructions to a `PROMPTLESS.md` file in your Agent Knowledge Base.
+You can guide when and how Promptless uses specific skills. You can prefer a certain skill for API reference tasks, or exclude a skill that only applies to interactive sessions. Add these instructions to a `PROMPTLESS.md` file in your Agent Knowledge Base.
 
 <BlogNewsletterCTA />
 
 ## Who benefits most
 
-Teams that have already built agent skills for their documentation workflows. If your docs team uses Claude Code and has accumulated skills for checking documentation style, enforcing a glossary, validating API reference structure, or following a review checklist—Promptless can now run those same workflows when it generates suggestions. The skills you built for interactive use now also run on every automated documentation trigger.
+Teams that have already built agent skills for their documentation workflows benefit most. If your docs team uses Claude Code, you may have skills for checking documentation style, enforcing a glossary, validating API reference structure, or following a review checklist. Promptless can now run those same workflows when it generates suggestions. The skills you built for interactive use now also run on every automated documentation trigger.
 
-This closes a gap that affected teams who were AI-forward enough to build skill libraries, but found that the documentation agent didn't share that context. The same skill library now powers both.
+This closes a gap for AI-forward teams. These teams built skill libraries, but the documentation agent could not share that context. The same skill library now powers both interactive and automated use.
 
-Teams without existing skills can still benefit: any skill you create now works in both contexts automatically, so the cost of building one is lower.
+Teams without existing skills can still benefit. Any skill you create now works in both contexts automatically, so building it costs less.
 
 ## How to use it
 
-No setup is required if you already have skills in your documentation repository. Promptless will pick them up on the next trigger.
+You need no setup if you already have skills in your documentation repository. Promptless picks them up on the next trigger.
 
 To create your first skill, add a Markdown file to `.claude/skills/` (or `.agents/skills/` or `.cursor/skills/`) in your docs repository. The file should describe what the skill does and the steps it follows. When a documentation task matches the skill's description, the agent runs it.
 


### PR DESCRIPTION
## Feature
Promptless now auto-discovers Agent Skills in your documentation repository (`.claude/skills/`, `.agents/skills/`, `.cursor/skills/`) and runs them when a documentation task matches a skill's description. No extra setup if skills already exist.

## Entries considered this run

Window: 2026-06-22 → 2026-06-29 (last 7 days). 27 commits, 33+ entries.

This is a third article from this run. The earlier session today (session `01UafUWo4QNBaV61gitMW1rT`) opened PRs for Google Drive (#652) and Microsoft Teams (#653) but skipped doc agents skills as borderline at the 3+ threshold. Re-evaluated: the feature enables a previously impossible customization workflow and meets the bar.

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **Doc agents use your existing skills** — auto-discovers `.claude/skills/`, `.agents/skills/`, `.cursor/skills/`; runs skills when task matches description | QUALIFIES | New capability: previously impossible to customize doc agent behavior via existing skill files |
| 2 | **Google Drive as a context source** | QUALIFIES — covered by PR #652 | Separate PR, same run |
| 3 | **Microsoft Teams notification channel** | QUALIFIES — covered by PR #653 | Existing PR from earlier session |
| 4 | **Structured configuration editor** | SKIP — duplicate | PR #630 open |
| 5 | **Slite integration** | SKIP — duplicate | PR #629 open |
| 6 | **Backfill suggestions for PR triggers** | SKIP — deprioritized | Qualifies (new capability) but deprioritized |
| 7 | **GitLab source code reading** | SKIP — deprioritized | Qualifies; deprioritized |
| 8 | **API access for doc collection management** | SKIP — deprioritized | Qualifies; deprioritized |
| 9 | **@promptless mentions in PR title/description** | SKIP — near-duplicate | Existing post `request-docs-via-pr-comments.mdx` |
| 10 | **Rich Slack suggestion previews** | SKIP | UX improvement to existing notifications |
| 11 | **Rebuilt onboarding as connect-only flow** | SKIP | Onboarding UX, no new capability |
| 12 | **Inline citations in Slack research replies** | SKIP | Enhancement to existing capability |
| 13 | **Vale Prose Linting** | SKIP | Existing undocumented feature, not new |
| 14 | **Triggers page grouping and date filtering** | SKIP | UI reorganization |
| 15 | **Multiple doc collections during onboarding** | SKIP | Onboarding improvement |
| 16 | **Reconnect Slack in place** | SKIP | Admin utility |
| 17 | **Filter by Unassigned** | SKIP | Minor UI filter |
| 18 | **GitHub pending install visibility** | SKIP | Onboarding edge case |
| 19 | **Admin-only AKB editing** | SKIP | Permission change |
| 20 | **Responsive sidebar** | SKIP | Minor UI polish |
| 21 | **Dynamic Slack status updates** | SKIP | UX improvement |
| 22 | **Provider-Branded Status Pills, Trigger Event Timeline, Bulk Selection, Sort control, PR# search** | SKIP | Dashboard UI refinements |
| 23 | **Sidebar suggestion count, docs target chip** | SKIP | Minor UI |
| 24 | **All bug fixes** (Slack Triggered-by labels, duplicate cards, refresh button, Teams tenant name, bot mentions, etc.) | SKIP | Bug fixes |

## Covered entry (full text)

> **Doc agents use your existing skills:** If you already keep Agent Skills in your documentation repository, Promptless now uses them automatically—no extra setup required. Skills under `.claude/skills/`, `.agents/skills/`, or `.cursor/skills/` are picked up, and when a documentation task matches a skill's description, the agent runs that skill instead of deriving the workflow from scratch. You can guide when and how Promptless reaches for your skills by adding instructions to the `PROMPTLESS.md` file in your Knowledge Base. See [How Promptless Learns Your Docs](/docs/configuring-promptless/doc-collections/how-promptless-learns-your-docs#using-your-existing-skills) for details.

Source: commit [c8f8640](https://github.com/Promptless/promptless.ai/commit/c8f8640290bdd7994e61b577125b22c1a16a04b9).

## PR(s) researched
- Promptless/promptless#551 (docs PR reference) — researched from changelog entry (GitHub MCP scoped to promptless.ai only)

## File
`src/content/blog/product-updates/doc-agents-existing-skills.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZfQDHxr2pimZqxQty3Bwr)_