### PR TITLE
content: Documentation Translations Are Only as Accurate as Your Source Docs

### DIFF
--- a/src/content/blog/technical/documentation-translations-are-only-as-accurate.mdx
+++ b/src/content/blog/technical/documentation-translations-are-only-as-accurate.mdx
@@ -1,0 +1,67 @@
+---
+title: 'Documentation Translations Are Only as Accurate as Your Source Docs'
+subtitle: Published July 2026
+description: >-
+  Translated docs inherit every inaccuracy in your source. Here's why documentation translations fail, and what you need to fix upstream first.
+date: '2026-07-08T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer in Japan opens your quickstart guide, follows the authentication steps, and gets an error. The error traces back to a parameter your team renamed in March. The English source was updated in April. The Japanese translation hasn't been touched since February.
+
+Three months of drift, multiplied across one more language.
+
+This is the structural problem with documentation translations for developer-facing products: you're not managing one set of docs against reality. You're managing every translated version against a source that's always in motion. The localization pipeline solves part of that problem, and teams often don't notice the part it leaves unsolved.
+
+## The two layers of staleness
+
+Most documentation teams know that docs drift from the product. Source content gets stale as engineers ship changes without updating the corresponding pages. The [Postman 2024 State of the API report](https://www.postman.com/state-of-api/2024) found that 68% of developers cite outdated documentation as their top frustration when working with APIs. Research on documentation accuracy consistently finds [60% of documentation becomes outdated within six months](https://document360.com/blog/documentation-drift/), regardless of translation.
+
+What's less discussed is that translations add a second layer of staleness. Every time a source page drifts from the product, each translated version inherits that inaccuracy. Then, when the source is updated, translated versions fall behind again. Two gaps to close instead of one.
+
+For a developer-facing product shipping frequently, this compounds quickly. A team releasing updates monthly might touch authentication flows, SDK parameters, or core API endpoints several times per quarter. Each of those changes is a new drift event for every translated language.
+
+The global software localization market was valued at USD 4.9 billion in 2024, growing at 12.4% annually according to GMInsights. Companies are investing in translations. What market size figures don't capture is whether the content being translated is accurate.
+
+## Why continuous localization pipelines don't close this gap
+
+Continuous localization is the approach most teams reach for when they need to scale translations. The pipeline watches for changes to source strings, routes them automatically to translators or machine translation systems, and delivers updates back to the product. It's designed to reduce the lag between source and translated versions.
+
+The problem is that "continuous" describes speed of transport, not accuracy of content. A continuous localization pipeline that catches a source update and delivers the translated version in 48 hours has reduced the translation lag. It says nothing about whether the source content was accurate before the update happened.
+
+A pipeline that runs efficiently on an inaccurate source delivers that inaccuracy into every supported language, efficiently. If your source says a parameter is named `auth_token` when your API now expects `access_token`, the pipeline propagates that wrong answer wherever you've localized. It does so at scale.
+
+This is the gap the pipeline doesn't solve. You need to know which pages drifted from the product before you can localize them correctly.
+
+<BlogNewsletterCTA />
+
+## Why API documentation requires higher precision
+
+A marketing page can be slightly imprecise without consequence. API reference documentation can't.
+
+When a code sample contains a deprecated method, a developer who follows it literally gets an error. When a parameter name is wrong, an integration fails at the first authenticated request. The developer doesn't know if the problem is the translation, the English source, or the actual API behavior — which makes debugging substantially harder than it would be with English-only documentation.
+
+This matters beyond individual developers. As the analysis of [documentation debt and blast radius](https://promptless.ai/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it) shows, inaccurate docs in high-traffic areas generate damage that's hard to measure from inside your organization. A broken quickstart in Japanese is invisible to your English-speaking team but is active damage to every developer in that market who encounters it.
+
+The situation is sharper now because AI-assisted coding has become standard. A developer building an integration might use Copilot or Cursor to generate code from your documentation. When that documentation is a stale translation, the agent doesn't flag the discrepancy. It generates broken code. The developer then debugs an AI's output that was wrong from the first line. That's slower and harder to diagnose than a direct error from a working integration attempt. [Stale documentation feeds AI tools poorly](https://promptless.ai/blog/technical/documentation-drift-detection-problem), and the effect compounds when the stale content is a translated version of source that was itself out of date.
+
+## What keeping translations accurate actually requires
+
+Two operational changes matter here.
+
+**Fix the detection problem upstream.** You need to know which source pages drifted from your product before deciding what to localize. Detection has to happen upstream of the translation pipeline. Catching a changed parameter in the English source and routing it for re-translation is straightforward. Catching it weeks later through a support ticket from a developer in a non-English market is expensive.
+
+Most documentation teams don't have systematic detection in place for their English docs, let alone their translated versions. Quarterly audits catch drift that's already happened. What closes the loop is connecting documentation review to code change signals: when an engineer changes a public API endpoint, the pages that document it should surface for review before the next translation cycle runs.
+
+**Prioritize translations by blast radius, not by language.** An API reference page for an endpoint that changes frequently in a high-traffic market needs a short feedback loop. A conceptual overview for a rarely-touched feature in a lower-traffic language needs less frequent attention. Traffic volume multiplied by change frequency tells you where inaccuracy is generating the most damage, across languages. Most teams already have analytics on their docs site and change history in their repository — connecting the two gives you a prioritization list that reflects actual risk rather than language count.
+
+15.2% of developers in a 2023 Solidity survey preferred documentation in their native language over English, and that number is growing year over year. For API programs competing in Japan, Germany, Brazil, or Southeast Asia, localized docs are a prerequisite for adoption. But the competitive advantage of having localized docs disappears if those docs are consistently behind your product.
+
+The translation pipeline is a delivery mechanism. It transports whatever accuracy problem already exists in your source, into every language you support. Solving localization quality means going upstream, to the point where source content drifts from reality and nobody catches it before the next translation cycle runs.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `documentation translations`

## Article plan

**Format:** Explainer for technical writers and DevRel engineers at developer-facing companies running or planning a localized docs program. Surfaces the specific failure mode of localization at scale: the translation pipeline solves delivery speed, not source accuracy.

**Thesis:** Documentation translations are only as accurate as their source docs — the localization pipeline transports whatever accuracy problem already exists, efficiently, into every language.

**Target reader:** Technical writers and DevRel engineers at companies with localized API docs. They've solved the "how to translate" problem but struggle with "how to keep translations accurate as the product ships."

**Key points:**
1. Translated docs have a two-layer staleness problem: source drifts from product, translations drift from source.
2. Continuous localization pipelines solve delivery, not accuracy — they transport wrong content fast.
3. API documentation requires high precision: one wrong parameter name breaks integrations across an entire market.
4. AI coding agents amplify the cost: stale translated docs produce broken AI-generated code that's harder to debug.
5. The fix: detection upstream of the pipeline, plus blast-radius prioritization per language.

**Promptless connection:** Promptless detects source docs drifting from the product, catching the upstream accuracy problem before it cascades through the translation pipeline.

## File

`src/content/blog/technical/documentation-translations-are-only-as-accurate.mdx`

This is an AI-generated draft and needs human review before publishing. Set `hidden: false` in the frontmatter when ready to publish (it is already set to `false` — confirm the content is ready before the page goes live).

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6v9i51dsEdkEtvmoyi9F6)_