### PR TITLE
Add a rendered OpenAPI reference for the API trigger

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import starlightOpenAPI, { openAPISidebarGroups } from 'starlight-openapi';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import partytown from '@astrojs/partytown';
@@ -30,7 +31,7 @@ const redirects = {
   '/blog/customer-stories-vellum': '/blog/customer-stories/vellum',
   '/use-cases': '/',
   '/faq': '/',
-  '/api-reference': '/',
+  '/api-reference': '/api/',
   '/oss': '/docs/getting-started/promptless-oss',
   '/media-kit': '/docs/media-kit',
   '/brand': '/docs/media-kit',
@@ -63,7 +64,16 @@ export default defineConfig({
       },
       favicon: '/favicon.ico',
       customCss: ['./src/styles/custom.css', './src/styles/site.css'],
-      sidebar: generatedSidebar,
+      plugins: [
+        starlightOpenAPI([
+          {
+            base: 'api',
+            schema: './public/openapi/api-triggers.yaml',
+            sidebar: { label: 'API Reference' },
+          },
+        ]),
+      ],
+      sidebar: [...generatedSidebar, ...openAPISidebarGroups],
       components: {
         Sidebar: './src/components/starlight/Sidebar.astro',
         Header: './src/components/starlight/Header.astro',

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "lucide-static": "^0.575.0",
         "posthog-js": "^1.362.0",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "starlight-openapi": "^0.22.0"
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
@@ -99,6 +100,22 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-13.0.5.tgz",
+      "integrity": "sha512-xfh4xVJD62gG6spIc7lwxoWT+l16nZu1ELyU8FkjaP/oD2yP09EvLAU6KhtudN9aML2Khhs9pY6Slr7KGTES3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
     },
     "node_modules/@astrojs/check": {
       "version": "0.9.6",
@@ -211,12 +228,6 @@
         "unist-util-visit-parents": "^6.0.2",
         "vfile": "^6.0.3"
       }
-    },
-    "node_modules/@astrojs/markdown-remark/node_modules/github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-      "license": "ISC"
     },
     "node_modules/@astrojs/mdx": {
       "version": "4.3.13",
@@ -1469,6 +1480,15 @@
         "tailwindcss": "^3.0 || ^4.0"
       }
     },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
+      "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
@@ -2668,6 +2688,55 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
+    "node_modules/@readme/better-ajv-errors": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-2.4.0.tgz",
+      "integrity": "sha512-9WODaOAKSl/mU+MYNZ2aHCrkoRSvmQ+1YkLj589OEqqjOAhbn8j7Z+ilYoiTu/he6X63/clsxxAB4qny9/dDzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/code-frame": "^7.22.5",
+        "@babel/runtime": "^7.22.5",
+        "@humanwhocodes/momoa": "^2.0.3",
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ajv": "4.11.8 - 8"
+      }
+    },
+    "node_modules/@readme/openapi-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-4.1.2.tgz",
+      "integrity": "sha512-lAFH88r/CHs5VZDUocEda0OSMSQsr6801sziIjOKyVA+0hSFN+BPuelPF5XvkMROHecnPd+XEJN1iNQqCgER/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^13.0.5",
+        "@readme/better-ajv-errors": "^2.3.2",
+        "@readme/openapi-schemas": "^3.1.0",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^8.12.0",
+        "ajv-draft-04": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@readme/openapi-schemas": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-schemas/-/openapi-schemas-3.1.0.tgz",
+      "integrity": "sha512-9FC/6ho8uFa8fV50+FPy/ngWN53jaUu4GRXlAjcxIRrzhltJnpKkBG2Tp0IDraFJeWrOpk84RJ9EMEEYzaI1Bw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@resvg/resvg-js": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
@@ -3781,6 +3850,12 @@
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -4114,7 +4189,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4131,7 +4205,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
       "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.5.0"
@@ -4493,12 +4566,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
-    },
-    "node_modules/astro/node_modules/github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-      "license": "ISC"
     },
     "node_modules/astro/node_modules/html-escaper": {
       "version": "3.0.3",
@@ -6957,7 +7024,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -7012,7 +7078,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7271,6 +7336,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -8272,7 +8343,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -8293,6 +8363,15 @@
       "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/katex": {
       "version": "0.16.45",
@@ -8377,6 +8456,15 @@
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -10800,6 +10888,13 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/p-queue": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
@@ -12013,7 +12108,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12518,6 +12612,25 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/starlight-openapi": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/starlight-openapi/-/starlight-openapi-0.22.0.tgz",
+      "integrity": "sha512-4H/fywAoTcvKbcv+xBr9LdrjMc5geDOSnydvzpiOxjxkHvI6g+7uPhWNCejnJPyZUd/MC1MI23tvYug85d/WzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@readme/openapi-parser": "^4.1.2",
+        "github-slugger": "^2.0.0",
+        "url-template": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18.17.1"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-remark": ">=6.0.1",
+        "@astrojs/starlight": ">=0.34.0",
+        "astro": ">=5.5.0"
+      }
     },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
@@ -13302,6 +13415,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-template": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-3.1.1.tgz",
+      "integrity": "sha512-4oszoaEKE/mQOtAmdMWqIRHmkxWkUZMnXFnjQ5i01CuRSK3uluxcH1MRVVVWmhlnzT1SCDfKxxficm2G37qzCA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "lucide-static": "^0.575.0",
     "posthog-js": "^1.362.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "starlight-openapi": "^0.22.0"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/public/openapi/api-triggers.yaml
+++ b/public/openapi/api-triggers.yaml
@@ -121,6 +121,15 @@ components:
           examples:
           - jira_ticket: DOC-456
             release: v2.5.0
+        doc_collection_id:
+          type: string
+          format: uuid
+          title: Doc Collection Id
+          description: Optional UUID of a single doc collection to target. When omitted,
+            the trigger may route to any of the organization's ready doc collections.
+            When supplied, dispatch is restricted to exactly that collection.
+          examples:
+          - 7c3e9f12-4b8a-4d2e-9f1a-2b6c8d0e4f5a
       additionalProperties: false
       type: object
       required:

--- a/public/openapi/api-triggers.yaml
+++ b/public/openapi/api-triggers.yaml
@@ -121,15 +121,6 @@ components:
           examples:
           - jira_ticket: DOC-456
             release: v2.5.0
-        doc_collection_id:
-          type: string
-          format: uuid
-          title: Doc Collection Id
-          description: Optional UUID of a single doc collection to target. When omitted,
-            the trigger may route to any of the organization's ready doc collections.
-            When supplied, dispatch is restricted to exactly that collection.
-          examples:
-          - 7c3e9f12-4b8a-4d2e-9f1a-2b6c8d0e4f5a
       additionalProperties: false
       type: object
       required:

--- a/public/openapi/api-triggers.yaml
+++ b/public/openapi/api-triggers.yaml
@@ -48,6 +48,10 @@ paths:
         '422':
           description: The request body is invalid (e.g. empty instructions or a malformed
             UUID).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '500':
           description: The trigger could not be enqueued for processing (`enqueue_failed`).
           content:
@@ -123,6 +127,37 @@ components:
       - instructions
       title: ApiTriggerIntakeRequest
       description: JSON request body for API-triggered task intake.
+    HTTPValidationError:
+      type: object
+      title: HTTPValidationError
+      description: Validation error body returned when the request fails schema validation.
+      properties:
+        detail:
+          type: array
+          title: Detail
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    ValidationError:
+      type: object
+      title: ValidationError
+      required:
+      - loc
+      - msg
+      - type
+      properties:
+        loc:
+          type: array
+          title: Location
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
   securitySchemes:
     bearerAuth:
       type: http

--- a/public/openapi/api-triggers.yaml
+++ b/public/openapi/api-triggers.yaml
@@ -1,0 +1,130 @@
+openapi: 3.1.0
+info:
+  title: Promptless API
+  description: |
+    API for triggering Promptless documentation updates from external systems like CI/CD pipelines and custom automations.
+
+    <a href="/openapi/api-triggers.yaml" download="promptless-openapi.yaml">Download the OpenAPI spec (YAML)</a>
+  version: 1.0.0
+servers:
+- url: https://api.gopromptless.ai
+paths:
+  /triggers:
+    post:
+      tags:
+      - Triggers
+      summary: Submit an API trigger
+      description: |
+        Request a documentation update. Authenticate with your organization's API key as a bearer token. A successful request returns the identifier of the trigger event.
+
+        <a href="/openapi/api-triggers.yaml" download="promptless-openapi.yaml">Download the OpenAPI spec (YAML)</a>
+      operationId: submitApiTrigger
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiTriggerIntakeRequest'
+        required: true
+      responses:
+        '202':
+          description: The trigger was accepted and enqueued for processing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiTriggerAcceptedResponse'
+        '401':
+          description: The API key is missing, invalid, or revoked.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiTriggerErrorResponse'
+        '409':
+          description: The organization has not finished setting up Promptless (`org_not_configured`),
+            or the requested doc collection is not configured or not ready (`no_eligible_doc_collection`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiTriggerErrorResponse'
+        '422':
+          description: The request body is invalid (e.g. empty instructions or a malformed
+            UUID).
+        '500':
+          description: The trigger could not be enqueued for processing (`enqueue_failed`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiTriggerErrorResponse'
+        '503':
+          description: Trigger intake is temporarily unavailable (`runtime_store_unavailable`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiTriggerErrorResponse'
+      security:
+      - bearerAuth: []
+components:
+  schemas:
+    ApiTriggerAcceptedResponse:
+      properties:
+        trigger_event_id:
+          type: string
+          title: Trigger Event Id
+          description: Identifier of the trigger event. Use it to correlate with trigger history.
+          examples:
+          - 550e8400-e29b-41d4-a716-446655440000
+      type: object
+      required:
+      - trigger_event_id
+      title: ApiTriggerAcceptedResponse
+      description: Response body returned when an API trigger is accepted for processing.
+    ApiTriggerErrorResponse:
+      properties:
+        error:
+          type: string
+          title: Error
+          description: Stable machine-readable error code.
+          examples:
+          - authentication_failed
+        message:
+          type: string
+          title: Message
+          description: Human-readable explanation of the error.
+          examples:
+          - Authentication failed.
+      type: object
+      required:
+      - error
+      - message
+      title: ApiTriggerErrorResponse
+      description: Error body returned when an API trigger request is rejected.
+    ApiTriggerIntakeRequest:
+      properties:
+        instructions:
+          type: string
+          title: Instructions
+          description: What you want Promptless to document. Be specific about which
+            docs to update and what changes to make.
+          minLength: 1
+          examples:
+          - Document the new rate limiting feature added in v2.5
+        context:
+          type: object
+          additionalProperties: true
+          title: Context
+          description: Optional arbitrary metadata to attach to the request. Appears in trigger
+            history for reference and is passed through to the workflow as additional
+            context.
+          examples:
+          - jira_ticket: DOC-456
+            release: v2.5.0
+      additionalProperties: false
+      type: object
+      required:
+      - instructions
+      title: ApiTriggerIntakeRequest
+      description: JSON request body for API-triggered task intake.
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: Organization API key issued from Settings > API Access.

--- a/src/content/docs/docs/configuring-promptless/triggers/api-triggers.mdx
+++ b/src/content/docs/docs/configuring-promptless/triggers/api-triggers.mdx
@@ -86,6 +86,7 @@ Send a JSON body with your documentation instructions:
 |-------|------|----------|-------------|
 | `instructions` | string | Yes | What you want Promptless to document. Be specific about which docs to update and what changes to make. |
 | `context` | object | No | Additional metadata to include with the request. This appears in trigger history for reference. |
+| `doc_collection_id` | string (UUID) | No | Target a single doc collection. When omitted, the trigger may route to any of your organization's ready doc collections; when supplied, dispatch is restricted to exactly that collection. |
 
 ### Example Request
 

--- a/src/content/docs/docs/configuring-promptless/triggers/api-triggers.mdx
+++ b/src/content/docs/docs/configuring-promptless/triggers/api-triggers.mdx
@@ -86,7 +86,6 @@ Send a JSON body with your documentation instructions:
 |-------|------|----------|-------------|
 | `instructions` | string | Yes | What you want Promptless to document. Be specific about which docs to update and what changes to make. |
 | `context` | object | No | Additional metadata to include with the request. This appears in trigger history for reference. |
-| `doc_collection_id` | string (UUID) | No | Target a single doc collection. When omitted, the trigger may route to any of your organization's ready doc collections; when supplied, dispatch is restricted to exactly that collection. |
 
 ### Example Request
 

--- a/src/content/docs/docs/configuring-promptless/triggers/api-triggers.mdx
+++ b/src/content/docs/docs/configuring-promptless/triggers/api-triggers.mdx
@@ -50,6 +50,8 @@ When rotating keys, update your integrations before generating a new key. The pr
 
 ## Using the API
 
+For the full request and response schemas, status codes, and an interactive explorer, see the [API Reference](/api/operations/submitapitrigger/). The sections below cover the same endpoint with examples.
+
 ### Endpoint
 
 ```
@@ -114,9 +116,9 @@ A successful request returns a `202 Accepted` response:
 
 | Status | Error | Description |
 |--------|-------|-------------|
-| 401 | `authentication_failed` | The API key is missing, invalid, or revoked |
-| 409 | `no_eligible_pipelines` | No doc collections are configured for your organization |
-| 422 | Validation error | The request body is invalid (e.g., empty instructions) |
+| 401 | `authentication_failed` | The API key is missing, invalid, or revoked. |
+| 409 | `org_not_configured` | Your organization hasn't finished setting up Promptless. |
+| 422 | Validation error | The request body is invalid. |
 
 ## Viewing API Triggers
 

--- a/src/content/docs/docs/configuring-promptless/triggers/api-triggers.mdx
+++ b/src/content/docs/docs/configuring-promptless/triggers/api-triggers.mdx
@@ -118,7 +118,10 @@ A successful request returns a `202 Accepted` response:
 |--------|-------|-------------|
 | 401 | `authentication_failed` | The API key is missing, invalid, or revoked. |
 | 409 | `org_not_configured` | Your organization hasn't finished setting up Promptless. |
+| 409 | `no_eligible_doc_collection` | The requested doc collection is not configured or not ready. |
 | 422 | Validation error | The request body is invalid. |
+| 500 | `enqueue_failed` | The trigger could not be enqueued for processing. |
+| 503 | `runtime_store_unavailable` | Trigger intake is temporarily unavailable. |
 
 ## Viewing API Triggers
 


### PR DESCRIPTION
## What

Publishes an interactive API reference for the public `POST /triggers` endpoint, rendered in the docs site via the `starlight-openapi` plugin, plus a download link for the spec.

## Changes

- **`starlight-openapi` plugin** wired into `astro.config.mjs` (pinned to `0.22.0` — the latest version compatible with our Starlight `0.37.x`), with its sidebar group spliced into the generated sidebar.
- **Spec at `public/openapi/api-triggers.yaml`** — a hand-maintained OpenAPI 3.1 document covering `POST /triggers` (request/response schemas, `202/401/409/422/500/503`, bearer auth). Living under `public/` means it's both the plugin's render source *and* a downloadable static asset at `/openapi/api-triggers.yaml`.
- **Download link** on the rendered reference: an HTML `<a … download>` anchor embedded in the spec descriptions (Starlight renders descriptions as Markdown, which preserves the raw anchor + `download` attribute). It appears on both the overview (`/api/`) and operation (`/api/operations/submitapitrigger/`) pages and saves the file directly rather than opening it in a tab.
- **Guide page** (`api-triggers.mdx`): links to the generated reference and corrects stale error codes in the error table (`no_eligible_pipelines` → `org_not_configured`, adds `enqueue_failed`).

## Reviewer notes

- The reference renders at **`/api/`** (overview) and **`/api/operations/submitapitrigger/`** (operation).
- The spec is **hand-maintained** (no generator). Update `public/openapi/api-triggers.yaml` directly when the public API changes.
- Scope is intentionally **`POST /triggers` only**. The doc-collection endpoints use a different API key (`plk_`) than the trigger key (`sk-pl-`) — confirmed by live testing — so they're deliberately excluded from this reference to avoid misrepresenting auth.

## Verification

- Spec validates as OpenAPI 3.1 (`@redocly/cli lint`).
- `npm run typecheck` (astro check) passes with 0 errors.
- Dev server renders both reference pages; the download anchor carries `download="promptless-openapi.yaml"` on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)