### PR TITLE
content: Developer Education Is a Documentation Accuracy Problem

### DIFF
--- a/src/content/blog/technical/developer-education-documentation-accuracy.mdx
+++ b/src/content/blog/technical/developer-education-documentation-accuracy.mdx
@@ -1,0 +1,71 @@
+---
+title: 'Developer Education Is a Documentation Accuracy Problem'
+subtitle: Published July 2026
+description: >-
+  67% of developers abandon a product after three failed documentation searches. Developer education programs fail because of documentation drift, not content volume.
+date: '2026-07-10T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer finds your API. They read the quickstart. Step three references an endpoint that was deprecated four months ago. They get an error they can't decode. They don't file a support ticket. They close the tab.
+
+Your developer education program failed. The quickstart existed. It just stopped being accurate.
+
+Most DevRel and technical writing teams think about developer education as a content problem: write more quickstarts and run more workshops. These things matter. The bottleneck is usually not production. It's maintenance. The content written six months ago may be wrong today, and no alarm goes off when it drifts.
+
+## Time to Value Is What You're Actually Measuring
+
+Developer education programs succeed or fail on one metric: time to value. The elapsed time from a developer's first interaction with your product to when they get actual value from it. Every broken step or misleading example in that path adds time and increases the probability the developer gives up.
+
+The data is specific. A 2025 study by the Developer Marketing Alliance found that 67% of developers will abandon a product after three failed documentation searches. Not three days. Three searches. The tolerance for inaccuracy is low because the cost of debugging someone else's docs is high.
+
+The flip side is equally specific. Developers who visit five or more unique documentation pages in their first session are 340% more likely to convert than those who visit only one. When documentation accurately reflects the product and guides someone through a real integration, developers go deeper. They stay.
+
+## The Content That Matters Most Drifts the Fastest
+
+Developer education programs are built on a core set of high-traffic documents: quickstarts, authentication guides, and API reference pages for active endpoints. These are the surfaces developers hit first. They are also the surfaces most likely to be wrong.
+
+This follows from how products evolve. The documentation team writes the quickstart carefully at launch. Then the product ships. Authentication flows change. Endpoints get renamed or deprecated. Parameters are added without backward compatibility notes. Each change creates a small divergence. Over months, small divergences become broken steps.
+
+[Quickstarts fail first](https://promptless.ai/blog/technical/developer-onboarding-documentation-fails-after-launch). They walk a developer through authentication and an initial integration. Developers arrive at them with zero prior context about your product. A broken step in a quickstart doesn't produce a fixable error. It produces a developer who assumes your product is harder than it looks.
+
+<BlogNewsletterCTA />
+
+## AI-Assisted Learning Has Raised the Stakes
+
+Developers increasingly learn through AI coding assistants. They ask Claude or Copilot to walk them through integrating an API. The assistant reads your documentation and generates code based on what it finds.
+
+When your documentation is accurate, this works. The developer gets code that runs.
+
+When your documentation references a deprecated endpoint or an outdated authentication pattern, the assistant generates broken code. The developer runs it, gets an error, and debugs the AI's output. They trace the error back to your docs, which still look authoritative. They lose confidence in your product.
+
+Gartner projected that over 30% of API demand growth by 2026 would come from AI and LLM tools. Those tools use your docs as [context for generating working code](https://promptless.ai/blog/technical/agent-context-engineering). Stale context produces stale code. The AI knows only what it read.
+
+This amplifies the existing problem. When a developer reads a stale quickstart, they may catch the error and adapt. When an AI reads the same quickstart and generates code for that developer, the error propagates into code that looks correct until it runs.
+
+## Developer Education Is a Maintenance Problem
+
+Teams treat developer education as a production problem. Produce more and better content. Production matters. It doesn't fix maintenance.
+
+The same patterns that create [documentation debt](https://promptless.ai/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it) in internal docs create silent failures in education content. Engineers ship changes. The PR template says "update relevant docs." Sometimes the writer gets a Slack message. More often, education content sits untouched until a developer files a support ticket about a broken example.
+
+The issue is structural. Documentation writers are not in the code review loop. Engineers are not always sure which education content covers the surface they changed. The connection between a code change and its documentation impact is informal at best.
+
+Adding more writers doesn't close that loop. A team of ten technical writers who don't know when code changes affect their content will still ship stale quickstarts. A team of two with a reliable signal for what changed will not.
+
+## What Changes This
+
+The fix is connecting documentation review to code change signals. When an engineer updates an authentication flow, the documentation pages covering that flow should surface for review. When an endpoint is deprecated, the quickstarts referencing it should be flagged before they go stale.
+
+[Detecting drift at the source](https://promptless.ai/blog/technical/documentation-drift-detection-problem) converts documentation maintenance from reactive to continuous, rather than discovering problems through support tickets or developer complaints.
+
+Teams that build this signal find their writing capacity goes further. Writers spend less time auditing PRs and more time improving content quality. The education investment compounds instead of decaying.
+
+For teams without a systematic detection layer, the practical starting point is blast-radius prioritization: multiply page traffic by change frequency. Your highest-traffic pages covering your most actively-changed endpoints are where education content is failing developers right now. Fix those first.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer education`

## Article plan

**Format:** A reframe — argues that developer education is a documentation maintenance problem, not a content production problem.

**Thesis:** Developer education programs fail not because teams produce too little content, but because they can't keep the content they have accurate as the product changes.

**Target reader:** DevRel engineers and technical writers at companies with developer-facing APIs or SDKs who are investing in education content and hitting the accuracy/scale problem.

**Key points:**
1. Time to first value is the defining metric for developer education, and documentation accuracy is its primary driver
2. The content that matters most (quickstarts, auth guides, API reference) is the content most likely to drift
3. Teams treat education as a production problem when it's a maintenance problem
4. AI coding assistants amplified the stakes: stale docs now produce broken AI-generated integrations
5. The fix is upstream: connect documentation review to code change signals

**Promptless connection:** Promptless keeps developer education content accurate as products change — the maintenance layer that makes the writing investment hold its value.

## File

`src/content/blog/technical/developer-education-documentation-accuracy.mdx`

This is an AI-generated draft and needs human review before publishing. Set `hidden: false` in the frontmatter when ready to publish (currently already set to `false` — change to `true` to hold until reviewed).

---
_Generated by [Claude Code](https://claude.ai/code/session_0169kJboSvUycUoAzRCbHzDo)_