### PR TITLE
content: Why Developer Relations Documentation Goes Stale Faster

### DIFF
--- a/src/content/blog/technical/why-developer-relations-documentation-goes-stale-faster.mdx
+++ b/src/content/blog/technical/why-developer-relations-documentation-goes-stale-faster.mdx
@@ -1,0 +1,73 @@
+---
+title: 'Why Developer Relations Documentation Goes Stale Faster'
+subtitle: Published June 2026
+description: >-
+  DevRel teams write about a product they don't control. When engineering ships changes, DevRel finds out later. Here's the structural fix.
+date: '2026-06-29T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer advocate spent two days troubleshooting a user's failing integration. The quickstart guide described the authentication flow correctly as of six months prior. Engineering had simplified the flow in a March release. Nobody had told DevRel.
+
+The user found the correct behavior in a GitHub commit message. DevRel updated the guide. But two days of developer friction came from one cause: the documentation team didn't know the product had changed.
+
+## The owner-writer gap
+
+Most documentation lives close to the thing it describes. SDK reference docs are generated from source. Internal runbooks are maintained by the engineers who wrote the systems. When something changes, the people who made the change are responsible for updating the docs.
+
+DevRel documentation breaks this pattern. Developer advocates write tutorials, quickstarts, and integration guides about a product they don't own and don't control. When engineering ships a change, DevRel is downstream. They find out through Slack, a [changelog](/blog/technical/api-changelog-best-practices), or a support ticket.
+
+The problem is structural: documentation owner and product owner are different teams with different calendars, different priorities, and no automated bridge between them.
+
+## Why the lag is invisible
+
+The dangerous part of this lag is that nothing signals it.
+
+When a function is renamed in source code and the reference docs aren't updated, static analysis can catch it. When an endpoint is deprecated and the API spec isn't updated, validation tooling can flag it. But when a DevRel-maintained tutorial describes a flow that engineering changed, the tutorial still renders fine. The code samples still look like code samples. Nothing throws an error.
+
+Developers hit the problem. A quickstart that worked now fails on step three. A concept guide describes a behavior the product no longer exhibits. Developers open a support ticket, dig through source code, or abandon the integration. DevRel finds out through human feedback, not automated detection.
+
+A survey of developer documentation teams found that 80% of knowledge bases are out of date. Only 19.1% of teams rate their documentation as "very accurate." DevRel teams aren't outliers here. They're dealing with the same problem in a context that makes it harder to catch.
+
+[Documentation drift is a detection problem before it's a writing problem.](/blog/technical/documentation-drift-detection-problem) DevRel documentation has a harder version of that problem because the detection signal is especially weak.
+
+<BlogNewsletterCTA />
+
+## What this costs
+
+DevRel teams care about two metrics more than most: time-to-first-success (how long it takes a developer to make their first working API call) and developer activation (whether developers who sign up actually ship something).
+
+Stale documentation undermines both. According to Postman, if a developer can't make their first API call within 15 minutes of starting, the integration is likely lost. A wrong authentication flow in step three of a quickstart eats that window.
+
+This matters for DevRel specifically because 60.7% of DevRel practitioners cite proving impact with metrics as their top challenge (State of Developer Relations 2024). Stale docs don't create noise in a dashboard. They silently drag down the numbers DevRel needs to justify its budget.
+
+## Two things that close the gap
+
+The standard advice is quarterly doc reviews and a documentation field in the PR template. Neither reliably closes the owner-writer gap. Quarterly reviews miss changes that happen in January and surface in March. PR template checkboxes get skipped when engineering is moving fast.
+
+What actually works requires two changes.
+
+**Put DevRel in the engineering ship path.** This doesn't mean a developer advocate reviews every PR. It means a lightweight trigger: when a PR touches something that DevRel maintains a doc about, a notification goes to DevRel before the PR merges. Not after the changelog publishes. Not after the support ticket arrives. Before.
+
+This requires mapping which parts of the codebase correspond to which DevRel-owned docs. That work is mechanical, but it only needs to be done once. After that, it runs as a filter.
+
+**Monitor documentation against the actual product.** A quarterly review depends on the reviewer knowing what changed. If someone reads a tutorial without visibility into what the product currently does, they can't reliably catch drift. The review needs to be grounded in the actual state of the API and SDK, not in memory or release notes.
+
+[Documentation debt accrues fastest where teams can't see it.](/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it) For DevRel teams, the invisible corner is the owner-writer gap: changes that happened upstream that nobody flagged downstream.
+
+## The detection problem DevRel didn't sign up for
+
+Developer advocates are hired to write tutorials, run workshops, and help developers succeed. They aren't hired to monitor engineering repositories for changes that might affect their content.
+
+But the current default puts that burden on them anyway. Without an automated change signal, DevRel documentation accuracy depends on whether the right person heard the right Slack message at the right time.
+
+The teams that maintain accurate DevRel docs at scale have moved the detection responsibility out of human memory and into tooling. When engineering changes something, a signal propagates to the people who maintain the documentation about that thing, before any developer sees the wrong version.
+
+Promptless monitors your documentation against your actual codebase and API surface, surfacing what's out of date as your product changes. For DevRel teams, that means the owner-writer gap has an automated bridge: instead of waiting for a support ticket to reveal that your quickstart is wrong, Promptless flags the gap as it opens.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer relations docs`

## Article plan

**Thesis:** DevRel docs go stale not because of bad writing, but because the writer and the product owner are different teams with no automated bridge between them.

**Target reader:** Developer advocates and DevRel engineers who write tutorials/quickstarts but don't own the codebase

**Key points:**
1. DevRel documentation has a structural owner-writer gap other doc types don't face
2. The staleness lag is invisible: nothing throws an error when a tutorial goes wrong
3. 80% of knowledge bases are out of date; 60.7% of DevRel practitioners can't prove impact with metrics (State of DevRel 2024)
4. Stale docs directly tank time-to-first-success, the metric DevRel cares about most
5. Two structural fixes: put DevRel in the engineering ship path (pre-merge notifications) + monitor docs against the actual product

**Promptless connection:** Promptless gives DevRel teams the automated change signal they're missing — surfacing gaps before a developer hits a stale quickstart.

## File

`src/content/blog/technical/why-developer-relations-documentation-goes-stale-faster.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pVFHvP921seDLeaGAPxYE)_