### PR TITLE
content: API Documentation Automation: What It Fixes and What It Doesn't

### DIFF
--- a/src/content/blog/technical/api-documentation-automation.mdx
+++ b/src/content/blog/technical/api-documentation-automation.mdx
@@ -1,0 +1,71 @@
+---
+title: 'API Documentation Automation: What It Fixes and What It Doesn''t'
+subtitle: Published July 2026
+description: >-
+  API documentation automation works only as well as the spec it reads from. Here's what teams get wrong and what actually solves it.
+date: '2026-07-17T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer opens your SDK reference page. The `authorize()` call shows `api_key` as a required parameter. In production, it's been `api_token` for three months. The parameter was renamed in a refactor. The OpenAPI spec was updated by the backend team. The documentation site was never regenerated.
+
+The automation was running. The spec was stale.
+
+This is the most common way API documentation automation fails: not because the tooling broke, but because the input to the tooling drifted. Most of the conversation about API doc automation focuses on generation. The harder problem is the accuracy of what you're generating from.
+
+## What automation actually solves
+
+Every major documentation platform today generates API reference pages from OpenAPI specs. Mintlify, ReadMe, Redocly, Fern: they all take a spec file and produce formatted, searchable reference documentation. This is genuinely useful. Writing API reference documentation by hand is slow and inconsistent. A well-maintained spec produces a better reference page than most technical writers have time to write manually.
+
+The tooling has also gotten better at the generation step. Several platforms now produce code examples in multiple languages, integrate with SDK generators like Speakeasy, auto-generate `llms.txt` files for AI-friendly access, and sync documentation through PR-based workflows. [64% of developers now use AI for writing documentation](https://writechoice.io/blog/5-best-api-documentation-tools-for-2026-ranked-by-roi). The generation problem, in terms of tooling availability, is largely solved.
+
+The problem that remains is the spec.
+
+## The spec-to-runtime gap
+
+The Fern team, which builds tooling for API docs and SDK generation, describes it plainly: "The biggest source of pain in OpenAPI tooling is the gap between your spec and your runtime."
+
+Specs drift from reality for predictable reasons. An engineer renames a field, updates the code, and ships it. Updating the spec requires a different workflow: edit the YAML, validate the schema, run a linter, open a PR in the docs repository. When the release deadline is Thursday, the spec update happens Friday. Or Monday. Or when a developer files a ticket three weeks later.
+
+[Postman's 2024 State of the API report](https://www.postman.com/state-of-api/2024) found that 88% of companies troubleshoot API issues on a weekly basis, and 68% of developers cite outdated documentation as their top frustration. Teams that have automated their documentation generation still produce these numbers. What they automated was output quality. They didn't automate input accuracy.
+
+This is [the drift problem](https://promptless.ai/blog/technical/documentation-drift-detection-problem) in a specific form: the gap between what the spec says and what the API actually does, rather than the gap between what the docs say and what the product does. Automation moves the problem upstream without eliminating it.
+
+<BlogNewsletterCTA />
+
+## What closes the loop
+
+Teams that have actually solved spec drift share one characteristic: they treat the OpenAPI spec as an engineering artifact, not a documentation artifact.
+
+In practice, this means the spec lives in the main application repository alongside the code that implements it. Changes to API behavior require changes to the spec in the same PR. A CI step validates that the spec accurately describes actual API responses, either through contract testing or automated spec linting that fails the build on inconsistency. The documentation site regenerates automatically when the spec changes.
+
+This is more friction than most teams start with, and it is appropriate friction. A spec that requires a PR to update is a spec that gets reviewed before the documentation it generates becomes authoritative.
+
+Several tools have built toward this model. Mintlify's Automations agent monitors pull requests and drafts update suggestions when it detects documentation-relevant changes. Speakeasy regenerates SDKs and reference docs from a single spec file on every merge to main. Fern produces SDKs and API reference pages from the same OpenAPI file, so any spec update propagates to all generated artifacts together.
+
+The specifics vary by team. The common thread is that spec accuracy gets enforced mechanically, not by hoping the developer opens the docs repository after they ship.
+
+## The writer's job in an automated pipeline
+
+The role of the technical writer does not disappear when generation is automated. It shifts.
+
+Generating accurate reference documentation from an accurate spec is something automation handles well. Writing the context around it requires someone who understands the product. What problem does this endpoint solve? What does this error code mean when it appears in production at 2am? These questions require domain knowledge, not just spec access.
+
+The 2025 WriteChoice survey of technical communicators found that [55% now use AI regularly or semi-regularly](https://instrktiv.com/en/ai-in-technical-writing/), with the role shifting toward reviewing and curating generated output rather than producing first drafts. For API documentation specifically, this means reviewing spec changes before they propagate into production docs and vetting AI-generated descriptions for accuracy. The writing work shifts toward conceptual guides and quickstarts that reference pages don't provide.
+
+The [changelog communication problem](https://promptless.ai/blog/technical/api-changelog-best-practices) is adjacent: automation can detect that a parameter changed, but deciding how to communicate that change to developers who depend on it is still a judgment call. Which integrations break? Does this need a migration guide or a one-line note? Automation flags the change. Someone still has to decide what the developer needs to know about it.
+
+## What to actually expect
+
+Automation eliminates the mechanical work of formatting and publishing reference documentation. It does not eliminate the work of keeping the spec accurate or writing the context that reference docs cannot provide on their own.
+
+Teams that treat automation as a way to solve the documentation problem end up with automatically generated wrong documentation. Teams that treat it as a force multiplier on a properly maintained spec end up with high-quality reference pages that stay current with the product.
+
+The distinction comes down to where the spec lives and who is responsible for it. A spec maintained as a documentation artifact (updated when someone remembers) will drift, and automation will propagate that drift at scale. A spec maintained as an engineering artifact (updated in the same PR as the code, validated by CI) gives automation accurate inputs to work with.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `API documentation automation`

## Article plan

**Thesis:** API documentation automation is only as accurate as the spec it reads from. Teams that treat the OpenAPI spec as an engineering artifact (in-repo, CI-enforced) solve drift; teams that treat it as a documentation artifact don't.

**Target reader:** Technical writers and DevRel engineers who have adopted OpenAPI-based generation but still fight inaccurate docs.

**Key points:**
1. Generation tooling is table-stakes (Mintlify, ReadMe, Fern, etc.) — 64% of developers use AI for docs, the tooling is solved
2. 88% of companies still troubleshoot API issues weekly; 68% cite outdated docs as top frustration — automation didn't fix accuracy
3. The root cause is spec-to-runtime gap: specs drift when code ships without spec updates
4. What closes the loop: spec-as-engineering-artifact with CI enforcement + PR-based review (Speakeasy, Fern, Mintlify Automations)
5. The writer's role shifts from drafting reference docs to reviewing spec changes and writing narrative content

**Promptless connection:** Drift detection surfaces when spec accuracy falls behind code behavior — the same pattern Promptless monitors across documentation broadly.

## File

`src/content/blog/technical/api-documentation-automation.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Fkg2wzB1cYgqPS616w2xt)_