### PR TITLE
content: Docs Site Search Is a Content Quality Problem

### DIFF
--- a/src/content/blog/technical/docs-site-search-content-quality.mdx
+++ b/src/content/blog/technical/docs-site-search-content-quality.mdx
@@ -1,0 +1,81 @@
+---
+title: 'Docs Site Search Is a Content Quality Problem'
+subtitle: Published July 2026
+description: >-
+  Most documentation search problems aren't tool problems. The search surface finds the right page. The page gives the wrong answer.
+date: '2026-07-13T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer searches your docs for "authentication." The search returns your authentication guide as the first result. The developer clicks through, follows the steps, and gets a 401.
+
+Three days later, a support ticket arrives. The authentication guide describes your old token format. You migrated to JWT eight months ago.
+
+The search worked correctly. The result was exactly right. The problem was the content.
+
+This is the actual shape of most docs search failures. Teams invest in better search tools — better indexing, semantic search, AI-powered query understanding — and the developer experience doesn't improve, because the bottleneck is not the retrieval layer. It's what gets retrieved.
+
+## What better search tooling cannot compensate for
+
+There are real problems with documentation search infrastructure: content indexed incorrectly, duplicate pages competing for the same query, heading structure that prevents search from extracting meaningful excerpts. These are worth fixing.
+
+But in most developer documentation systems, the infrastructure is not the limiting factor. The major documentation platforms index content reliably and return semantically relevant results. The search is fast and the results are plausible.
+
+Plausible is the problem. A search result that surfaces the correct page — the page that genuinely covers the topic the developer searched for — but contains outdated information is worse than a missing result. A missing result tells the developer nothing is here; they go look elsewhere. A plausible result looks authoritative.
+
+For consumer software, some lag in documentation is tolerable. For API documentation, it is not. A developer integrating against your API is making technical decisions based on what the docs say. One outdated parameter description can cause hours of debugging before the developer realizes the docs were wrong, not their code.
+
+Trust collapses quickly in this context. Once a developer concludes that your docs cannot be trusted, they do not go back to your search. They read your source code directly, or they go to GitHub issues and community Slacks to get answers. For a developer-facing company, that is an expensive signal to receive — and a hard one to reverse. Rebuilding documentation credibility takes consistent accuracy over time, not a single rewrite sprint.
+
+According to research on technical documentation usage, at least 80% of developer documentation traffic arrives through organic search. Search is how most developers find documentation in the first place. When what they find is wrong, the problem compounds with every developer who searched for the same thing.
+
+<BlogNewsletterCTA />
+
+## Semantic search amplifies the staleness problem
+
+AI-powered semantic search, now standard across documentation platforms, makes the staleness problem more consequential.
+
+Traditional keyword search is partially self-correcting for outdated content. If a page describes a deprecated parameter, keyword search only surfaces it when someone searches for that exact string. Developers using the new parameter would never see the old page.
+
+Semantic search does not work that way. A semantic search for "authentication token format" finds the page about your deprecated token because the underlying topic — authentication, tokens, format — matches. The old page ranks well precisely because it covers the subject thoroughly. There is no freshness or accuracy signal in the embedding. Age and correctness are invisible at retrieval time.
+
+The same pattern applies when [AI assistants answer questions about your product](/blog/technical/agent-friendly-docs-necessary-not-sufficient). When a developer asks an AI coding assistant how to authenticate with your API, the assistant retrieves semantically relevant documentation. That documentation may be current or it may be eight months out of date. The assistant cannot tell the difference, and it produces a confident answer with code samples either way.
+
+Perplexity, ChatGPT, and Claude all fetch and synthesize documentation from the live web. If your documentation describes a deprecated pattern, these tools will describe that pattern to developers asking about your product. The page's publication date rarely factors into how the answer is framed.
+
+## What actually affects docs search quality
+
+The standard documentation SEO checklist — sitemaps, structured data, meta descriptions, canonical URLs — helps search engines index your content correctly. It is worth doing. But none of it affects whether the content, once found, is accurate.
+
+Three things have a larger impact on search quality than infrastructure optimization:
+
+**Content freshness.** A developer who finds the correct page but gets wrong information has a worse experience than a developer who gets no result. Outdated content damages trust. Missing content is neutral. Teams that track support ticket sources consistently find that the tickets tied to documentation errors are among the most expensive: a developer has already invested time trusting the wrong answer before they realize it was wrong.
+
+**Removing redundant pages.** Developer documentation accumulates duplicate and near-duplicate pages over time. Two pages covering the same authentication flow, both partially accurate, create a harder problem than one outdated page. A developer now has to figure out which to trust. Search will return whichever is more semantically relevant, which may not be the more accurate one. One authoritative page per topic gives search a cleaner target and gives developers a clearer result.
+
+**Structural scope clarity.** Search works better when pages have clear, specific scope. A page titled "Authentication" that covers OAuth, API keys, JWT, and session management will rank for all of them, but imprecisely. Separate pages with clear titles surface more precisely. This also makes content maintenance simpler: when a parameter changes, there is one page to update, not four.
+
+## The monitoring gap
+
+Documentation drifts continuously. Engineers ship changes. Parameters get renamed, endpoints get deprecated. Some of those changes include documentation updates. Many do not. The engineer shipping the code is rarely the person responsible for the docs, and the handoff between them is weak.
+
+Most teams catch [documentation drift](/blog/technical/documentation-drift-detection-problem) through support tickets. A developer cannot get something to work, files a ticket, and the investigation reveals the docs were wrong. By that point, the inaccuracy has been live for weeks or months. Every developer who used that search result during that window got a wrong answer.
+
+Search optimization tooling — crawlers, index auditors, query analytics — identifies gaps in search coverage. It does not identify whether the pages that do get found are accurate. That requires a different mechanism: comparing documentation content against the actual product behavior.
+
+Teams that treat documentation accuracy and search optimization as separate workstreams end up with well-indexed, well-structured content that gives developers confident wrong answers. The investment in search infrastructure becomes invisible because users stop trusting it.
+
+## Accurate docs make search optimization durable
+
+The teams whose developers complain about search quality are usually dealing with a content problem that search is being blamed for. Switching from one search tool to another changes which pages surface first. It does not change whether those pages are right.
+
+When documentation is accurate and well-maintained, developers who find results through search get correct answers. They build trust and come back. Search analytics reflect this: low bounce rates, low support ticket rates for documented features. The content behind the results is reliable, and that is what the developer experiences.
+
+Fixing documentation accuracy fixes the search experience. The search tooling is a multiplier on content quality. If the content is accurate, better search makes it easier to find. If the content is not accurate, better search makes wrong answers easier to find faster.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `docs site search optimization`

## Article plan

**Format:** Problem-first explainer that reframes "docs search optimization" as a content accuracy problem, not a tooling problem.

**Thesis:** The most common docs search failure isn't bad indexing or bad UI — it's that the retrieved content is accurate enough to surface but wrong enough to mislead.

**Target reader:** Technical writers and DevRel engineers who've implemented search (Algolia, DocSearch) and still hear developers complaining about finding things.

**Promptless connection:** Accurate docs are the root input quality issue for all documentation search, whether traditional or AI-powered. Promptless keeps that input fresh, which is what makes search quality improve durably.

**Key points covered:**
1. Plausible-but-wrong search results are worse than missing results — they look authoritative and destroy trust
2. AI/semantic search amplifies staleness — old pages rank on topic relevance, not accuracy; there's no freshness signal in the embedding
3. Standard SEO checklists (sitemaps, metadata) don't touch content accuracy
4. The monitoring gap: most teams catch drift through support tickets, not search analytics

**Internal links added:** documentation-drift-detection-problem, agent-friendly-docs-necessary-not-sufficient

## File

`src/content/blog/technical/docs-site-search-content-quality.mdx`

This is an AI-generated draft and needs human review before publishing. When ready to publish, confirm `hidden: false` is set in the frontmatter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcpCiJzAWPDMKr3gtqCSFX)_