### PR TITLE
Add tracked Ask AI homepage CTA

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -64,6 +64,7 @@ sends a parallel `gtag` event for Google Analytics.
 - `watch_demo` -- jobs_page
 - `use_free_tool` -- free_tools
 - `view_commits` -- demo_social_proof
+- `ask_ai` -- homepage_ask_ai (AI provider in `campaign`)
 
 ## Design Decisions
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -56,6 +56,7 @@ Current `action` values:
 | `watch_demo` | `jobs_page` |
 | `use_free_tool` | `free_tools` |
 | `view_commits` | `demo_social_proof` |
+| `ask_ai` | `homepage_ask_ai` (provider in `campaign`: `claude`, `chatgpt`, `gemini`, or `perplexity`) |
 | `wtd_sign_up` | `hero_callout` |
 | `banner_cta` | `announcement_banner` |
 
@@ -74,7 +75,7 @@ section per page load.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities` |
+| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai` |
 | `page` | string | Pathname (always `/` for homepage) |
 
 **Component**: Inline IntersectionObserver in `posthog.astro`. Elements opt in

--- a/src/components/site/AskAI.astro
+++ b/src/components/site/AskAI.astro
@@ -1,0 +1,163 @@
+---
+const prompt =
+  'What is Promptless (promptless.ai), and how does it help software teams keep technical documentation up to date? Include its key features, integrations, and who it is best for.';
+const encodedPrompt = encodeURIComponent(prompt);
+
+const assistants = [
+  {
+    name: 'Claude',
+    campaign: 'claude',
+    href: `https://claude.ai/new?q=${encodedPrompt}`,
+    icon: 'claude',
+  },
+  {
+    name: 'ChatGPT',
+    campaign: 'chatgpt',
+    href: `https://chatgpt.com/?q=${encodedPrompt}`,
+    icon: 'chatgpt',
+  },
+  {
+    name: 'Gemini',
+    campaign: 'gemini',
+    href: `https://www.google.com/search?q=${encodedPrompt}&udm=50`,
+    icon: 'gemini',
+  },
+  {
+    name: 'Perplexity',
+    campaign: 'perplexity',
+    href: `https://www.perplexity.ai/search?q=${encodedPrompt}`,
+    icon: 'perplexity',
+  },
+] as const;
+---
+
+<section
+  class="pl-ask-ai"
+  aria-labelledby="ask-ai-heading"
+  data-section-tracked="ask-ai"
+>
+  <h2 id="ask-ai-heading">Ask your favorite AI about Promptless</h2>
+
+  <div class="pl-ask-ai-links" aria-label="Ask an AI assistant about Promptless">
+    {
+      assistants.map((assistant) => (
+        <a
+          href={assistant.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-track-action="ask_ai"
+          data-track-funnel="evaluation"
+          data-track-location="homepage_ask_ai"
+          data-track-campaign={assistant.campaign}
+          aria-label={`Ask ${assistant.name} about Promptless (opens in a new tab)`}
+        >
+          <span class="pl-ask-ai-icon" aria-hidden="true">
+            {assistant.icon === 'claude' && (
+              <svg viewBox="0 0 20 20" role="img">
+                <path d="M3.92 13.3 7.86 11.09l.07-.19-.07-.11h-.19l-6.75-.28-.47-.1L0 9.82l.05-.29.4-.27 7.15.56h.33l.04-.13-.2-.16-5.8-3.96-.31-.38-.13-.84.55-.6.92.1 4.71 3.58.12-.09.02-.06-3.01-5.2-.14-.52c-.05-.21-.09-.39-.09-.61l.63-.84L5.58 0l.83.11.35.3 3.03 6.31.2.7.08.21h.13v-.12L10.76 1.46l.31-.76.63-.41.48.23.4.58-.06.37-1 5.58h.18l3-3.7.71-.75h.86l.64.94-.29.97-2.87 4.27.06.09.16-.02 5.2-1 .69.33.08.33-.28.67-6.43 1.5.04.05 6.37.34.66.43.4.54-.07.4-1.01.52-5.81-1.31h-.15v.09l4.78 4.34.11.48-.27.38-.28-.04-4.26-3.36h-.11v.14l2.43 3.94.1.9-.14.29-.51.18-.56-.1-3.39-5.03-.12.07-.82 6.35-.61.23-.5-.39-.27-.62 1.23-6.22.14-.53-.01-.03-.12.01-4.45 5.64-1.44 1.54-.34.14-.6-.31.06-.55.33-.49 3.96-5.14-.01-.13h-.04l-5.29 3.43-.94.12-.41-.38.05-.62.19-.2 1.59-1.1Z" />
+              </svg>
+            )}
+            {assistant.icon === 'chatgpt' && (
+              <svg viewBox="0 0 20 20" role="img">
+                <path d="M18.68 8.19a5.02 5.02 0 0 0-.43-4.1 5.1 5.1 0 0 0-5.5-2.41A5.1 5.1 0 0 0 4.07 3.49 5.07 5.07 0 0 0 .69 5.91a5.01 5.01 0 0 0 .63 5.9 5.02 5.02 0 0 0 .43 4.1 5.1 5.1 0 0 0 5.5 2.41 5.1 5.1 0 0 0 8.68-1.81 5.07 5.07 0 0 0 3.38-2.42 5.01 5.01 0 0 0-.63-5.9Zm-7.62 10.5a3.82 3.82 0 0 1-2.43-.87l4.16-2.36a.65.65 0 0 0 .33-.57V9.28l1.74.99v4.68a3.79 3.79 0 0 1-3.8 3.74Zm-8.16-3.44a3.75 3.75 0 0 1-.45-2.51l4.16 2.37c.2.12.45.12.66 0l4.93-2.81v1.98l-4.11 2.35a3.84 3.84 0 0 1-5.19-1.38ZM1.84 6.56a3.8 3.8 0 0 1 1.97-1.64v4.74c0 .23.13.45.34.56l4.93 2.81-1.74.99-4.11-2.34a3.77 3.77 0 0 1-1.39-5.12Zm14.01 3.22-4.93-2.81 1.74-.97 4.11 2.32a3.78 3.78 0 0 1-.59 6.76v-4.74a.65.65 0 0 0-.33-.56Zm1.7-2.52-4.16-2.37a.67.67 0 0 0-.66 0L7.8 7.7V5.72l4.11-2.35a3.83 3.83 0 0 1 5.64 3.89ZM6.88 10.72l-1.74-.99V5.05a3.8 3.8 0 0 1 6.23-2.87L7.21 4.54a.65.65 0 0 0-.33.57v5.61Zm.92-1.97L10 7.5l2.2 1.25v2.5L10 12.5l-2.2-1.25v-2.5Z" />
+              </svg>
+            )}
+            {assistant.icon === 'gemini' && (
+              <svg viewBox="0 0 20 20" role="img">
+                <path d="M10 20c0-1.38-.27-2.68-.8-3.9a10.08 10.08 0 0 0-5.3-5.3A9.7 9.7 0 0 0 0 10c1.38 0 2.68-.26 3.9-.78a10.1 10.1 0 0 0 5.3-5.32A9.7 9.7 0 0 0 10 0c0 1.38.26 2.68.78 3.9a10.1 10.1 0 0 0 5.32 5.32c1.22.52 2.52.78 3.9.78-1.38 0-2.68.27-3.9.8a10.08 10.08 0 0 0-5.32 5.3A9.7 9.7 0 0 0 10 20Z" />
+              </svg>
+            )}
+            {assistant.icon === 'perplexity' && (
+              <svg viewBox="0 0 16 21" role="img">
+                <path d="M13.25 1.21 8 6.49h5.25V1.21Zm0 0v1.45M7.99.44v20m5.26-8.67L8 6.49m5.25 5.28v7.57L8 14.06m5.25-2.29L8 6.49m5.25 5.28v2.26h2.25V6.49H8m0 0v7.57m0-7.57-5.25 5.28M8 14.06l-5.25 5.28v-7.57m0 0v2.26H.5V6.49H8m-5.25 5.28L8 6.49M8 6.49 2.75 1.21v5.28H8Z" fill="none" stroke="currentColor" stroke-miterlimit="10" />
+              </svg>
+            )}
+          </span>
+          <span>Ask {assistant.name}</span>
+        </a>
+      ))
+    }
+  </div>
+</section>
+
+<style>
+  .pl-ask-ai {
+    display: grid;
+    grid-template-columns: minmax(12rem, 15rem) 1fr;
+    align-items: center;
+    gap: 1.25rem;
+    margin-top: 1.5rem;
+  }
+
+  .pl-ask-ai h2 {
+    margin: 0;
+    color: #4b5563;
+    font-size: 0.9rem;
+    font-weight: 500;
+    line-height: 1.4;
+    letter-spacing: 0;
+  }
+
+  .pl-ask-ai-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+  }
+
+  .pl-ask-ai-links a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.48rem 0.7rem;
+    border: 1px solid #d1d5db;
+    border-radius: 999px;
+    background: transparent;
+    color: #111827;
+    font-size: 0.82rem;
+    font-weight: 500;
+    line-height: 1;
+    text-decoration: none;
+    transition: border-color 0.15s ease, background-color 0.15s ease;
+  }
+
+  .pl-ask-ai-links a:hover {
+    border-color: #506aea;
+    background: #f8f9ff;
+    color: #111827;
+    text-decoration: none;
+  }
+
+  .pl-ask-ai-links a:focus-visible {
+    outline: 2px solid #506aea;
+    outline-offset: 2px;
+  }
+
+  .pl-ask-ai-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    flex: 0 0 auto;
+    color: #111827;
+  }
+
+  .pl-ask-ai-icon svg {
+    width: 100%;
+    height: 100%;
+    fill: currentColor;
+  }
+
+  @media (max-width: 44rem) {
+    .pl-ask-ai {
+      grid-template-columns: 1fr;
+      gap: 0.75rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pl-ask-ai-links a {
+      transition: none;
+    }
+  }
+</style>

--- a/src/content/website/home.mdx
+++ b/src/content/website/home.mdx
@@ -13,6 +13,7 @@ import WhyPromptless from '@components/site/WhyPromptless.astro';
 import ArcadeDemo from '@components/site/ArcadeDemo.astro';
 import VideoEmbed from '@components/site/VideoEmbed.astro';
 import SocialProofLinks from '@components/site/SocialProofLinks.astro';
+import AskAI from '@components/site/AskAI.astro';
 
 <div class="pl-hero-v2-layout">
   <Hero />
@@ -36,3 +37,4 @@ Promptless drafts PRs and suggests changes — then the docs maintainers at thes
 
 <HowItWorks />
 <WhyPromptless />
+<AskAI />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,7 +21,7 @@ const { Content } = await render(entry);
     editUrl: false,
   }}
 >
-  <div class="pl-site-page">
+  <div class="pl-site-page pl-site-page-home">
     <Content />
   </div>
 </StarlightPage>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -669,6 +669,10 @@ main:has(.blog-layout--has-aside) .sl-markdown-content table {
   border-top: 1px solid var(--sl-color-hairline);
 }
 
+main:has(.pl-site-page-home) .pl-site-footer {
+  margin-top: 0;
+}
+
 .pl-site-footer-inner {
   display: flex;
   flex-wrap: wrap;
@@ -919,4 +923,3 @@ main:has(.blog-layout--has-aside) .sl-markdown-content table {
 .pl-docs-cta a {
   font-weight: 600;
 }
-

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -2,6 +2,10 @@
   padding: 1.25rem 0 4.2rem;
 }
 
+.pl-site-page-home {
+  padding-bottom: 1.5rem;
+}
+
 .pl-site-page.pl-site-page-compact {
   padding-top: 0;
 }

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -277,6 +277,9 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.match(homeHtml, /Write the docs/);
   assert.match(homeHtml, /How Promptless works/);
   assert.match(homeHtml, /Get a demo/);
+  assert.match(homeHtml, /Ask your favorite AI about Promptless/);
+  assert.match(homeHtml, /data-track-action="ask_ai"/);
+  assert.match(homeHtml, /data-track-location="homepage_ask_ai"/);
   assert.doesNotMatch(homeHtml, /Getting Started/i);
 
   const meetResponse = await fetch(`${preview.baseUrl}/meet`);


### PR DESCRIPTION
## Summary
- add a compact Ask AI row near the homepage footer for Claude, ChatGPT, Gemini, and Perplexity
- instrument provider clicks and section visibility in PostHog
- tighten homepage-only footer spacing and document the new analytics values

## Verification
- `npm run check`
- `npm run test:smoke`
- browser checks at desktop and mobile widths