### PR TITLE
Serve the docs as a read-only MCP server at /mcp (Starport port, ADR 0007)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ src/
 |   +-- legal/          # Privacy policy, terms
 +-- lib/                # Shared utilities (navigation, route manifest, content ordering)
 +-- styles/             # Global CSS (custom.css, site.css)
+packages/
++-- starlight-mcp/      # Read-only MCP server plugin (/mcp route; ADR 0007), vendored from Starport
 scripts/                # Build/migration scripts
 tests/smoke/            # Smoke tests
 adrs/                   # Architecture Decision Records (MADR format); see adrs/README.md
@@ -85,9 +87,10 @@ CUSTOMIZE.md            # Starport "where to change what" map (branding, content
 ```bash
 npm install              # install dependencies
 npm run dev              # dev server at localhost:4321
-npm run build            # production build
-npm run check            # typecheck + build
-npm run test:smoke       # smoke tests
+npm run build            # production build (MCP_ENABLED=false for a static, adapter-less build)
+npm run check            # typecheck + MCP contract tests + build
+npm run test:mcp         # MCP server contract + index tests (packages/starlight-mcp)
+npm run test:smoke       # smoke tests (serves .vercel/output/static or dist from the last build)
 npm run build:diagrams   # compile src/diagrams/*.mmd → public/mermaid/*.svg
 npm run lint:md          # remark-lint: Markdown/MDX structure (src/content/docs)
 npm run lint:md:fix      # remark-lint auto-repair (full reflow via --output)

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,8 @@ import starlightLlmsTxt from 'starlight-llms-txt';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import partytown from '@astrojs/partytown';
+import vercel from '@astrojs/vercel';
+import starlightMcp from './packages/starlight-mcp/src/index.ts';
 
 import redirectsManifest from './src/lib/generated/redirects.json' with { type: 'json' };
 import routeManifest from './src/lib/generated/route-manifest.json' with { type: 'json' };
@@ -22,6 +24,15 @@ const hiddenSitemapPaths = new Set([
   ...getHiddenDocsPaths(new URL('./src/content/docs/', import.meta.url)),
   ...getHiddenWebsitePaths(new URL('./src/content/website/', import.meta.url)),
 ]);
+
+// ---------------------------------------------------------------------------
+// MCP server (packages/starlight-mcp, ported from the Starport template). The
+// /mcp route is rendered on demand, so enabling it requires the @astrojs/vercel
+// SSR adapter — the rest of the site stays static (output: 'static' +
+// prerender: false on the MCP route only). Set MCP_ENABLED=false for a fully
+// static, adapter-less build (e.g. if the adapter ever misbehaves in a deploy).
+// ---------------------------------------------------------------------------
+const MCP_ENABLED = process.env.MCP_ENABLED !== 'false';
 
 const redirects = {
   '/home': '/',
@@ -43,6 +54,7 @@ const redirects = {
 
 export default defineConfig({
   site: process.env.SITE_URL || 'https://promptless.ai',
+  adapter: MCP_ENABLED ? vercel() : undefined,
   redirects,
   integrations: [
     react(),
@@ -213,6 +225,10 @@ export default defineConfig({
             ],
           },
         ),
+        // Read-only MCP server at /mcp (see packages/starlight-mcp): `search` +
+        // `get_page` tools and an llms.txt resource over Streamable HTTP. Omitted
+        // when MCP_ENABLED=false so the build needs no SSR adapter.
+        ...(MCP_ENABLED ? [starlightMcp({ serverName: 'Promptless Docs' })] : []),
       ],
       components: {
         Sidebar: './src/components/starlight/Sidebar.astro',

--- a/docs/starport-migration/adrs/0007-docs-mcp-server.md
+++ b/docs/starport-migration/adrs/0007-docs-mcp-server.md
@@ -71,9 +71,12 @@ fully static, adapter-less build as an escape hatch).
   without it the Astro framework preset already defaults to `dist`.
 - `vercel.json` routing (redirects/headers/rewrites) and the root Routing Middleware are
   platform-level features that apply regardless of the adapter ([Vercel: Routing Middleware works
-  with any framework](https://vercel.com/docs/routing-middleware)). **Verify both on the first
-  preview deploy** (docs.promptless.ai host redirect, `Accept: text/markdown` negotiation) —
-  that's the one thing not provable locally.
+  with any framework](https://vercel.com/docs/routing-middleware)). **Verified on the first
+  preview deploy (2026-07-15):** `/mcp` tools work, `Accept: text/markdown` negotiation still
+  returns Markdown, and `/api-reference` 301s to `/api/`. Preview URLs sit behind Vercel
+  Deployment Protection (SSO), so verification needs a browser session or a protection-bypass
+  header — repeatable steps in `packages/starlight-mcp/README.md` § "Verifying against a Vercel
+  preview deployment". Host-conditioned redirects (docs.promptless.ai) only apply in production.
 - Astro-config redirects change from prerendered "Redirecting to: …" stub pages to real platform
   301s — a behavior improvement, matched by the smoke tests, which now accept either form.
 - `astro preview` is not supported by `@astrojs/vercel`, so the smoke-test harness

--- a/docs/starport-migration/adrs/0007-docs-mcp-server.md
+++ b/docs/starport-migration/adrs/0007-docs-mcp-server.md
@@ -1,0 +1,96 @@
+# Adopt the Starport docs MCP server (read-only /mcp via the Vercel adapter)
+
+- Status: accepted
+- Date: 2026-07-15
+- Deciders: Manny (Promptless)
+
+## Context and Problem Statement
+
+[ADR 0004](0004-adopt-capabilities.md) accepted the Starport template's docs MCP server capability
+(`@starport/starlight-mcp`) but deferred it out of Phase 6: "Attempt phase 6 again, but drop the
+MCP server capabilities. We'll attempt to add them again later." This ADR records that later
+attempt: porting the plugin from
+[starport-template](https://github.com/Promptless/starport-template) `packages/starlight-mcp`
+into this repo so AI clients (Claude connectors, Cursor, VS Code, Claude Code, the Anthropic API
+MCP connector) can search and read the docs over the
+[Model Context Protocol](https://modelcontextprotocol.io).
+
+The port was non-trivial because this site differs from the template in ways the plugin's v1
+implementation did not anticipate.
+
+## Decision Drivers
+
+- Ship the deferred capability without rewriting it — stay byte-compatible with the template's
+  plugin so future Starport re-syncs stay cheap.
+- The site is otherwise fully static and depends on platform behavior the SSR adapter must not
+  break: `vercel.json` (host redirects, `.md` content-type headers, `/report/:slug` rewrite) and
+  the root Vercel Routing Middleware (`middleware.ts`, Accept-header `.md` content negotiation).
+- CI (`check` + `test:smoke`) must keep passing without a deployed environment.
+
+## Considered Options
+
+- Port the Starport plugin as-is and fix incompatibilities in place (vendored
+  `packages/starlight-mcp`).
+- Keep the site static and hand-roll a separate Vercel serverless function (`api/mcp.ts`) around
+  the plugin's core.
+- Stay deferred (no MCP server).
+
+## Decision Outcome
+
+Chosen option: **port the plugin as-is into `packages/starlight-mcp` and fix the
+incompatibilities in the plugin**, keeping the template's architecture (Starlight plugin →
+Astro integration → build-time index inlined via a Vite virtual module → injected on-demand
+`/mcp` route with a Fetch-native stateless handler). A separate `api/` function would fork the
+architecture away from the template for no functional gain.
+
+`astro.config.mjs` gains `adapter: vercel()` and the `starlightMcp({ serverName: 'Promptless
+Docs' })` plugin entry, both behind `MCP_ENABLED` (default on; `MCP_ENABLED=false` restores the
+fully static, adapter-less build as an escape hatch).
+
+### Port fixes (bugs found and remediated)
+
+1. **Frontmatter `slug` support (load-bearing).** Every docs page in this repo sets an explicit
+   `slug:` (e.g. `src/content/docs/internal/component-fixtures.mdx` → `slug:
+   docs/internal/component-fixtures`), which Starlight uses verbatim as the route. The template's
+   index builder derived routes only from file location, so *all 66 pages* would have carried
+   wrong paths/URLs and `get_page` would never match. The builder now honors `slug` verbatim
+   (including locale-prefixed slugs) and falls back to file-derived routes otherwise.
+2. **`get_page` Markdown cleanup.** Returned pages began with MDX `import` plumbing and, when the
+   body opened with its own H1, a duplicated title heading. The builder now strips the leading
+   single-line MDX import block and only prepends `# {title}` when the body doesn't already start
+   with an H1.
+3. **Stale peer range.** The package declared `astro: ^6`; this repo (and the template root) run
+   Astro 7. Now `^6 || ^7`.
+
+### Deploy-shape consequences
+
+- With the adapter, `astro build` emits Build Output API artifacts to `.vercel/output/`
+  (static site in `static/`, one `_render` function serving only `/mcp`, config redirects as
+  platform 301s in `config.json`) instead of `dist/`. `vercel.json`'s `outputDirectory: "dist"`
+  was removed — with the adapter the Build Output API directory is the deploy artifact, and
+  without it the Astro framework preset already defaults to `dist`.
+- `vercel.json` routing (redirects/headers/rewrites) and the root Routing Middleware are
+  platform-level features that apply regardless of the adapter ([Vercel: Routing Middleware works
+  with any framework](https://vercel.com/docs/routing-middleware)). **Verify both on the first
+  preview deploy** (docs.promptless.ai host redirect, `Accept: text/markdown` negotiation) —
+  that's the one thing not provable locally.
+- Astro-config redirects change from prerendered "Redirecting to: …" stub pages to real platform
+  301s — a behavior improvement, matched by the smoke tests, which now accept either form.
+- `astro preview` is not supported by `@astrojs/vercel`, so the smoke-test harness
+  (`tests/smoke/preview-server.ts`) was rewritten as an in-process static server that serves
+  `.vercel/output/static` and applies `config.json` redirect routes (or serves `dist/` for
+  `MCP_ENABLED=false` builds).
+- `npm run check` now runs the plugin's contract + index tests (`npm run test:mcp`) between
+  typecheck and build.
+
+### Consequences
+
+- Good: `/mcp` serves `search` + `get_page` and an `llms.txt` resource over stateless Streamable
+  HTTP; the rest of the site stays static. Verified end-to-end against `astro dev` and by 19
+  contract/index tests plus the smoke suite.
+- Good: removable in one line (plugin entry + adapter), same as the template.
+- Tradeoff: the deploy gains one serverless function and the Build Output API shape; local
+  `npm run preview` no longer works (use the smoke harness or `vercel dev` instead).
+- Follow-up: backport fixes 1–3 to `starport-template` so the template keeps parity with this
+  port. Auth (v2, OAuth 2.1 resource server) remains future work per the template's
+  `MCP_SERVER_PLAN.md` §6 — the `AuthProvider` seam is retained.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,12 @@
         "@astrojs/react": "^6.0.1",
         "@astrojs/sitemap": "^3.7.3",
         "@astrojs/starlight": "^0.41.2",
+        "@astrojs/vercel": "^11.0.1",
         "@calcom/embed-react": "^1.5.3",
         "@lucide/astro": "^1.23.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "astro": "^7.0.5",
+        "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
         "lucide-static": "^0.575.0",
@@ -23,7 +26,8 @@
         "react-dom": "^19.2.4",
         "starlight-llms-txt": "^0.11.0",
         "starlight-openapi": "^0.26.0",
-        "starlight-sidebar-topics": "^0.8.0"
+        "starlight-sidebar-topics": "^0.8.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
@@ -560,6 +564,62 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/vercel": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-11.0.3.tgz",
+      "integrity": "sha512-UMhcZ/lWB0/B2l1L8BJh6QxysjZt8SLS9e40xRfBdVhfi3Y6SIDw+99rY/+OGW/yem/S7sBRkvqvto8neevO2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.1",
+        "@vercel/analytics": "^1.6.1",
+        "@vercel/functions": "^3.4.3",
+        "@vercel/nft": "^1.3.2",
+        "@vercel/routing-utils": "^5.3.3",
+        "esbuild": "^0.28.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "peerDependencies": {
+        "astro": "^7.0.0"
+      }
+    },
+    "node_modules/@astrojs/vercel/node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@astrojs/yaml2ts": {
@@ -1752,6 +1812,18 @@
         "tailwindcss": "^3.0 || ^4.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/momoa": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
@@ -1797,7 +1869,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1820,7 +1891,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1843,7 +1913,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1860,7 +1929,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1877,7 +1945,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1894,7 +1961,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1911,7 +1977,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1928,7 +1993,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1945,7 +2009,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1962,7 +2025,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1979,7 +2041,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1996,7 +2057,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2013,7 +2073,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2036,7 +2095,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2059,7 +2117,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2082,7 +2139,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2105,7 +2161,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2128,7 +2183,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2151,7 +2205,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2174,7 +2227,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2197,7 +2249,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2217,7 +2268,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2237,7 +2287,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2257,7 +2306,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2403,6 +2451,18 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2455,6 +2515,63 @@
       "license": "ISC",
       "peerDependencies": {
         "astro": "^4 || ^5 || ^6 || ^7"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
+      "integrity": "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "consola": "^3.2.3",
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^2.6.7",
+        "nopt": "^8.0.0",
+        "semver": "^7.5.3",
+        "tar": "^7.4.0"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/abbrev": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^3.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@mdx-js/mdx": {
@@ -2573,6 +2690,46 @@
       "license": "MIT",
       "dependencies": {
         "@chevrotain/types": "~11.1.2"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -4720,12 +4877,237 @@
         "d3-transition": "^3.0.1"
       }
     },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
+      "integrity": "sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz",
+      "integrity": "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@vercel/edge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.3.1.tgz",
       "integrity": "sha512-k0tKWeYEWOv6qU6+Z8+hv2Nt/u3vFHRZdB0uvwE0DxoddU/5kWX/Chu8F6ojvqmRlnZwuX/7kyZFVeCP6DxqBg==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.7.5.tgz",
+      "integrity": "sha512-ESf8BbeDebqRUyMi09JwRbQqpLn4g6fjcVVHPsHB56j2dSqRrSHO4h3X4aaxJf6iQQjzhAtDGI2xCWQ27JE8PA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.8.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*",
+        "ws": ">=8"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/nft": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.10.2.tgz",
+      "integrity": "sha512-w+WyX5Ulmj4dtTZrxaulqrjaLZHSbnPzx75SJsTNYmotKsqn1JlLnDJa+lz5hn90HJofhl/2MAtw0mCrgM3qYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^2.0.0",
+        "@rollup/pluginutils": "^5.1.3",
+        "acorn": "^8.6.0",
+        "acorn-import-attributes": "^1.9.5",
+        "async-sema": "^3.1.1",
+        "bindings": "^1.4.0",
+        "estree-walker": "2.0.2",
+        "glob": "^13.0.0",
+        "graceful-fs": "^4.2.9",
+        "node-gyp-build": "^4.2.2",
+        "picomatch": "^4.0.2",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "nft": "out/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/nft/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vercel/nft/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.0.tgz",
+      "integrity": "sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.0",
+        "@vercel/cli-exec": "1.0.0",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/oidc/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@vercel/routing-utils": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@vercel/routing-utils/-/routing-utils-5.3.3.tgz",
+      "integrity": "sha512-KYm2sLNUD48gDScv8ob4ejc3Gww2jcJyW80hTdYlenAPz/5BQar1Gyh38xrUuZ532TUwSb5mV1uRbAuiykq0EQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "path-to-regexp": "6.1.0",
+        "path-to-regexp-updated": "npm:path-to-regexp@6.3.0"
+      },
+      "optionalDependencies": {
+        "ajv": "^6.12.3"
+      }
+    },
+    "node_modules/@vercel/routing-utils/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@vercel/routing-utils/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -4926,6 +5308,44 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -4938,6 +5358,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -4945,6 +5374,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/agentkeepalive": {
@@ -4994,7 +5432,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -5266,6 +5703,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/async-sema": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
+      "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -5358,6 +5801,68 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -5426,6 +5931,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -5437,6 +5951,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelize": {
@@ -5546,6 +6076,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chromium-bidi": {
@@ -5736,6 +6275,37 @@
         "typedarray": "^0.0.6"
       }
     },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -5761,6 +6331,15 @@
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
     },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
@@ -5770,6 +6349,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cose-base": {
@@ -5786,7 +6382,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6574,6 +7169,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -6834,6 +7438,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.389",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
@@ -6878,6 +7488,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/entities": {
@@ -7057,7 +7676,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -7176,6 +7794,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-stream": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
@@ -7206,6 +7833,151 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/expressive-code": {
       "version": "0.44.0",
@@ -7259,6 +8031,13 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -7347,6 +8126,12 @@
       "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
       "license": "MIT"
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7357,6 +8142,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/flattie": {
@@ -7451,6 +8257,24 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/from": {
@@ -7557,6 +8381,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "5.0.0-beta.4",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
@@ -7624,6 +8460,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
@@ -8154,6 +8996,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
@@ -8213,6 +9064,39 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/httpsnippet": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-3.0.10.tgz",
@@ -8263,6 +9147,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/humanize-ms": {
@@ -8341,7 +9234,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -8368,6 +9260,24 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/iron-webcrypto": {
@@ -8536,6 +9446,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
@@ -8545,11 +9461,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
@@ -8566,6 +9493,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/jotai": {
@@ -8653,6 +9589,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -9536,6 +10478,33 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -10388,6 +11357,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -10418,10 +11396,21 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mitt": {
@@ -10483,6 +11472,15 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/neotraverse": {
       "version": "0.6.18",
       "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
@@ -10530,7 +11528,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -10552,6 +11549,17 @@
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-mock-http": {
       "version": "1.0.4",
@@ -10715,6 +11723,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -10725,6 +11745,27 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obug": {
@@ -10757,6 +11798,42 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
@@ -10780,6 +11857,15 @@
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
+      }
     },
     "node_modules/p-limit": {
       "version": "6.2.0",
@@ -10956,6 +12042,15 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -10974,7 +12069,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11003,6 +12097,19 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
+      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==",
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp-updated": {
+      "name": "path-to-regexp",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/pause-stream": {
       "version": "0.0.11",
@@ -11038,6 +12145,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pluralize": {
@@ -11250,6 +12366,29 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/puppeteer": {
       "version": "25.3.0",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.3.0.tgz",
@@ -11292,6 +12431,22 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/query-selector-shadow-dom": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
@@ -11324,6 +12479,50 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/react": {
       "version": "19.2.7",
@@ -12409,6 +13608,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -12559,6 +13767,32 @@
         "points-on-path": "^0.2.1"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -12615,7 +13849,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/satori": {
@@ -12701,6 +13934,82 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -12763,7 +14072,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -12776,7 +14084,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12799,6 +14106,78 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -13007,6 +14386,15 @@
         "@astrojs/starlight": ">=0.38.0"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/stream-combiner": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
@@ -13133,6 +14521,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -13230,6 +14627,31 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/tar": {
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13295,11 +14717,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/trim-lines": {
@@ -13379,6 +14809,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-query-selector": {
@@ -13844,6 +15330,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unstorage": {
       "version": "1.17.5",
       "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
@@ -14007,6 +15502,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/url-extras": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/url-extras/-/url-extras-0.1.0.tgz",
@@ -14077,6 +15582,15 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -14676,14 +16190,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -14694,7 +16206,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -14742,11 +16253,17 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -14763,6 +16280,31 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/xxhash-wasm": {
@@ -14911,6 +16453,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -16,16 +16,20 @@
     "lint:md": "remark src/content/docs --ext md,mdx --frail --quiet",
     "lint:md:fix": "remark src/content/docs --ext md,mdx --output --quiet",
     "lint:frontmatter": "docmeta validate --quiet",
-    "check": "npm run typecheck && npm run build"
+    "test:mcp": "node --import tsx --test packages/starlight-mcp/src/core/contract.test.ts packages/starlight-mcp/src/core/index/build.test.ts",
+    "check": "npm run typecheck && npm run test:mcp && npm run build"
   },
   "dependencies": {
     "@astrojs/mdx": "^7.0.1",
     "@astrojs/react": "^6.0.1",
     "@astrojs/sitemap": "^3.7.3",
+    "@astrojs/vercel": "^11.0.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@astrojs/starlight": "^0.41.2",
     "@calcom/embed-react": "^1.5.3",
     "@lucide/astro": "^1.23.0",
     "astro": "^7.0.5",
+    "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0",
     "lucide-static": "^0.575.0",
@@ -34,7 +38,8 @@
     "react-dom": "^19.2.4",
     "starlight-llms-txt": "^0.11.0",
     "starlight-openapi": "^0.26.0",
-    "starlight-sidebar-topics": "^0.8.0"
+    "starlight-sidebar-topics": "^0.8.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "build:diagrams": "tsx scripts/build-diagrams.ts",
     "prebuild": "npm run generate:manifest",
-    "preview": "astro preview",
+    "preview": "tsx scripts/preview.ts",
     "typecheck": "astro check",
     "generate:manifest": "tsx scripts/generate-manifest.ts",
     "marketing:image": "node scripts/marketing-image/generate.mjs",

--- a/packages/starlight-mcp/README.md
+++ b/packages/starlight-mcp/README.md
@@ -122,6 +122,66 @@ prints — it bumps to 4322+ if 4321 is taken).
 Note: `astro preview` with the Vercel adapter does not execute the `/mcp`
 function, so it will 404 there. Use `npm run dev` locally, or a real deploy.
 
+## Verifying against a Vercel preview deployment
+
+Preview URLs sit behind Vercel Deployment Protection, so a plain `curl` or MCP
+client gets `401 {"error":{"message":"Protected deployment"}}` before the
+request ever reaches the server. Two ways through:
+
+### Option A — browser console (no settings changes)
+
+Open the preview URL in a browser that's logged into Vercel (SSO completes
+automatically), then run this in the DevTools console:
+
+```js
+(async () => {
+  const out = {};
+  out.mcp = await fetch('/mcp', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+  }).then(r => r.json());
+  out.search = await fetch('/mcp', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/call',
+      params: { name: 'search', arguments: { query: 'slack trigger', limit: 2 } } }),
+  }).then(r => r.json());
+  // Root routing-middleware check (Accept-based .md negotiation):
+  const md = await fetch('/docs/start-here/welcome', { headers: { accept: 'text/markdown' } });
+  out.middleware = { contentType: md.headers.get('content-type'), startsWithMd: (await md.text()).trimStart().startsWith('#') };
+  console.log(JSON.stringify(out, null, 2));
+})();
+```
+
+### Option B — protection bypass (for curl / real MCP clients)
+
+Generate a secret under **Vercel project → Settings → Deployment Protection →
+Protection Bypass for Automation**, then send it as a header:
+
+```bash
+curl -X POST "https://<preview>.vercel.app/mcp" \
+  -H "x-vercel-protection-bypass: $BYPASS_SECRET" \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+
+claude mcp add --transport http docs-preview "https://<preview>.vercel.app/mcp" \
+  --header "x-vercel-protection-bypass: $BYPASS_SECRET"
+```
+
+### What to expect
+
+- `tools/list` → `search` and `get_page`, each with `readOnlyHint: true`.
+- `search` → ranked results whose URLs point at the **canonical `SITE_URL`**
+  (e.g. `https://promptless.ai/...`), not the preview host — the index bakes
+  absolute URLs at build time. That is correct for production.
+- The middleware check → `content-type: text/markdown` and a Markdown body
+  (proves the root Routing Middleware survived the Build Output API deploy).
+- Host-conditioned `vercel.json` redirects (e.g. a `docs.` subdomain rule)
+  cannot be exercised on a preview URL — the host never matches. Production
+  only.
+
 ## Architecture
 
 ```

--- a/packages/starlight-mcp/README.md
+++ b/packages/starlight-mcp/README.md
@@ -1,0 +1,142 @@
+# @starport/starlight-mcp
+
+A [Starlight](https://starlight.astro.build) plugin that serves your documentation
+site as a **read-only [MCP](https://modelcontextprotocol.io) server**, so AI clients
+(Claude connectors, Cursor, VS Code, Claude Code, the Anthropic API MCP connector)
+can search and read your docs.
+
+> **Vendored into promptless.ai from the
+> [Starport template](https://github.com/Promptless/starport-template)** — see
+> `docs/starport-migration/adrs/0007-docs-mcp-server.md`. This copy adds
+> frontmatter `slug:` support in the index builder (this site sets an explicit
+> slug on every docs page), cleaner `get_page` Markdown (leading MDX imports
+> stripped, no duplicated H1), and an `astro ^6 || ^7` peer range. Backport
+> these when re-syncing with the template.
+
+> **v1 is authless** — every page is public. The plugin is built with the seams to
+> add OAuth-based authentication and per-user content gating later without a
+> rewrite. See `MCP_SERVER_PLAN.md` (repo root) §6 for the eventual auth design.
+
+## What it exposes
+
+- **Transport:** Streamable HTTP (JSON-RPC over `POST`) at `/mcp`.
+- **Tools (read-only):**
+  - `search({ query, lang?, limit? })` — ranked passages with source URLs.
+  - `get_page({ path })` — full Markdown for one page.
+- **Resources:** an `llms.txt`-style documentation index.
+
+The request handler uses only standard Fetch APIs (`Request`/`Response`, no Node
+`http`). **Verified target: Vercel/Node.** Cloudflare Workers is *not yet verified* —
+the SDK's Zod validation uses `new Function` (JIT), which workerd's CSP blocks, so it
+would need jitless Zod first (see [Local development](#local-development)).
+
+## Install
+
+This template vendors the plugin in-repo at `packages/starlight-mcp`. Add it to your
+Starlight `plugins` array:
+
+```js
+// astro.config.mjs
+import starlightMcp from './packages/starlight-mcp/src/index.ts';
+
+starlight({
+  plugins: [
+    starlightMcp(),
+    // …other plugins
+  ],
+});
+```
+
+### You must configure an SSR adapter
+
+The `/mcp` route is rendered on demand, so the build needs an adapter. Keep
+`output: 'static'`; the plugin only makes its own route on-demand.
+
+```js
+import vercel from '@astrojs/vercel';      // Astro 7: @astrojs/vercel@^11 (Astro 6: ^10)
+// import cloudflare from '@astrojs/cloudflare'; // experimental — see below
+
+export default defineConfig({
+  adapter: vercel(),
+  // …
+});
+```
+
+Without an adapter the plugin logs a warning and the build fails on the on-demand route.
+
+## Options
+
+| Option | Default | Description |
+|---|---|---|
+| `endpoint` | `'/mcp'` | Route to mount the server at. |
+| `enabled` | `true` | When `false`, the route responds `503`. |
+| `serverName` | site title | MCP `serverInfo.name`. |
+| `corsAllowOrigin` | `'*'` | `Access-Control-Allow-Origin` for the endpoint. |
+| `packageDir` | `'packages/starlight-mcp'` | Package location relative to project root (used to resolve the injected route entry). Override if you move the package. |
+
+## Content gating seam (for v2 auth)
+
+Pages may declare access metadata in frontmatter:
+
+```yaml
+---
+title: Internal runbook
+access: internal      # default: public
+groups: [partners]    # who may see it once auth exists
+---
+```
+
+In v1 (authless), every request is anonymous, so `internal` pages are simply not
+returned. When v2 adds an authenticated identity, `internal` pages become visible to
+users whose groups intersect the page's `groups` — no reindex or schema change.
+
+## Connect a client
+
+```bash
+# Claude Code
+claude mcp add --transport http docs https://your-site/mcp
+```
+
+Cursor / VS Code: add the URL to `mcp.json` / `.vscode/mcp.json`. Inspect with
+`npx @modelcontextprotocol/inspector`.
+
+## Local development
+
+`npm run dev` serves the endpoint at `http://localhost:4321/mcp` (the port Astro
+prints — it bumps to 4322+ if 4321 is taken).
+
+> **Restart fully after editing the plugin or config.** The `/mcp` route is added
+> via `injectRoute` in the integration's `config:setup`, and Astro's in-place
+> hot-reload does **not** reliably re-register injected routes. After changing
+> `astro.config.mjs` or anything under `packages/starlight-mcp/`, stop and rerun
+> `npm run dev`. If the route is live you'll see this on startup:
+>
+> ```
+> [starlight-mcp] MCP server route registered at "/mcp".
+> ```
+>
+> If it's missing — or requests to `/mcp` 404 with a `getStaticPaths()` /
+> "Entry docs → 404" router warning — the route fell through to Starlight's
+> catch-all; do a full restart.
+
+Note: `astro preview` with the Vercel adapter does not execute the `/mcp`
+function, so it will 404 there. Use `npm run dev` locally, or a real deploy.
+
+## Architecture
+
+```
+src/
+  index.ts          Starlight plugin (config:setup → addIntegration)
+  integration.ts    builds the index, inlines it via a Vite virtual module, injects /mcp
+  route.ts          thin Astro endpoint → core handler
+  core/             Node-free (Fetch-only) request path: transport (wraps the MCP SDK's Fetch-native
+                    WebStandardStreamableHTTPServerTransport), server (per-request McpServer),
+                    tools, resources, auth seam, index query. Node fs only in
+                    core/index/build.ts (build-time).
+```
+
+## Extraction
+
+This is authored as a standalone package (`private: true`). To publish it: flip
+`private`, add a build step that compiles `src` to `dist` with file extensions on
+relative imports, and update `exports`/`main`/`types` accordingly.

--- a/packages/starlight-mcp/package.json
+++ b/packages/starlight-mcp/package.json
@@ -27,6 +27,6 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
-    "zod": "^3.25.0"
+    "zod": "^3.25.0 || ^4.0.0"
   }
 }

--- a/packages/starlight-mcp/package.json
+++ b/packages/starlight-mcp/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@starport/starlight-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Starlight plugin that serves the documentation site as a read-only MCP (Model Context Protocol) server. Authless v1, architected for authentication later.",
+  "keywords": [
+    "astro",
+    "starlight",
+    "starlight-plugin",
+    "mcp",
+    "model-context-protocol",
+    "documentation"
+  ],
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src"
+  ],
+  "peerDependencies": {
+    "@astrojs/starlight": ">=0.34.0",
+    "astro": "^6 || ^7"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "github-slugger": "^2.0.0",
+    "gray-matter": "^4.0.3",
+    "zod": "^3.25.0"
+  }
+}

--- a/packages/starlight-mcp/src/core/auth/provider.ts
+++ b/packages/starlight-mcp/src/core/auth/provider.ts
@@ -1,0 +1,34 @@
+/**
+ * Authentication seam.
+ *
+ * v1 ships only `AnonymousAuthProvider` (no auth — every request is anonymous,
+ * and only `public` content is visible). The interface exists so that v2 can
+ * add a `DelegatedResourceServer` (OAuth 2.1 resource server: verify a bearer
+ * token, bind audience, map claims → groups) behind the same contract without
+ * changing the transport, the server factory, or any tool signature.
+ *
+ * See `MCP_SERVER_PLAN.md` §6 for the eventual auth design.
+ */
+
+export type Identity =
+  | { kind: 'anonymous' }
+  | { kind: 'user'; subject: string; groups: string[] };
+
+export interface AuthProvider {
+  /** Whether this provider rejects unauthenticated requests. v1: false. */
+  readonly requiresAuth: boolean;
+  /**
+   * Resolve the caller's identity from the request. v1 always returns
+   * `{ kind: 'anonymous' }`. v2 verifies a bearer token and returns a user
+   * identity, or signals a challenge (to be added to the return type then).
+   */
+  authenticate(request: Request): Promise<Identity>;
+}
+
+export class AnonymousAuthProvider implements AuthProvider {
+  readonly requiresAuth = false;
+
+  async authenticate(_request: Request): Promise<Identity> {
+    return { kind: 'anonymous' };
+  }
+}

--- a/packages/starlight-mcp/src/core/context.ts
+++ b/packages/starlight-mcp/src/core/context.ts
@@ -1,0 +1,11 @@
+import type { Identity } from './auth/provider';
+import type { DocEntry } from './index/types';
+
+/** Per-request context passed to the MCP server factory and the tool/resource handlers. */
+export interface McpContext {
+  index: DocEntry[];
+  identity: Identity;
+  serverInfo: { name: string; version: string };
+  siteTitle?: string;
+  siteUrl?: string;
+}

--- a/packages/starlight-mcp/src/core/contract.test.ts
+++ b/packages/starlight-mcp/src/core/contract.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Contract tests for the MCP server, exercised through the real Fetch handler
+ * (SDK-backed). Each call is an independent stateless request, which also proves
+ * that `tools/list` / `tools/call` work without a same-instance `initialize`.
+ * Run with `npm test`.
+ */
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { type AuthProvider, type Identity } from './auth/provider';
+import type { DocEntry } from './index/types';
+import { handleMcpRequest, type McpHandlerOptions } from './transport';
+
+const index: DocEntry[] = [
+  {
+    title: 'Welcome',
+    url: 'https://x/welcome/',
+    path: '/welcome/',
+    lang: 'en',
+    access: 'public',
+    groups: [],
+    text: 'welcome getting started overview',
+    markdown: '# Welcome\n\nhi',
+  },
+  {
+    title: 'Secret',
+    url: 'https://x/secret/',
+    path: '/secret/',
+    lang: 'en',
+    access: 'internal',
+    groups: ['partners'],
+    text: 'secret internal partner content',
+    markdown: '# Secret\n\nshh',
+  },
+];
+
+const serverInfo = { name: 'test', version: '0.0.0' };
+
+class StubAuth implements AuthProvider {
+  readonly requiresAuth = false;
+  constructor(private readonly identity: Identity) {}
+  async authenticate(): Promise<Identity> {
+    return this.identity;
+  }
+}
+
+function opts(identity: Identity): McpHandlerOptions {
+  return { index, authProvider: new StubAuth(identity), serverInfo, siteTitle: 'T', siteUrl: 'https://x/' };
+}
+
+const anon: Identity = { kind: 'anonymous' };
+
+async function rpc(body: unknown, identity: Identity = anon): Promise<Response> {
+  return handleMcpRequest(
+    new Request('http://x/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+      body: JSON.stringify(body),
+    }),
+    opts(identity),
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function rpcJson(body: unknown, identity: Identity = anon): Promise<{ status: number; json: any }> {
+  const res = await rpc(body, identity);
+  return { status: res.status, json: await res.json() };
+}
+
+const call = (id: number, name: string, args: Record<string, unknown>) => ({
+  jsonrpc: '2.0',
+  id,
+  method: 'tools/call',
+  params: { name, arguments: args },
+});
+
+test('initialize negotiates protocol + returns serverInfo', async () => {
+  const { json } = await rpcJson({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'c', version: '1' } } });
+  assert.equal(json.result.serverInfo.name, 'test');
+  assert.ok(typeof json.result.protocolVersion === 'string');
+});
+
+test('tools/list (stateless, no prior initialize) exposes search + get_page', async () => {
+  const { json } = await rpcJson({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+  assert.deepEqual(json.result.tools.map((t: { name: string }) => t.name).sort(), ['get_page', 'search']);
+});
+
+test('search returns ranked results with source URLs; internal hidden from anon', async () => {
+  const ok = await rpcJson(call(3, 'search', { query: 'welcome' }));
+  assert.match(ok.json.result.content[0].text, /Welcome/);
+  assert.match(ok.json.result.content[0].text, /https:\/\/x\/welcome\//);
+
+  const hidden = await rpcJson(call(4, 'search', { query: 'secret' }));
+  assert.match(hidden.json.result.content[0].text, /No documentation matched/);
+});
+
+test('gating seam: internal page visible to a user in the group', async () => {
+  const user: Identity = { kind: 'user', subject: 'u1', groups: ['partners'] };
+  const { json } = await rpcJson(call(5, 'search', { query: 'secret' }), user);
+  assert.match(json.result.content[0].text, /Secret/);
+});
+
+test('get_page found returns Markdown; missing returns a tool error', async () => {
+  const ok = await rpcJson(call(6, 'get_page', { path: '/welcome/' }));
+  assert.match(ok.json.result.content[0].text, /# Welcome/);
+
+  const bad = await rpcJson(call(7, 'get_page', { path: '/missing/' }));
+  assert.equal(bad.json.result.isError, true);
+});
+
+test('invalid tool args are rejected by the SDK (zod)', async () => {
+  const { json } = await rpcJson(call(8, 'search', { query: '' })); // min(1) violated
+  // Either a JSON-RPC error or an isError tool result is acceptable.
+  assert.ok(json.error || json.result?.isError, 'expected an error for empty query');
+});
+
+test('resources: list + read the llms.txt index', async () => {
+  const list = await rpcJson({ jsonrpc: '2.0', id: 9, method: 'resources/list' });
+  const uri = list.json.result.resources[0].uri;
+  assert.ok(uri);
+  const read = await rpcJson({ jsonrpc: '2.0', id: 10, method: 'resources/read', params: { uri } });
+  assert.match(read.json.result.contents[0].text, /# T/);
+});
+
+test('transport: OPTIONS 204 with CORS; notification accepted', async () => {
+  const optionsRes = await handleMcpRequest(new Request('http://x/mcp', { method: 'OPTIONS' }), opts(anon));
+  assert.equal(optionsRes.status, 204);
+  assert.equal(optionsRes.headers.get('access-control-allow-origin'), '*');
+
+  const note = await rpc({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  assert.ok(note.status === 202 || note.status === 200);
+});
+
+test('disabled flag short-circuits with 503', async () => {
+  const res = await handleMcpRequest(
+    new Request('http://x/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    }),
+    { ...opts(anon), enabled: false },
+  );
+  assert.equal(res.status, 503);
+});
+
+// --- Regression tests for adversarial-review findings ---
+
+test('GET is rejected with 405 and does not hang (#1: SSE buffer deadlock)', async () => {
+  const res = (await Promise.race([
+    handleMcpRequest(
+      new Request('http://x/mcp', { method: 'GET', headers: { accept: 'text/event-stream' } }),
+      opts(anon),
+    ),
+    new Promise<Response>((_, reject) => setTimeout(() => reject(new Error('handler hung on GET')), 2000)),
+  ])) as Response;
+  assert.equal(res.status, 405);
+  assert.equal(res.headers.get('allow'), 'POST, OPTIONS');
+});
+
+test('search matches CJK content (#3: Unicode tokenizer)', async () => {
+  const cjkIndex: DocEntry[] = [
+    {
+      title: '文档',
+      url: 'https://x/zh/',
+      path: '/zh/',
+      lang: 'zh',
+      access: 'public',
+      groups: [],
+      text: '文档 概述 入门 指南',
+      markdown: '# 文档',
+    },
+  ];
+  const res = await handleMcpRequest(
+    new Request('http://x/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+      body: JSON.stringify(call(40, 'search', { query: '文档' })),
+    }),
+    { index: cjkIndex, authProvider: new StubAuth(anon), serverInfo, siteTitle: 'T', siteUrl: 'https://x/' },
+  );
+  const json = await res.json();
+  assert.match(json.result.content[0].text, /文档/);
+});
+
+test('get_page matches case-insensitively (#6)', async () => {
+  const { json } = await rpcJson(call(41, 'get_page', { path: '/WELCOME/' }));
+  assert.match(json.result.content[0].text, /# Welcome/);
+});
+
+test('a specific CORS origin sets Allow-Credentials (#4)', async () => {
+  const res = await handleMcpRequest(new Request('http://x/mcp', { method: 'OPTIONS' }), {
+    ...opts(anon),
+    corsAllowOrigin: 'https://client.example',
+  });
+  assert.equal(res.headers.get('access-control-allow-origin'), 'https://client.example');
+  assert.equal(res.headers.get('access-control-allow-credentials'), 'true');
+});

--- a/packages/starlight-mcp/src/core/contract.test.ts
+++ b/packages/starlight-mcp/src/core/contract.test.ts
@@ -186,6 +186,11 @@ test('get_page matches case-insensitively (#6)', async () => {
   assert.match(json.result.content[0].text, /# Welcome/);
 });
 
+test('get_page tolerates duplicate leading slashes (protocol-relative parse)', async () => {
+  const { json } = await rpcJson(call(42, 'get_page', { path: '//welcome/' }));
+  assert.match(json.result.content[0].text, /# Welcome/);
+});
+
 test('a specific CORS origin sets Allow-Credentials (#4)', async () => {
   const res = await handleMcpRequest(new Request('http://x/mcp', { method: 'OPTIONS' }), {
     ...opts(anon),

--- a/packages/starlight-mcp/src/core/index/build.test.ts
+++ b/packages/starlight-mcp/src/core/index/build.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the build-time index generator, focused on slug/route derivation
+ * matching Astro's real rules (github-slugger). Run with `npm test`.
+ */
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { buildDocsIndex, type LocaleDef } from './build';
+
+const ROOT_ONLY: LocaleDef[] = [{ key: 'root', lang: 'en', isRoot: true }];
+
+function withDocs(files: Record<string, string>, fn: (dir: string) => void): void {
+  const dir = mkdtempSync(join(tmpdir(), 'mcp-idx-'));
+  try {
+    for (const [rel, body] of Object.entries(files)) {
+      const full = join(dir, rel);
+      mkdirSync(join(full, '..'), { recursive: true });
+      writeFileSync(full, body);
+    }
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const page = (title: string) => `---\ntitle: ${title}\n---\n\nBody for ${title}.\n`;
+
+test('slugifies punctuated filenames exactly like Astro (github-slugger)', () => {
+  withDocs(
+    {
+      'guides/v1.2 Release.md': page('Release'),
+      'guides/C++ Guide.md': page('Cpp'),
+      'guides/a--b.md': page('Dashes'),
+      'index.mdx': page('Home'),
+    },
+    (dir) => {
+      const paths = buildDocsIndex({ docsDir: dir, site: 'https://x/', base: '/', locales: ROOT_ONLY })
+        .map((e) => e.path)
+        .sort();
+      // These are the routes Astro actually generates for these filenames.
+      assert.ok(paths.includes('/guides/v12-release/'), `paths: ${paths.join(', ')}`);
+      assert.ok(paths.includes('/guides/c-guide/'), `paths: ${paths.join(', ')}`);
+      assert.ok(paths.includes('/guides/a--b/'), `paths: ${paths.join(', ')}`);
+      assert.ok(paths.includes('/'), `paths: ${paths.join(', ')}`);
+    },
+  );
+});
+
+test('locale prefix + absolute URL derivation', () => {
+  withDocs(
+    { 'es/getting-started/welcome.md': page('Bienvenida') },
+    (dir) => {
+      const entries = buildDocsIndex({
+        docsDir: dir,
+        site: 'https://docs.example.com/',
+        base: '/',
+        locales: [
+          { key: 'root', lang: 'en', isRoot: true },
+          { key: 'es', lang: 'es', isRoot: false },
+        ],
+      });
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].path, '/es/getting-started/welcome/');
+      assert.equal(entries[0].lang, 'es');
+      assert.equal(entries[0].url, 'https://docs.example.com/es/getting-started/welcome/');
+    },
+  );
+});
+
+test('frontmatter slug overrides the file-derived route verbatim', () => {
+  withDocs(
+    {
+      // Slug puts the page somewhere unrelated to its file location, like
+      // promptless.ai's docs do (e.g. internal/component-fixtures.mdx →
+      // slug: docs/internal/component-fixtures).
+      'internal/component-fixtures.md': `---\ntitle: Fixtures\nslug: docs/internal/component-fixtures\n---\n\nx\n`,
+      'guides/nested/page.md': `---\ntitle: Welcome\nslug: docs/start-here/welcome\n---\n\nx\n`,
+      'home.md': `---\ntitle: Home\nslug: ""\n---\n\nx\n`,
+    },
+    (dir) => {
+      const entries = buildDocsIndex({ docsDir: dir, site: 'https://x/', base: '/', locales: ROOT_ONLY });
+      const paths = entries.map((e) => e.path).sort();
+      assert.deepEqual(paths, ['/', '/docs/internal/component-fixtures/', '/docs/start-here/welcome/']);
+      const welcome = entries.find((e) => e.title === 'Welcome');
+      assert.equal(welcome?.url, 'https://x/docs/start-here/welcome/');
+    },
+  );
+});
+
+test('slug override with a locale prefix sets the entry language', () => {
+  withDocs(
+    { 'anywhere/guia.md': `---\ntitle: Guía\nslug: es/guia\n---\n\nx\n` },
+    (dir) => {
+      const entries = buildDocsIndex({
+        docsDir: dir,
+        site: 'https://x/',
+        base: '/',
+        locales: [
+          { key: 'root', lang: 'en', isRoot: true },
+          { key: 'es', lang: 'es', isRoot: false },
+        ],
+      });
+      assert.equal(entries[0].path, '/es/guia/');
+      assert.equal(entries[0].lang, 'es');
+    },
+  );
+});
+
+test('get_page markdown drops leading MDX imports and avoids a duplicate H1', () => {
+  withDocs(
+    {
+      'with-imports.md': `---\ntitle: Fixtures\n---\n\nimport { Aside } from '@astrojs/starlight/components';\nimport Video from '@components/Video.astro';\n\n# Fixtures\n\nBody text.\n`,
+      'plain.md': `---\ntitle: Plain\n---\n\nJust a body, no heading.\n\n\`\`\`js\nimport notStripped from 'inside-a-fence';\n\`\`\`\n`,
+    },
+    (dir) => {
+      const entries = buildDocsIndex({ docsDir: dir, site: 'https://x/', base: '/', locales: ROOT_ONLY });
+      const fixtures = entries.find((e) => e.title === 'Fixtures');
+      // Imports stripped, and the body's own H1 is kept without prepending another.
+      assert.equal(fixtures?.markdown, '# Fixtures\n\nBody text.\n');
+      const plain = entries.find((e) => e.title === 'Plain');
+      // Title prepended when the body has no H1; fenced `import` lines untouched.
+      assert.match(plain?.markdown ?? '', /^# Plain\n\nJust a body, no heading\./);
+      assert.match(plain?.markdown ?? '', /import notStripped from 'inside-a-fence';/);
+    },
+  );
+});
+
+test('draft pages are excluded', () => {
+  withDocs(
+    { 'guides/draft.md': `---\ntitle: Draft\ndraft: true\n---\n\nx\n`, 'guides/live.md': page('Live') },
+    (dir) => {
+      const paths = buildDocsIndex({ docsDir: dir, site: 'https://x/', base: '/', locales: ROOT_ONLY }).map(
+        (e) => e.path,
+      );
+      assert.deepEqual(paths, ['/guides/live/']);
+    },
+  );
+});

--- a/packages/starlight-mcp/src/core/index/build.test.ts
+++ b/packages/starlight-mcp/src/core/index/build.test.ts
@@ -127,6 +127,21 @@ test('get_page markdown drops leading MDX imports and avoids a duplicate H1', ()
   );
 });
 
+test('a file with malformed frontmatter is skipped, not fatal to the index', () => {
+  withDocs(
+    {
+      'bad.md': `---\ntitle: "unclosed\n\tbad: [\n---\n\nx\n`,
+      'good.md': page('Good'),
+    },
+    (dir) => {
+      const paths = buildDocsIndex({ docsDir: dir, site: 'https://x/', base: '/', locales: ROOT_ONLY }).map(
+        (e) => e.path,
+      );
+      assert.deepEqual(paths, ['/good/']);
+    },
+  );
+});
+
 test('draft pages are excluded', () => {
   withDocs(
     { 'guides/draft.md': `---\ntitle: Draft\ndraft: true\n---\n\nx\n`, 'guides/live.md': page('Live') },

--- a/packages/starlight-mcp/src/core/index/build.ts
+++ b/packages/starlight-mcp/src/core/index/build.ts
@@ -110,13 +110,15 @@ export function buildDocsIndex(opts: BuildIndexOptions): DocEntry[] {
     const segments = rel.split('/');
     if (segments[segments.length - 1]?.toLowerCase() === 'index') segments.pop();
 
-    let raw: string;
+    // Skip unreadable files and files with malformed frontmatter individually —
+    // one bad page must not abort the walk and empty the whole index.
+    let data: Record<string, unknown>;
+    let content: string;
     try {
-      raw = readFileSync(file, 'utf8');
+      ({ data, content } = matter(readFileSync(file, 'utf8')));
     } catch {
       continue;
     }
-    const { data, content } = matter(raw);
     if (data.draft === true) continue;
 
     // A frontmatter `slug` replaces the file-derived route entirely (Starlight

--- a/packages/starlight-mcp/src/core/index/build.ts
+++ b/packages/starlight-mcp/src/core/index/build.ts
@@ -1,0 +1,181 @@
+/**
+ * Build-time content index generation.
+ *
+ * Runs inside the Astro integration (Node context), NOT at request time — this
+ * is the only module in the package that touches `node:fs`. It walks the
+ * Starlight docs collection, parses frontmatter, computes each page's route +
+ * language, and produces `DocEntry[]` that the integration inlines into the
+ * request handler via a Vite virtual module.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { extname, join, relative } from 'node:path';
+import { slug as githubSlug } from 'github-slugger';
+import matter from 'gray-matter';
+import type { AccessLevel, DocEntry } from './types';
+
+export interface LocaleDef {
+  /** Directory prefix / locale key. The root locale has `isRoot: true`. */
+  key: string;
+  /** BCP-47 language tag for this locale. */
+  lang: string;
+  isRoot: boolean;
+}
+
+export interface BuildIndexOptions {
+  /** Absolute path to `src/content/docs`. */
+  docsDir: string;
+  /** `astroConfig.site`, if set. */
+  site?: string;
+  /** `astroConfig.base`, default `/`. */
+  base?: string;
+  /** Starlight locales, normalized. */
+  locales: LocaleDef[];
+}
+
+const DOC_EXTENSIONS = new Set(['.md', '.mdx', '.markdown']);
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else if (DOC_EXTENSIONS.has(extname(entry.name).toLowerCase())) out.push(full);
+  }
+  return out;
+}
+
+/** Approximate Markdown/MDX → plain text for search ranking and snippets. */
+export function stripMarkdown(input: string): string {
+  return input
+    .replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, '') // stray frontmatter (gray-matter already strips the real one; handle CRLF)
+    .replace(/^(import|export)\s.*$/gm, '') // MDX import/export
+    .replace(/```[\s\S]*?```/g, ' ') // fenced code
+    .replace(/`[^`]*`/g, ' ') // inline code
+    .replace(/<\/?[a-zA-Z][^>]*>/g, ' ') // HTML/JSX tags
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1') // images → alt
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links → text
+    .replace(/^#{1,6}\s+/gm, '') // heading markers
+    .replace(/[*_~>#-]+/g, ' ') // emphasis / blockquote / list markers
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function toPosix(p: string): string {
+  return p.split(/[\\/]/).join('/');
+}
+
+/**
+ * Drop the leading MDX import block from a page body so `get_page` returns
+ * readable Markdown instead of module plumbing. Only complete single-line
+ * `import … from '…'` statements (and blank lines between them) are removed,
+ * so multi-line statements and code fences are never touched.
+ */
+export function stripLeadingMdxImports(body: string): string {
+  const lines = body.split('\n');
+  let i = 0;
+  while (i < lines.length && (lines[i].trim() === '' || /^import\s.+['"];?\s*$/.test(lines[i]))) {
+    i++;
+  }
+  return lines.slice(i).join('\n');
+}
+
+/**
+ * Slugify a single path segment exactly as Astro does. Astro maps each path
+ * segment through github-slugger's `slug()`
+ * (`astro/dist/content/utils.js` → `rawSlugSegments.map(githubSlug)`), so using
+ * the same function keeps the index `path`/`url` aligned with real site routes
+ * for punctuated filenames (`v1.2 Release` → `v12-release`, `C++ Guide` →
+ * `c-guide`, `a--b` → `a--b`).
+ */
+function slugifySegment(seg: string): string {
+  return githubSlug(seg);
+}
+
+export function buildDocsIndex(opts: BuildIndexOptions): DocEntry[] {
+  const { docsDir, site, base = '/', locales } = opts;
+  const rootLocale = locales.find((l) => l.isRoot);
+  const localeByKey = new Map(locales.filter((l) => !l.isRoot).map((l) => [l.key, l]));
+  const basePrefix = base === '/' ? '' : base.replace(/\/+$/, '');
+
+  const entries: DocEntry[] = [];
+
+  for (const file of walk(docsDir)) {
+    const rel = toPosix(relative(docsDir, file)).replace(/\.(md|mdx|markdown)$/i, '');
+    const segments = rel.split('/');
+    if (segments[segments.length - 1]?.toLowerCase() === 'index') segments.pop();
+
+    let raw: string;
+    try {
+      raw = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    const { data, content } = matter(raw);
+    if (data.draft === true) continue;
+
+    // A frontmatter `slug` replaces the file-derived route entirely (Starlight
+    // uses it verbatim, no slugification). Locale detection runs on the route
+    // segments so it works for both derivations.
+    const slugOverride =
+      typeof data.slug === 'string' ? data.slug.trim().replace(/^\/+|\/+$/g, '') : undefined;
+    const routeSegments =
+      slugOverride !== undefined
+        ? slugOverride === ''
+          ? []
+          : slugOverride.split('/')
+        : segments.map(slugifySegment);
+
+    // For file-derived routes the locale key is the raw first directory segment;
+    // for slug overrides it is the first slug segment (e.g. `slug: es/guia`).
+    const localeKeyCandidate = slugOverride !== undefined ? routeSegments[0] : segments[0];
+    const localeMatch =
+      localeKeyCandidate !== undefined ? localeByKey.get(localeKeyCandidate) : undefined;
+    const lang = localeMatch ? localeMatch.lang : (rootLocale?.lang ?? 'en');
+
+    const path = (basePrefix + '/' + routeSegments.join('/'))
+      .replace(/\/{2,}/g, '/')
+      .replace(/\/?$/, '/'); // always trailing slash (Starlight default)
+
+    const title = typeof data.title === 'string' && data.title.trim()
+      ? data.title.trim()
+      : (segments[segments.length - 1] ?? 'Untitled');
+
+    const access: AccessLevel = data.access === 'internal' ? 'internal' : 'public';
+    const groups = Array.isArray(data.groups) ? data.groups.map((g) => String(g)) : [];
+
+    const url = site
+      ? (() => {
+          try {
+            return new URL(path, site).href;
+          } catch {
+            return path;
+          }
+        })()
+      : path;
+
+    // Prepend the frontmatter title as an H1 unless the body already opens with
+    // one (some pages repeat their title as a Markdown heading).
+    const body = stripLeadingMdxImports(content).trim();
+    const markdown = /^#\s/.test(body) ? `${body}\n` : `# ${title}\n\n${body}\n`;
+
+    entries.push({
+      title,
+      url,
+      path,
+      lang,
+      access,
+      groups,
+      text: stripMarkdown(content),
+      markdown,
+    });
+  }
+
+  entries.sort((a, b) => a.path.localeCompare(b.path));
+  return entries;
+}

--- a/packages/starlight-mcp/src/core/index/query.ts
+++ b/packages/starlight-mcp/src/core/index/query.ts
@@ -1,0 +1,137 @@
+/**
+ * Request-time querying over the build-time content index.
+ *
+ * Pure functions, no I/O — runs on any runtime. All results are filtered by the
+ * caller's `Identity` via `visibleTo`, which is where the auth seam bites: an
+ * anonymous caller (v1) only ever sees `public` pages.
+ */
+import type { Identity } from '../auth/provider';
+import type { DocEntry } from './types';
+
+export interface SearchResult {
+  title: string;
+  url: string;
+  path: string;
+  lang: string;
+  snippet: string;
+  score: number;
+}
+
+/** Whether `entry` is visible to `identity`. The single gating decision point. */
+export function visibleTo(entry: DocEntry, identity: Identity): boolean {
+  if (entry.access === 'public') return true;
+  // `internal` pages require a user identity whose groups intersect the page's
+  // groups (an `internal` page with no groups is visible to any authenticated user).
+  if (identity.kind === 'user') {
+    return entry.groups.length === 0 || entry.groups.some((g) => identity.groups.includes(g));
+  }
+  return false;
+}
+
+function tokenize(s: string): string[] {
+  // Unicode-aware: match runs of letters/numbers across scripts (Latin, CJK, etc.)
+  // rather than splitting on non-[a-z0-9], which dropped all non-ASCII text.
+  return s.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  let count = 0;
+  let i = 0;
+  while ((i = haystack.indexOf(needle, i)) !== -1) {
+    count++;
+    i += needle.length;
+  }
+  return count;
+}
+
+function buildSnippet(text: string, terms: string[], max = 240): string {
+  const lower = text.toLowerCase();
+  let at = -1;
+  for (const term of terms) {
+    const idx = lower.indexOf(term);
+    if (idx !== -1 && (at === -1 || idx < at)) at = idx;
+  }
+  if (at === -1) return text.slice(0, max).trim();
+  const start = Math.max(0, at - 60);
+  const slice = text.slice(start, start + max).trim();
+  return (start > 0 ? '…' : '') + slice + (start + max < text.length ? '…' : '');
+}
+
+export interface SearchOptions {
+  query: string;
+  lang?: string;
+  limit?: number;
+}
+
+export function searchDocs(
+  index: DocEntry[],
+  identity: Identity,
+  { query, lang, limit = 10 }: SearchOptions,
+): SearchResult[] {
+  const terms = tokenize(query);
+  const phrase = query.trim().toLowerCase();
+  if (terms.length === 0) return [];
+
+  const results: SearchResult[] = [];
+  for (const entry of index) {
+    if (!visibleTo(entry, identity)) continue;
+    if (lang && entry.lang !== lang) continue;
+
+    const title = entry.title.toLowerCase();
+    const text = entry.text.toLowerCase();
+    let score = 0;
+    for (const term of terms) {
+      score += countOccurrences(title, term) * 5;
+      score += countOccurrences(text, term);
+    }
+    // Phrase + title-substring bonuses to surface the most direct matches.
+    if (phrase.length > 2 && text.includes(phrase)) score += 3;
+    if (title.includes(phrase)) score += 8;
+    if (score <= 0) continue;
+
+    results.push({
+      title: entry.title,
+      url: entry.url,
+      path: entry.path,
+      lang: entry.lang,
+      snippet: buildSnippet(entry.text, terms),
+      score,
+    });
+  }
+
+  results.sort((a, b) => b.score - a.score || a.path.localeCompare(b.path));
+  return results.slice(0, Math.max(1, Math.min(limit, 50)));
+}
+
+/** Normalize a user-supplied path or full URL to a comparable route path. */
+export function normalizePath(input: string): string {
+  let p = input.trim();
+  try {
+    // Resolve against a dummy base so both bare paths and absolute URLs work; this
+    // strips any query string and fragment and yields just the pathname.
+    p = new URL(p, 'http://x').pathname;
+  } catch {
+    /* fall through with the raw string */
+  }
+  if (!p.startsWith('/')) p = '/' + p;
+  if (!p.endsWith('/')) p = p + '/';
+  return p.replace(/\/{2,}/g, '/'); // collapse duplicate slashes
+}
+
+export function getPage(
+  index: DocEntry[],
+  identity: Identity,
+  pathOrUrl: string,
+): DocEntry | undefined {
+  const target = normalizePath(pathOrUrl);
+  const matches = (p: string) => p === target || normalizePath(p) === target;
+  // Exact match first; fall back to case-insensitive (models often re-case paths).
+  const lower = target.toLowerCase();
+  const ciMatches = (p: string) => p.toLowerCase() === lower || normalizePath(p).toLowerCase() === lower;
+  const entry =
+    index.find((e) => matches(e.path) || matches(e.url)) ??
+    index.find((e) => ciMatches(e.path) || ciMatches(e.url));
+  if (!entry || !visibleTo(entry, identity)) return undefined;
+  return entry;
+}

--- a/packages/starlight-mcp/src/core/index/query.ts
+++ b/packages/starlight-mcp/src/core/index/query.ts
@@ -107,6 +107,9 @@ export function searchDocs(
 /** Normalize a user-supplied path or full URL to a comparable route path. */
 export function normalizePath(input: string): string {
   let p = input.trim();
+  // Collapse duplicate leading slashes: `//guides/x/` would otherwise parse as a
+  // protocol-relative URL below, discarding `guides` as a hostname.
+  if (p.startsWith('//')) p = '/' + p.replace(/^\/+/, '');
   try {
     // Resolve against a dummy base so both bare paths and absolute URLs work; this
     // strips any query string and fragment and yields just the pathname.

--- a/packages/starlight-mcp/src/core/index/types.ts
+++ b/packages/starlight-mcp/src/core/index/types.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared content-index types. The index is generated at build time
+ * (see `./build.ts`) and queried at request time (see `./query.ts`).
+ *
+ * The `access` and `groups` fields are the auth-readiness seam: v1 is authless
+ * and every page is `public`, but the schema already carries the metadata so
+ * that adding per-user gating in v2 is purely additive (populate `groups` from
+ * frontmatter + supply a non-anonymous identity — no reindex/migration).
+ */
+
+export type AccessLevel = 'public' | 'internal';
+
+export interface DocEntry {
+  /** Page title from frontmatter. */
+  title: string;
+  /** Absolute URL when `site` is configured, otherwise the route path. */
+  url: string;
+  /** Route path, e.g. `/getting-started/welcome/`. */
+  path: string;
+  /** Language code: the root locale's lang (e.g. `en`) or a locale key (e.g. `es`). */
+  lang: string;
+  /** Visibility tier. v1 emits `public` for everything. */
+  access: AccessLevel;
+  /** Groups permitted to see this page when `access` is `internal`. Empty in v1. */
+  groups: string[];
+  /** Plain-text rendition of the body, used for ranking + snippets. */
+  text: string;
+  /** Raw Markdown body (with a leading `# title`), returned by `get_page`. */
+  markdown: string;
+}

--- a/packages/starlight-mcp/src/core/observability.ts
+++ b/packages/starlight-mcp/src/core/observability.ts
@@ -1,0 +1,41 @@
+/**
+ * Minimal structured logging. Logs request metadata and timings; never logs raw
+ * user content (query strings, page bodies). Accepts any console-like sink so it
+ * works with Astro's integration logger or a plain `console`.
+ */
+
+export interface LogSink {
+  info(msg: string): void;
+  warn(msg: string): void;
+  error(msg: string): void;
+}
+
+export interface RequestLogFields {
+  requestId: string;
+  httpMethod: string;
+  protocolMethod?: string;
+  toolName?: string;
+  status: number;
+  durationMs: number;
+  contentLength?: number;
+}
+
+export function logRequest(sink: LogSink, fields: RequestLogFields): void {
+  const parts = [
+    `id=${fields.requestId}`,
+    `http=${fields.httpMethod}`,
+    fields.protocolMethod ? `rpc=${fields.protocolMethod}` : '',
+    fields.toolName ? `tool=${fields.toolName}` : '',
+    `status=${fields.status}`,
+    `dur=${fields.durationMs}ms`,
+    fields.contentLength !== undefined ? `bytes=${fields.contentLength}` : '',
+  ].filter(Boolean);
+  sink.info(`[mcp] ${parts.join(' ')}`);
+}
+
+/** Best-effort request id without depending on `crypto.randomUUID` availability. */
+export function newRequestId(): string {
+  const g = globalThis as { crypto?: { randomUUID?: () => string } };
+  if (g.crypto?.randomUUID) return g.crypto.randomUUID();
+  return 'r' + Date.now().toString(36) + Math.floor(Math.random() * 1e6).toString(36);
+}

--- a/packages/starlight-mcp/src/core/resources/index.ts
+++ b/packages/starlight-mcp/src/core/resources/index.ts
@@ -1,0 +1,42 @@
+/**
+ * MCP resources. v1 exposes a single `llms.txt`-style index resource, generated
+ * from the visible content index (so it respects the same identity gating as the
+ * tools and needs no dependency on the `starlight-llms-txt` build output).
+ */
+import type { McpContext } from '../context';
+import { visibleTo } from '../index/query';
+
+const LLMS_TXT_NAME = 'llms.txt';
+
+export function llmsTxtUri(ctx: McpContext): string {
+  if (ctx.siteUrl) {
+    try {
+      return new URL('/llms.txt', ctx.siteUrl).href;
+    } catch {
+      /* fall through */
+    }
+  }
+  return 'docs://llms.txt';
+}
+
+export function listResources(ctx: McpContext) {
+  return [
+    {
+      uri: llmsTxtUri(ctx),
+      name: LLMS_TXT_NAME,
+      title: 'Documentation index (llms.txt)',
+      description: 'A link index of the documentation, suitable for LLM consumption.',
+      mimeType: 'text/plain',
+    },
+  ];
+}
+
+export function renderLlmsTxt(ctx: McpContext): string {
+  const title = ctx.siteTitle ?? 'Documentation';
+  const lines: string[] = [`# ${title}`, '', '## Docs', ''];
+  for (const e of ctx.index.filter((entry) => visibleTo(entry, ctx.identity))) {
+    const summary = e.text.replace(/\s+/g, ' ').trim().slice(0, 140);
+    lines.push(`- [${e.title}](${e.url})${summary ? `: ${summary}` : ''}`);
+  }
+  return lines.join('\n') + '\n';
+}

--- a/packages/starlight-mcp/src/core/server.ts
+++ b/packages/starlight-mcp/src/core/server.ts
@@ -1,0 +1,32 @@
+/**
+ * Per-request MCP server factory, built on the official MCP SDK's high-level
+ * `McpServer`. A fresh server is created for each request (stateless), with tools
+ * and resources bound to the caller's identity. The SDK owns the protocol engine
+ * (initialize negotiation, capability advertisement, input validation against the
+ * Zod schemas, error formatting), so we only supply business logic.
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpContext } from './context';
+import { listResources, renderLlmsTxt } from './resources/index';
+import { getPageToolConfig, runGetPage } from './tools/get-page';
+import { searchToolConfig, runSearch } from './tools/search';
+
+export function createMcpServer(ctx: McpContext): McpServer {
+  const server = new McpServer(ctx.serverInfo);
+
+  server.registerTool('search', searchToolConfig, async (args) => runSearch(args, ctx));
+  server.registerTool('get_page', getPageToolConfig, async (args) => runGetPage(args, ctx));
+
+  for (const resource of listResources(ctx)) {
+    server.registerResource(
+      resource.name,
+      resource.uri,
+      { title: resource.title, description: resource.description, mimeType: resource.mimeType },
+      async (uri) => ({
+        contents: [{ uri: uri.href, mimeType: 'text/plain', text: renderLlmsTxt(ctx) }],
+      }),
+    );
+  }
+
+  return server;
+}

--- a/packages/starlight-mcp/src/core/tools/get-page.ts
+++ b/packages/starlight-mcp/src/core/tools/get-page.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import type { McpContext } from '../context';
+import { getPage } from '../index/query';
+
+/** Zod input shape for the `get_page` tool. */
+export const getPageInputSchema = {
+  path: z.string().min(1).describe('The page route path (e.g. "/guides/example/") or its full URL.'),
+};
+
+export const getPageToolConfig = {
+  title: 'Get a documentation page',
+  description:
+    'Retrieve the full Markdown content of a single documentation page by its path (e.g. "/getting-started/welcome/") or full URL. Use `search` first to discover the path.',
+  inputSchema: getPageInputSchema,
+  annotations: { readOnlyHint: true, openWorldHint: false },
+};
+
+export interface GetPageArgs {
+  path: string;
+}
+
+export function runGetPage(args: GetPageArgs, ctx: McpContext) {
+  const entry = getPage(ctx.index, ctx.identity, args.path);
+  if (!entry) {
+    return {
+      isError: true,
+      content: [{ type: 'text' as const, text: `No documentation page found at "${args.path}".` }],
+    };
+  }
+
+  return {
+    content: [{ type: 'text' as const, text: entry.markdown }],
+    structuredContent: {
+      title: entry.title,
+      url: entry.url,
+      path: entry.path,
+      lang: entry.lang,
+      markdown: entry.markdown,
+    },
+  };
+}

--- a/packages/starlight-mcp/src/core/tools/search.ts
+++ b/packages/starlight-mcp/src/core/tools/search.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+import type { McpContext } from '../context';
+import { searchDocs } from '../index/query';
+
+/** Zod input shape for the `search` tool. The SDK derives the wire JSON Schema from this. */
+export const searchInputSchema = {
+  query: z.string().min(1).describe('Search query.'),
+  lang: z.string().optional().describe('Optional language filter (e.g. "en", "es"). Omit to search all languages.'),
+  limit: z.number().int().min(1).max(50).optional().describe('Maximum number of results (1–50, default 10).'),
+};
+
+export const searchToolConfig = {
+  title: 'Search documentation',
+  description:
+    'Full-text search across the documentation. Returns ranked passages with their source page titles and URLs. Use this to find where a topic is covered before reading a full page with `get_page`.',
+  inputSchema: searchInputSchema,
+  annotations: { readOnlyHint: true, openWorldHint: false },
+};
+
+export interface SearchArgs {
+  query: string;
+  lang?: string;
+  limit?: number;
+}
+
+export function runSearch(args: SearchArgs, ctx: McpContext) {
+  const results = searchDocs(ctx.index, ctx.identity, {
+    query: args.query,
+    lang: args.lang,
+    limit: args.limit,
+  });
+
+  if (results.length === 0) {
+    return {
+      content: [{ type: 'text' as const, text: `No documentation matched "${args.query}".` }],
+      structuredContent: { results: [] },
+    };
+  }
+
+  const text = results
+    .map((r, i) => `${i + 1}. ${r.title} — ${r.url}\n   ${r.snippet}`)
+    .join('\n\n');
+
+  return {
+    content: [{ type: 'text' as const, text }],
+    structuredContent: {
+      results: results.map((r) => ({
+        title: r.title,
+        url: r.url,
+        path: r.path,
+        lang: r.lang,
+        snippet: r.snippet,
+      })),
+    },
+  };
+}

--- a/packages/starlight-mcp/src/core/transport.ts
+++ b/packages/starlight-mcp/src/core/transport.ts
@@ -1,0 +1,190 @@
+/**
+ * Fetch-native MCP transport. Wraps the MCP SDK's
+ * `WebStandardStreamableHTTPServerTransport` (Web `Request` → `Response`) and
+ * builds a fresh stateless server per request (`sessionIdGenerator` undefined,
+ * `enableJsonResponse` for single-shot JSON replies).
+ *
+ * The request path uses only standard Fetch APIs — no Node `http` — which is what
+ * makes it portable. NOTE: full Cloudflare Workers support is NOT yet verified.
+ * The SDK's Zod-based validation uses `new Function` (JIT), which workerd's CSP
+ * blocks, so running there would need jitless Zod plus a Cloudflare build test.
+ * The supported/verified target today is Vercel/Node.
+ *
+ * This layer owns method routing, CORS, the enabled flag, and request logging;
+ * the SDK owns protocol negotiation and tool-level errors.
+ */
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import type { AuthProvider } from './auth/provider';
+import type { DocEntry } from './index/types';
+import { logRequest, newRequestId, type LogSink } from './observability';
+import { createMcpServer } from './server';
+
+export interface McpHandlerOptions {
+  index: DocEntry[];
+  authProvider: AuthProvider;
+  serverInfo: { name: string; version: string };
+  siteTitle?: string;
+  siteUrl?: string;
+  /** When false, the endpoint responds 503. Default true. */
+  enabled?: boolean;
+  /** CORS allowed origin. Default '*'. */
+  corsAllowOrigin?: string;
+  /** Max request body in bytes (Content-Length based). Default 4 MiB. */
+  maxBodyBytes?: number;
+  logger?: LogSink;
+}
+
+const DEFAULT_MAX_BODY = 4 * 1024 * 1024;
+
+function corsHeaders(origin: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'content-type, accept, authorization, mcp-protocol-version, mcp-session-id',
+    'Access-Control-Expose-Headers': 'mcp-session-id, mcp-protocol-version',
+    'Access-Control-Max-Age': '86400',
+  };
+  // A specific origin can be used with credentialed requests (needed once auth is
+  // wired up); the wildcard '*' cannot be combined with credentials per the spec.
+  if (origin !== '*') {
+    headers['Access-Control-Allow-Credentials'] = 'true';
+    headers['Vary'] = 'Origin';
+  }
+  return headers;
+}
+
+/**
+ * Re-emit the transport's response with CORS headers, buffering the body first.
+ * Only POST/JSON responses reach here (GET/SSE is rejected upstream), so the body
+ * is always finite — buffering is safe and lets us attach headers and close the
+ * per-request server before the body is handed to the host's HTTP layer.
+ */
+async function finalize(
+  res: Response,
+  extra: Record<string, string>,
+): Promise<{ response: Response; bytes: number }> {
+  const body = await res.arrayBuffer();
+  const headers = new Headers(res.headers);
+  for (const [k, v] of Object.entries(extra)) headers.set(k, v);
+  const response = new Response(body.byteLength ? body : null, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  });
+  return { response, bytes: body.byteLength };
+}
+
+function jsonResponse(body: unknown, status: number, headers: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+export async function handleMcpRequest(request: Request, opts: McpHandlerOptions): Promise<Response> {
+  const requestId = newRequestId();
+  const start = Date.now();
+  const sink = opts.logger;
+  const cors = corsHeaders(opts.corsAllowOrigin ?? '*');
+
+  // Best-effort metadata for logging. Only done when logging is on, and on a clone
+  // so the body stays readable by the transport.
+  let protocolMethod: string | undefined;
+  let toolName: string | undefined;
+  if (sink && request.method === 'POST') {
+    try {
+      const peek = await request.clone().json();
+      const msg = Array.isArray(peek) ? peek[0] : peek;
+      protocolMethod = typeof msg?.method === 'string' ? msg.method : undefined;
+      if (protocolMethod === 'tools/call' && typeof msg?.params?.name === 'string') {
+        toolName = msg.params.name as string;
+      }
+    } catch {
+      /* ignore — not our job to validate here */
+    }
+  }
+
+  const finish = (status: number, bytes?: number) => {
+    if (sink) {
+      logRequest(sink, {
+        requestId,
+        httpMethod: request.method,
+        protocolMethod,
+        toolName,
+        status,
+        durationMs: Date.now() - start,
+        contentLength: bytes,
+      });
+    }
+  };
+
+  if (request.method === 'OPTIONS') {
+    finish(204);
+    return new Response(null, { status: 204, headers: cors });
+  }
+
+  if (opts.enabled === false) {
+    finish(503);
+    return jsonResponse({ error: 'MCP server is disabled.' }, 503, cors);
+  }
+
+  // Streamable HTTP is request/response only here (stateless, no server-initiated
+  // SSE), so only POST is accepted. Rejecting GET/DELETE also prevents buffering a
+  // never-ending SSE stream, which would otherwise hang the invocation.
+  if (request.method !== 'POST') {
+    finish(405);
+    const headers = { ...cors, Allow: 'POST, OPTIONS' };
+    // HEAD responses must not carry a body.
+    if (request.method === 'HEAD') return new Response(null, { status: 405, headers });
+    return jsonResponse(
+      { jsonrpc: '2.0', error: { code: -32601, message: `Method ${request.method} not allowed; use POST.` }, id: null },
+      405,
+      headers,
+    );
+  }
+
+  // Bound memory: reject oversized bodies up front by Content-Length.
+  const declaredLen = Number(request.headers.get('content-length'));
+  if (Number.isFinite(declaredLen) && declaredLen > (opts.maxBodyBytes ?? DEFAULT_MAX_BODY)) {
+    finish(413);
+    return jsonResponse(
+      { jsonrpc: '2.0', error: { code: -32600, message: 'Request body too large.' }, id: null },
+      413,
+      cors,
+    );
+  }
+
+  // Declared outside the try so `finally` can always close it, even if
+  // connect/handleRequest/finalize throws (avoids leaking a per-request server).
+  let server: ReturnType<typeof createMcpServer> | undefined;
+  try {
+    const identity = await opts.authProvider.authenticate(request);
+    server = createMcpServer({
+      index: opts.index,
+      identity,
+      serverInfo: opts.serverInfo,
+      siteTitle: opts.siteTitle,
+      siteUrl: opts.siteUrl,
+    });
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+
+    await server.connect(transport);
+    const res = await transport.handleRequest(request);
+    const { response, bytes } = await finalize(res, cors);
+    finish(response.status, bytes);
+    return response;
+  } catch (err) {
+    if (sink) sink.error(`[mcp] id=${requestId} internal error: ${(err as Error).message}`);
+    finish(500);
+    return jsonResponse(
+      { jsonrpc: '2.0', error: { code: -32603, message: 'Internal server error.' }, id: null },
+      500,
+      cors,
+    );
+  } finally {
+    if (server) await server.close().catch(() => {});
+  }
+}

--- a/packages/starlight-mcp/src/core/transport.ts
+++ b/packages/starlight-mcp/src/core/transport.ts
@@ -125,6 +125,10 @@ export async function handleMcpRequest(request: Request, opts: McpHandlerOptions
 
   if (opts.enabled === false) {
     finish(503);
+    // HEAD responses must not carry a body.
+    if (request.method === 'HEAD') {
+      return new Response(null, { status: 503, headers: { 'content-type': 'application/json', ...cors } });
+    }
     return jsonResponse({ error: 'MCP server is disabled.' }, 503, cors);
   }
 

--- a/packages/starlight-mcp/src/index.ts
+++ b/packages/starlight-mcp/src/index.ts
@@ -1,0 +1,82 @@
+/**
+ * starlight-mcp — a Starlight plugin that serves the docs site as a read-only
+ * MCP (Model Context Protocol) server.
+ *
+ * v1 is authless: every page is public, exposed via `search` + `get_page` tools
+ * and an `llms.txt` resource over Streamable HTTP at `/mcp`. The architecture is
+ * built so authentication + per-user gating can be added in v2 without a rewrite
+ * (see `./core/auth/provider.ts` and `MCP_SERVER_PLAN.md` §6).
+ *
+ * Requires an SSR adapter (@astrojs/vercel or @astrojs/cloudflare) because the
+ * MCP route is rendered on demand.
+ */
+import type { StarlightPlugin } from '@astrojs/starlight/types';
+import { mcpIntegration } from './integration';
+import type { LocaleDef } from './core/index/build';
+
+export interface StarlightMcpOptions {
+  /** Route to mount the MCP server at. Default `/mcp`. */
+  endpoint?: string;
+  /** Enable the server. When false the route responds 503. Default true. */
+  enabled?: boolean;
+  /** MCP `serverInfo.name`. Defaults to the site title. */
+  serverName?: string;
+  /** CORS `Access-Control-Allow-Origin`. Default `*` (public read-only server). */
+  corsAllowOrigin?: string;
+  /** Package location relative to the project root. Override if you move it. */
+  packageDir?: string;
+}
+
+const PLUGIN_VERSION = '0.1.0';
+
+interface StarlightConfigLike {
+  title?: string | Record<string, string>;
+  locales?: Record<string, { lang?: string } | undefined>;
+  defaultLocale?: { lang?: string };
+}
+
+function coerceTitle(title: StarlightConfigLike['title']): string | undefined {
+  if (typeof title === 'string') return title;
+  if (title && typeof title === 'object') {
+    const first = Object.values(title)[0];
+    return typeof first === 'string' ? first : undefined;
+  }
+  return undefined;
+}
+
+function normalizeLocales(config: StarlightConfigLike): LocaleDef[] {
+  const locales = config.locales;
+  if (!locales || Object.keys(locales).length === 0) {
+    return [{ key: 'root', lang: config.defaultLocale?.lang ?? 'en', isRoot: true }];
+  }
+  return Object.entries(locales).map(([key, val]) => ({
+    key,
+    lang: val?.lang ?? (key === 'root' ? 'en' : key),
+    isRoot: key === 'root',
+  }));
+}
+
+export default function starlightMcp(options: StarlightMcpOptions = {}): StarlightPlugin {
+  return {
+    name: 'starlight-mcp',
+    hooks: {
+      'config:setup': ({ config, addIntegration, logger }) => {
+        const cfg = config as StarlightConfigLike;
+        const siteTitle = coerceTitle(cfg.title);
+        addIntegration(
+          mcpIntegration({
+            endpoint: options.endpoint ?? '/mcp',
+            enabled: options.enabled ?? true,
+            serverName: options.serverName ?? (siteTitle ? `${siteTitle} MCP` : 'starlight-mcp'),
+            serverVersion: PLUGIN_VERSION,
+            siteTitle,
+            corsAllowOrigin: options.corsAllowOrigin,
+            locales: normalizeLocales(cfg),
+            packageDir: options.packageDir ?? 'packages/starlight-mcp',
+          }),
+        );
+        logger.info(`MCP server route registered at "${options.endpoint ?? '/mcp'}".`);
+      },
+    },
+  };
+}

--- a/packages/starlight-mcp/src/integration.ts
+++ b/packages/starlight-mcp/src/integration.ts
@@ -1,0 +1,131 @@
+/**
+ * Astro integration added by the Starlight plugin. It:
+ *   1. builds the content index at config time (Node context),
+ *   2. inlines `{ index, config }` into a Vite virtual module so it bundles into
+ *      the request handler with no runtime fs (verified on Vercel/Node),
+ *   3. injects the `/mcp` route as an on-demand (prerendered:false) endpoint,
+ *   4. warns if no SSR adapter is configured (the route needs one to build).
+ */
+import { fileURLToPath } from 'node:url';
+import type { AstroIntegration } from 'astro';
+import { buildDocsIndex, type LocaleDef } from './core/index/build';
+import type { DocEntry } from './core/index/types';
+
+const VIRTUAL_ID = 'virtual:starlight-mcp';
+const RESOLVED_VIRTUAL_ID = '\0' + VIRTUAL_ID;
+
+// JS line/paragraph separators: valid in JSON but invalid in a JS source string
+// literal, so they must be escaped before being inlined into the virtual module.
+const LINE_SEPARATOR = String.fromCharCode(0x2028);
+const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
+
+export interface IntegrationOptions {
+  /** Route the MCP server is mounted at. Default `/mcp`. */
+  endpoint: string;
+  /** Master enable flag (the route still exists but responds 503 when false). */
+  enabled: boolean;
+  /** MCP `serverInfo.name`. */
+  serverName: string;
+  /** MCP `serverInfo.version`. */
+  serverVersion: string;
+  /** Human-readable site title, used in resource rendering. */
+  siteTitle?: string;
+  /** CORS allowed origin. Default `*`. */
+  corsAllowOrigin?: string;
+  /** Normalized Starlight locales for language detection. */
+  locales: LocaleDef[];
+  /** Package location relative to project root (for resolving the route entry). */
+  packageDir: string;
+}
+
+export interface RuntimeConfig {
+  serverInfo: { name: string; version: string };
+  siteTitle?: string;
+  siteUrl?: string;
+  enabled: boolean;
+  endpoint: string;
+  corsAllowOrigin?: string;
+}
+
+/**
+ * Serialize the inlined payload safely. `JSON.stringify` does not escape U+2028 /
+ * U+2029, so doc content containing them would corrupt the generated
+ * `export default <json>` virtual module. Escape them to their `\uXXXX` forms.
+ */
+function serializePayload(value: unknown): string {
+  return JSON.stringify(value)
+    .split(LINE_SEPARATOR)
+    .join('\\u2028')
+    .split(PARAGRAPH_SEPARATOR)
+    .join('\\u2029');
+}
+
+export function mcpIntegration(options: IntegrationOptions): AstroIntegration {
+  return {
+    name: 'starlight-mcp',
+    hooks: {
+      'astro:config:setup': ({ config, injectRoute, updateConfig, logger }) => {
+        const docsDir = fileURLToPath(new URL('content/docs/', config.srcDir));
+        let index: DocEntry[] = [];
+        try {
+          index = buildDocsIndex({
+            docsDir,
+            site: config.site,
+            base: config.base,
+            locales: options.locales,
+          });
+          logger.info(`Indexed ${index.length} documentation page(s) for the MCP server.`);
+        } catch (err) {
+          logger.warn(`Failed to build MCP content index: ${(err as Error).message}`);
+        }
+
+        const runtimeConfig: RuntimeConfig = {
+          serverInfo: { name: options.serverName, version: options.serverVersion },
+          siteTitle: options.siteTitle,
+          siteUrl: config.site,
+          enabled: options.enabled,
+          endpoint: options.endpoint,
+          corsAllowOrigin: options.corsAllowOrigin,
+        };
+
+        const payload = serializePayload({ index, config: runtimeConfig });
+
+        // `updateConfig` deep-merges and CONCATENATES arrays, so passing a single
+        // Vite plugin here appends to (does not replace) plugins added elsewhere.
+        updateConfig({
+          vite: {
+            plugins: [
+              {
+                name: 'starlight-mcp:virtual',
+                resolveId(id: string) {
+                  if (id === VIRTUAL_ID) return RESOLVED_VIRTUAL_ID;
+                  return null;
+                },
+                load(id: string) {
+                  if (id === RESOLVED_VIRTUAL_ID) return `export default ${payload};`;
+                  return null;
+                },
+              },
+            ],
+          },
+        });
+
+        injectRoute({
+          pattern: options.endpoint,
+          entrypoint: new URL(`${options.packageDir}/src/route.ts`, config.root),
+          prerender: false,
+        });
+      },
+
+      'astro:config:done': ({ config, logger }) => {
+        if (!config.adapter) {
+          logger.warn(
+            `No SSR adapter configured — the MCP route "${options.endpoint}" needs on-demand ` +
+              `rendering and the build will fail without one. Add @astrojs/vercel or ` +
+              `@astrojs/cloudflare (see the starlight-mcp README).`,
+          );
+        }
+      },
+    },
+  };
+}

--- a/packages/starlight-mcp/src/route.ts
+++ b/packages/starlight-mcp/src/route.ts
@@ -1,0 +1,31 @@
+/**
+ * Injected Astro endpoint for the MCP server. Intentionally thin: it adapts the
+ * runtime `Request` to the runtime-agnostic core handler and returns its
+ * `Response`. All logic lives in `./core`. `data` is inlined at build time by the
+ * integration's Vite virtual module, so no filesystem access happens here.
+ */
+import type { APIContext } from 'astro';
+import data from 'virtual:starlight-mcp';
+import { AnonymousAuthProvider } from './core/auth/provider';
+import { handleMcpRequest } from './core/transport';
+
+export const prerender = false;
+
+// v1 is authless — every request is anonymous (public content only). The
+// AuthProvider seam is retained so v2 can drop in an OAuth 2.1 resource server
+// behind the same interface without touching the transport or tools.
+// See MCP_SERVER_PLAN.md §6.
+const authProvider = new AnonymousAuthProvider();
+
+export async function ALL(context: APIContext): Promise<Response> {
+  return handleMcpRequest(context.request, {
+    index: data.index,
+    authProvider,
+    serverInfo: data.config.serverInfo,
+    siteTitle: data.config.siteTitle,
+    siteUrl: data.config.siteUrl,
+    enabled: data.config.enabled,
+    corsAllowOrigin: data.config.corsAllowOrigin,
+    logger: console,
+  });
+}

--- a/packages/starlight-mcp/src/virtual.d.ts
+++ b/packages/starlight-mcp/src/virtual.d.ts
@@ -1,0 +1,7 @@
+/** Types for the build-time-inlined index + runtime config virtual module. */
+declare module 'virtual:starlight-mcp' {
+  import type { RuntimeConfig } from './integration';
+  import type { DocEntry } from './core/index/types';
+  const data: { index: DocEntry[]; config: RuntimeConfig };
+  export default data;
+}

--- a/scripts/preview.ts
+++ b/scripts/preview.ts
@@ -1,0 +1,19 @@
+/**
+ * `npm run preview` — serve the last production build locally.
+ *
+ * `astro preview` is not supported once the @astrojs/vercel adapter is active
+ * (the MCP route needs it; see docs/starport-migration/adrs/0007-docs-mcp-server.md),
+ * so this reuses the smoke-test static server, which serves the newest build
+ * output (`.vercel/output/static` with its config.json redirects, or `dist`).
+ * Note: the /mcp function is not executed here — use `npm run dev` for that.
+ */
+import { startPreviewServer } from '../tests/smoke/preview-server';
+
+const port = Number(process.env.PORT) || 4321;
+const server = await startPreviewServer({ port });
+console.log(`Serving the last build at ${server.baseUrl} (Ctrl-C to stop)`);
+console.log('Note: /mcp is a serverless function and is not served here; use `npm run dev`.');
+
+process.on('SIGINT', () => {
+  void server.close().finally(() => process.exit(0));
+});

--- a/tests/smoke/preview-server.ts
+++ b/tests/smoke/preview-server.ts
@@ -1,14 +1,23 @@
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
-import { access } from 'node:fs/promises';
+/**
+ * In-process preview server for the smoke tests.
+ *
+ * `astro preview` is not supported by @astrojs/vercel (the SSR adapter required
+ * by the MCP route), so this serves the built static output directly:
+ *   - Adapter builds: `.vercel/output/static`, plus the redirect routes the
+ *     adapter emits into `.vercel/output/config.json` (applied as real 3xx
+ *     responses, matching what Vercel does in production).
+ *   - Static builds (MCP_ENABLED=false): `dist`, where Astro emits
+ *     "Redirecting to: …" stub pages instead of platform redirects.
+ * The smoke tests accept both behaviors.
+ */
+import { createServer, type Server } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
 import net from 'node:net';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { setTimeout as sleep } from 'node:timers/promises';
 
 const PREVIEW_HOST = '127.0.0.1';
-const STARTUP_TIMEOUT_MS = 25_000;
-const REQUEST_TIMEOUT_MS = 3_000;
-const SHUTDOWN_TIMEOUT_MS = 5_000;
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(dirname, '..', '..');
 
@@ -17,15 +26,87 @@ export interface PreviewServer {
   close: () => Promise<void>;
 }
 
-async function ensureBuildOutput() {
-  const distPath = path.join(ROOT, 'dist', 'index.html');
-  try {
-    await access(distPath);
-  } catch {
-    throw new Error(
-      `Missing build output at ${distPath}. Run \"npm run build\" (or \"npm run check\") before smoke tests.`
-    );
+interface RedirectRoute {
+  pattern: RegExp;
+  location: string;
+  status: number;
+}
+
+interface BuildOutput {
+  staticRoot: string;
+  redirects: RedirectRoute[];
+}
+
+function loadRedirectRoutes(configPath: string): RedirectRoute[] {
+  if (!existsSync(configPath)) return [];
+  const config = JSON.parse(readFileSync(configPath, 'utf8')) as {
+    routes?: Array<{ src?: string; status?: number; headers?: Record<string, string> }>;
+  };
+  const redirects: RedirectRoute[] = [];
+  for (const route of config.routes ?? []) {
+    const location = route.headers?.Location;
+    if (!route.src || !location || !route.status || route.status < 300 || route.status >= 400) {
+      continue;
+    }
+    try {
+      redirects.push({ pattern: new RegExp(route.src), location, status: route.status });
+    } catch {
+      // Skip patterns Node's RegExp cannot parse; smoke coverage degrades gracefully.
+    }
   }
+  return redirects;
+}
+
+function resolveBuildOutput(): BuildOutput {
+  const vercelStatic = path.join(ROOT, '.vercel', 'output', 'static');
+  if (existsSync(path.join(vercelStatic, 'index.html'))) {
+    return {
+      staticRoot: vercelStatic,
+      redirects: loadRedirectRoutes(path.join(ROOT, '.vercel', 'output', 'config.json')),
+    };
+  }
+  const dist = path.join(ROOT, 'dist');
+  if (existsSync(path.join(dist, 'index.html'))) {
+    return { staticRoot: dist, redirects: [] };
+  }
+  throw new Error(
+    `Missing build output (looked for ${vercelStatic}/index.html and ${dist}/index.html). ` +
+      'Run "npm run build" (or "npm run check") before smoke tests.'
+  );
+}
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.md': 'text/markdown; charset=utf-8',
+  '.xml': 'application/xml; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+};
+
+function contentTypeFor(filePath: string): string {
+  return CONTENT_TYPES[path.extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+}
+
+/** Map a request pathname to candidate files inside the static root. */
+function candidateFiles(staticRoot: string, pathname: string): string[] {
+  const decoded = decodeURIComponent(pathname);
+  const safe = path.normalize(decoded).replace(/^(\.\.[/\\])+/, '');
+  const base = path.join(staticRoot, safe);
+  if (!base.startsWith(staticRoot)) return [];
+  if (path.extname(safe) !== '') return [base];
+  return [path.join(base, 'index.html'), base];
 }
 
 function getFreePort(): Promise<number> {
@@ -47,108 +128,56 @@ function getFreePort(): Promise<number> {
   });
 }
 
-async function waitForServerReady(baseUrl: string, child: ChildProcessWithoutNullStreams) {
-  const start = Date.now();
-  let lastError = '';
-
-  while (Date.now() - start < STARTUP_TIMEOUT_MS) {
-    if (child.exitCode !== null) {
-      throw new Error(
-        `Preview server exited early with code ${child.exitCode}. ${lastError}`.trim()
-      );
-    }
-
-    try {
-      const response = await fetch(`${baseUrl}/docs/getting-started/welcome`, {
-        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-      });
-      if (response.ok) return;
-    } catch (error) {
-      lastError = String(error);
-    }
-
-    await sleep(250);
-  }
-
-  throw new Error(`Timed out waiting for preview server at ${baseUrl}. ${lastError}`.trim());
-}
-
-async function waitForExit(
-  child: ChildProcessWithoutNullStreams,
-  timeoutMs: number
-): Promise<boolean> {
-  if (child.exitCode !== null) return true;
-
-  let onExit: (() => void) | undefined;
-  const exited = await Promise.race([
-    new Promise<boolean>((resolve) => {
-      onExit = () => resolve(true);
-      child.once('exit', onExit);
-    }),
-    sleep(timeoutMs).then(() => false),
-  ]);
-
-  if (onExit) {
-    child.off('exit', onExit);
-  }
-
-  return exited;
-}
-
-async function stopServer(child: ChildProcessWithoutNullStreams) {
-  const killProcessTree = (signal: NodeJS.Signals) => {
-    const pid = child.pid;
-    if (!pid) return;
-
-    try {
-      // Detached mode creates a new process group so we can terminate npm + astro children.
-      process.kill(-pid, signal);
-    } catch {
-      child.kill(signal);
-    }
-  };
-
-  killProcessTree('SIGTERM');
-  if (!(await waitForExit(child, SHUTDOWN_TIMEOUT_MS))) {
-    killProcessTree('SIGKILL');
-    await waitForExit(child, SHUTDOWN_TIMEOUT_MS);
-  }
-
-  child.stdout.destroy();
-  child.stderr.destroy();
-}
-
 export async function startPreviewServer(): Promise<PreviewServer> {
-  await ensureBuildOutput();
-
+  const { staticRoot, redirects } = resolveBuildOutput();
   const port = await getFreePort();
   const baseUrl = `http://${PREVIEW_HOST}:${port}`;
-  const child = spawn('npm', ['run', 'preview', '--', '--host', PREVIEW_HOST, '--port', String(port)], {
-    cwd: ROOT,
-    detached: true,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env, FORCE_COLOR: '0' },
+
+  const server: Server = createServer(async (req, res) => {
+    const method = req.method ?? 'GET';
+    if (method !== 'GET' && method !== 'HEAD') {
+      res.writeHead(405, { Allow: 'GET, HEAD' }).end();
+      return;
+    }
+    const pathname = new URL(req.url ?? '/', baseUrl).pathname;
+
+    for (const redirect of redirects) {
+      if (redirect.pattern.test(pathname)) {
+        res.writeHead(redirect.status, { Location: redirect.location }).end();
+        return;
+      }
+    }
+
+    for (const candidate of candidateFiles(staticRoot, pathname)) {
+      try {
+        const body = await readFile(candidate);
+        res.writeHead(200, { 'content-type': contentTypeFor(candidate) });
+        res.end(method === 'HEAD' ? undefined : body);
+        return;
+      } catch {
+        continue;
+      }
+    }
+
+    try {
+      const notFound = await readFile(path.join(staticRoot, '404.html'));
+      res.writeHead(404, { 'content-type': 'text/html; charset=utf-8' });
+      res.end(method === 'HEAD' ? undefined : notFound);
+    } catch {
+      res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' }).end('Not found');
+    }
   });
 
-  let logs = '';
-  child.stdout.on('data', (chunk) => {
-    logs += String(chunk);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, PREVIEW_HOST, resolve);
   });
-  child.stderr.on('data', (chunk) => {
-    logs += String(chunk);
-  });
-
-  try {
-    await waitForServerReady(baseUrl, child);
-  } catch (error) {
-    await stopServer(child);
-    throw new Error(`${String(error)}\n${logs}`.trim());
-  }
 
   return {
     baseUrl,
-    close: async () => {
-      await stopServer(child);
-    },
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
   };
 }

--- a/tests/smoke/preview-server.ts
+++ b/tests/smoke/preview-server.ts
@@ -12,7 +12,7 @@
  */
 import { createServer, type Server } from 'node:http';
 import { readFile } from 'node:fs/promises';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import net from 'node:net';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -57,16 +57,29 @@ function loadRedirectRoutes(configPath: string): RedirectRoute[] {
   return redirects;
 }
 
+function mtimeOf(filePath: string): number {
+  try {
+    return statSync(filePath).mtimeMs;
+  } catch {
+    return -1;
+  }
+}
+
 function resolveBuildOutput(): BuildOutput {
   const vercelStatic = path.join(ROOT, '.vercel', 'output', 'static');
-  if (existsSync(path.join(vercelStatic, 'index.html'))) {
+  const dist = path.join(ROOT, 'dist');
+  // Both roots can exist (an adapter build followed by an MCP_ENABLED=false
+  // build, or vice versa) — serve whichever was built most recently so the
+  // smoke run always tests the current build, not a stale artifact.
+  const vercelMtime = mtimeOf(path.join(vercelStatic, 'index.html'));
+  const distMtime = mtimeOf(path.join(dist, 'index.html'));
+  if (vercelMtime >= 0 && vercelMtime >= distMtime) {
     return {
       staticRoot: vercelStatic,
       redirects: loadRedirectRoutes(path.join(ROOT, '.vercel', 'output', 'config.json')),
     };
   }
-  const dist = path.join(ROOT, 'dist');
-  if (existsSync(path.join(dist, 'index.html'))) {
+  if (distMtime >= 0) {
     return { staticRoot: dist, redirects: [] };
   }
   throw new Error(
@@ -101,11 +114,18 @@ function contentTypeFor(filePath: string): string {
 
 /** Map a request pathname to candidate files inside the static root. */
 function candidateFiles(staticRoot: string, pathname: string): string[] {
-  const decoded = decodeURIComponent(pathname);
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    return []; // malformed percent-encoding → 404, not an unhandled rejection
+  }
   const safe = path.normalize(decoded).replace(/^(\.\.[/\\])+/, '');
   const base = path.join(staticRoot, safe);
   if (!base.startsWith(staticRoot)) return [];
-  if (path.extname(safe) !== '') return [base];
+  // Try both interpretations regardless of a dot in the last segment: a route
+  // like /reference/v1.2 is a directory with an index.html, not a file.
+  if (path.extname(safe) !== '') return [base, path.join(base, 'index.html')];
   return [path.join(base, 'index.html'), base];
 }
 
@@ -128,9 +148,9 @@ function getFreePort(): Promise<number> {
   });
 }
 
-export async function startPreviewServer(): Promise<PreviewServer> {
+export async function startPreviewServer(options: { port?: number } = {}): Promise<PreviewServer> {
   const { staticRoot, redirects } = resolveBuildOutput();
-  const port = await getFreePort();
+  const port = options.port ?? (await getFreePort());
   const baseUrl = `http://${PREVIEW_HOST}:${port}`;
 
   const server: Server = createServer(async (req, res) => {

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -256,16 +256,18 @@ test('website routes are canonicalized to /, /meet, and /pricing', async () => {
   assert.equal(pricing.status, 200);
   assert.match(await pricing.text(), /Pricing/);
 
-  const aliases = ['/use-cases', '/faq', '/api-reference'];
-  for (const alias of aliases) {
+  // Alias → canonical destination (see the `redirects` map in astro.config.mjs;
+  // /api-reference points at the API reference, not the homepage).
+  const aliases: Record<string, string> = { '/use-cases': '/', '/faq': '/', '/api-reference': '/api/' };
+  for (const [alias, destination] of Object.entries(aliases)) {
     const aliasResponse = await fetch(`${preview.baseUrl}${alias}`, { redirect: 'manual' });
     if (aliasResponse.status >= 300 && aliasResponse.status < 400) {
-      assert.equal(aliasResponse.headers.get('location'), '/');
+      assert.equal(aliasResponse.headers.get('location'), destination, `Alias ${alias}`);
       continue;
     }
     assert.equal(aliasResponse.status, 200);
     const body = await aliasResponse.text();
-    assert.match(body, /Redirecting to: \//);
+    assert.match(body, new RegExp(`Redirecting to: ${escapeRegExp(destination)}`), `Alias ${alias}`);
   }
 });
 
@@ -390,15 +392,24 @@ test('website markdown endpoints are available for agent-friendly content', asyn
 });
 
 test('website compatibility routes redirect to canonical destinations', async () => {
-  const rootAliases = ['/home', '/use-cases', '/faq', '/api-reference', '/page', '/wtd', '/hn'];
-  for (const alias of rootAliases) {
+  // Alias → canonical destination (see the `redirects` map in astro.config.mjs).
+  const rootAliases: Record<string, string> = {
+    '/home': '/',
+    '/use-cases': '/',
+    '/faq': '/',
+    '/api-reference': '/api/',
+    '/page': '/',
+    '/wtd': '/',
+    '/hn': '/',
+  };
+  for (const [alias, destination] of Object.entries(rootAliases)) {
     const response = await fetch(`${preview.baseUrl}${alias}`, { redirect: 'manual' });
     if (response.status >= 300 && response.status < 400) {
-      assert.equal(response.headers.get('location'), '/');
+      assert.equal(response.headers.get('location'), destination, `Alias ${alias}`);
       continue;
     }
     assert.equal(response.status, 200);
     const body = await response.text();
-    assert.match(body, /Redirecting to: \//);
+    assert.match(body, new RegExp(`Redirecting to: ${escapeRegExp(destination)}`), `Alias ${alias}`);
   }
 });

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { after, before, test } from 'node:test';
 import { startPreviewServer, type PreviewServer } from './preview-server';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 let preview: PreviewServer;
 
@@ -412,4 +417,25 @@ test('website compatibility routes redirect to canonical destinations', async ()
     const body = await response.text();
     assert.match(body, new RegExp(`Redirecting to: ${escapeRegExp(destination)}`), `Alias ${alias}`);
   }
+});
+
+test('adapter build wires the /mcp route to the render function (ADR 0007)', (t) => {
+  // Only meaningful for adapter builds; MCP_ENABLED=false static builds have no
+  // serverless function by design.
+  const configPath = path.join(REPO_ROOT, '.vercel', 'output', 'config.json');
+  if (!existsSync(configPath)) {
+    t.skip('No .vercel/output/config.json — static (MCP_ENABLED=false) build.');
+    return;
+  }
+  const config = JSON.parse(readFileSync(configPath, 'utf8')) as {
+    routes?: Array<{ src?: string; dest?: string }>;
+  };
+  const mcpRoute = (config.routes ?? []).find(
+    (route) => route.src && route.dest && new RegExp(route.src).test('/mcp')
+  );
+  assert.ok(mcpRoute, 'Expected a config.json route mapping /mcp to a function.');
+  assert.ok(
+    existsSync(path.join(REPO_ROOT, '.vercel', 'output', 'functions', `${mcpRoute.dest}.func`)),
+    `Expected the ${mcpRoute.dest} serverless function to exist in the build output.`
+  );
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,6 @@
     },
     "resolveJsonModule": true
   },
-  "include": [".astro/types.d.ts", "src/**/*", "scripts/**/*", "astro.config.mjs"],
+  "include": [".astro/types.d.ts", "src/**/*", "scripts/**/*", "packages/**/*", "astro.config.mjs"],
   "exclude": ["dist", "fern", "node_modules"]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -170,7 +170,7 @@
     },
     {
       "source": "/api-reference",
-      "destination": "/",
+      "destination": "/api/",
       "permanent": true
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "outputDirectory": "dist",
   "rewrites": [
     { "source": "/report/:slug", "destination": "/report" }
   ],


### PR DESCRIPTION
## Summary

Ports the Starport template's `starlight-mcp` plugin into this repo (the "later attempt" deferred in ADR 0004) and enables it behind `MCP_ENABLED` with the `@astrojs/vercel` adapter. The docs are now searchable/readable by AI clients over Streamable HTTP at `/mcp` (`search` + `get_page` tools, `llms.txt` resource). Only the `/mcp` route is rendered on demand — the rest of the site stays static, and `MCP_ENABLED=false` restores today's fully static, adapter-less build.

Full decision record: `docs/starport-migration/adrs/0007-docs-mcp-server.md`.

## Bugs remediated during the port

- **Frontmatter `slug:` support (the port blocker).** Every docs page here sets an explicit slug, which Starlight uses verbatim as the route; the template's index builder derived routes from file location only, so all 66 pages carried wrong paths/URLs and `get_page` could never match. The builder now honors `slug` (incl. locale-prefixed), with regression tests.
- **`get_page` output quality:** leading MDX `import` block stripped; no duplicated H1 when the body opens with its own heading.
- Stale `astro ^6` peer range → `^6 || ^7`.

## Code-review findings fixed (adversarial review, 8 angles)

- **`vercel.json` redirected `/api-reference` → `/`** while astro.config and the smoke tests say `/api/`; the platform rule wins in production, so prod contradicted green CI. Aligned to `/api/`.
- One malformed frontmatter file no longer **empties the entire MCP index** (skipped per-file instead of aborting the walk).
- `get_page` with duplicate leading slashes (`//welcome/`) no longer parses as a protocol-relative URL and misses.
- Smoke preview server: malformed percent-encoding → clean 404 (was an unhandled rejection/hang); dotted directory routes fall back to `index.html`; serves the **newer** of `.vercel/output/static` vs `dist` instead of a stale artifact.
- `npm run preview` no longer a broken trap (`astro preview` errors under the adapter) — now serves the last build via the smoke harness.
- New smoke test asserts the adapter build actually **wires `/mcp` to the render function**.

Not fixed, deliberate: template-parity tradeoffs in the vendored package (per-request server construction, `text`+`markdown` both inlined) — kept aligned with upstream for cheap re-syncs; backport of the fixes to starport-template is queued separately.

## Deploy-shape changes

- Build now emits Build Output API artifacts (`.vercel/output/`): static site + one `_render` function serving only `/mcp`; astro-config redirects become platform 301s instead of meta-refresh stub pages.
- `vercel.json` `outputDirectory: "dist"` removed (BOA is the artifact with the adapter; the Astro preset defaults to `dist` without it).

## Verification

- 21 MCP contract/index tests, 15 smoke tests (both `MCP_ENABLED` modes), `astro check` clean, docmeta 66/66.
- `/mcp` exercised end-to-end against `astro dev`: initialize, `tools/list`, `search`, `get_page` (incl. slug-override page), `resources/read`.
- Preview harness probed live: pages 200, `/api-reference` → 301 `/api/`, `/%zz` → 404.

## ⚠️ Check on the Vercel preview deploy (not provable locally)

1. **Root Routing Middleware still runs**: `curl -H 'Accept: text/markdown' <preview>/docs/start-here/welcome` should return Markdown, not HTML.
2. **`vercel.json` host redirects still apply** (docs.promptless.ai → promptless.ai).
3. **`/mcp` responds**: `curl -X POST <preview>/mcp -H 'content-type: application/json' -H 'accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`.
4. Project settings sanity: framework preset should be **Astro** (relevant if `MCP_ENABLED=false` is ever used, since `outputDirectory` is no longer pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)