### PR TITLE
content: Documentation Translations: The Drift Problem Most Teams Don't Plan For

### DIFF
--- a/src/content/blog/technical/documentation-translations-localization-drift.mdx
+++ b/src/content/blog/technical/documentation-translations-localization-drift.mdx
@@ -1,0 +1,75 @@
+---
+title: 'Documentation Translations: The Drift Problem Most Teams Don''t Plan For'
+subtitle: Published July 2026
+description: >-
+  Translating your developer docs is the easy part. Keeping them accurate as your product changes is harder. Most localization workflows have no way to detect when they've drifted.
+date: '2026-07-01T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer in Germany opens your quickstart. It was translated eight months ago, when your auth flow worked differently. Your API now expects a Bearer token in the Authorization header. The translated page still says to pass an API key in `X-Auth-Token`. They follow the instructions exactly and get a 401.
+
+They don't file a support ticket. They close the tab.
+
+Your English docs are correct. Your dashboard looks fine. The problem is invisible to everyone except the developer who hit it.
+
+This is the localization drift problem, and it's the part of documentation translation that most teams don't plan for.
+
+## The case for translated developer docs
+
+Companies invest in translated developer documentation for real reasons. Localization of technical documentation on developer portals has become one of the most effective levers for global API adoption. A [2025 analysis of developer portal localization](https://medium.com/@ron_huber/developer-portals-and-api-documentation-localization-best-practices-to-drive-global-adoption-762e62b21100) found that translated docs consistently reduce time-to-first-API-call for non-English-speaking developers and reduce international support ticket volume. The ROI of multilingual content, across technical and non-technical contexts, is described by practitioners as among the highest of any content investment.
+
+The math is straightforward: if a developer can't read your quickstart, they can't integrate your API. Translation removes that barrier. For markets where English proficiency is lower or where developers strongly prefer native-language documentation, translation is a meaningful adoption lever.
+
+So the decision to translate is typically justified. The problem comes after.
+
+## How translation debt accumulates
+
+When you publish a translated version of a doc, the translation is accurate at that moment. The problem is everything that happens next.
+
+Your product ships. An authentication flow gets updated. An endpoint gets a new required parameter. A code sample uses a method that's been deprecated. Your English documentation team catches these changes through pull requests, Slack alerts, and the same sprint cadence that drives the product changes. They update the English docs.
+
+The translated versions don't update automatically. They update when someone on the translation team notices that the source changed, initiates the translation workflow, and gets the update published. In practice, that gap can be days, weeks, or months. And it's not one gap: every product change creates a new gap in each language you support simultaneously.
+
+Three languages means three separate translation queues, each accumulating independently. Six languages means six parallel staleness problems. The translation team is downstream of both the product and the English documentation team, and they have no direct line to the code changes driving those updates.
+
+<BlogNewsletterCTA />
+
+## What Translation Memory does and doesn't solve
+
+Most localization teams use Translation Memory (TM) systems: databases of previously translated segments that can be reused when source text appears again. When your authentication doc gets updated and 80% of the text is unchanged, TM lets you pay to translate only the 20% that changed. This is useful and correct.
+
+TM solves the cost problem. It does not solve the detection problem.
+
+TM tells you how to efficiently translate content once you know it needs updating. It has no mechanism for discovering that your Japanese quickstart now describes a flow your API no longer supports, or that your German SDK guide references a configuration option that was removed two sprints ago. The system helps translation teams work efficiently on the tasks in their queue. It doesn't populate that queue.
+
+The discovery of which source pages have drifted still falls to manual processes: a writer scanning pull requests, a localization manager comparing page versions, a support ticket from an international developer who finally got frustrated enough to report the problem. These processes work until they don't, and they don't, reliably, at any documentation scale.
+
+## The cost of invisible drift
+
+When translated docs drift, the damage is unevenly distributed. Your English-speaking users are reading current documentation. Your international users are reading whatever was accurate when your translation vendor last ran a project.
+
+This creates a version of brand drift: different users see your product at different points in its development history, with no visible signal that anything is wrong. A developer in Japan following your guide may be working from documentation that reflects your authentication model from eighteen months ago. The experience of using your product differs by language, not by geography or pricing tier, but simply because of when the last translation update happened.
+
+The feedback loop is broken in both directions. International developers who hit broken documentation don't typically file support tickets or post to your forum. They abandon the integration, often without any record that they tried. And because the failure happens in a context where your team isn't present, the problem isn't visible until you're looking for it.
+
+AI coding agents make this more acute. An agent that reads your translated docs to generate integration code doesn't distinguish between current documentation and documentation that was accurate eighteen months ago. It generates confidently wrong code based on whatever the doc says. A developer debugging that output may have no idea that the agent's source was a translated page your product has since outpaced. The [blast radius of stale documentation](https://promptless.ai/blog/technical/agent-friendly-docs-necessary-not-sufficient) has grown as agents increasingly mediate how developers interact with your docs.
+
+## What a real fix looks like
+
+Continuous localization workflows, which integrate translation into your CI/CD pipeline so that source changes trigger translation jobs automatically, reduce the lag between English updates and translated updates. This is a meaningful improvement over periodic translation projects.
+
+But continuous localization still depends on the same missing piece: it needs to know when source content has actually changed in a way that makes the translated version wrong. A trigger based on "the source file was modified" is too broad. Not every line change in a source doc requires re-translation. A trigger based on "the content has drifted from what the translated version says" is much harder to build.
+
+The detection problem for translated docs is the same detection problem that affects English documentation, [applied one layer further downstream](https://promptless.ai/blog/technical/documentation-drift-detection-problem). When source docs drift from your actual product, translated docs drift from a version that was already wrong. The inaccuracies compound.
+
+Teams that solve drift detection at the source level get more out of their translation investments. When Promptless flags a source doc as stale because the product has changed, that signal becomes the input to the translation workflow rather than the output of manual review. Translation teams stop discovering that docs have drifted from developer support tickets and start acting on the change that caused the drift before it reached an international user.
+
+The first translation is an investment. Keeping translations accurate is a continuous process, and it needs the same upstream monitoring that keeps English docs current.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `documentation translations`

## Article plan

**Keyword(s) targeted:** "documentation translations" + "developer documentation localization"

**Thesis:** Translating your developer docs once is achievable. Keeping them accurate as your product changes is the harder problem — because translated docs have no direct line to product signals, and every source update creates silent drift in every language simultaneously.

**Target reader:** Technical writers, DevRel engineers, and EMs at developer-facing companies who have started or are considering a documentation translation program.

**Key points:**
1. Multilingual dev docs have clear ROI: faster adoption in non-English markets, fewer international support tickets, faster time to first API call
2. Every source doc update creates translation debt in each language simultaneously — silently
3. Translation Memory systems solve cost, not drift detection — they translate efficiently once you know what needs updating, but don't tell you which pages have become wrong
4. Translation teams are downstream of product with no direct signal when source docs change
5. Brand drift: some users see today's product, others see a version accurate 18 months ago
6. The fix is upstream: source doc change detection becomes the trigger for translation workflows

**Promptless connection:** Promptless detects when source docs drift from the product — that detection signal is what translation teams are missing.

## File

`src/content/blog/technical/documentation-translations-localization-drift.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwCNfBjQ9pvU5WMVnQzLPW)_