### PR TITLE
content: Launch post — Promptless Now Alerts You When an Integration Has a Problem

### DIFF
--- a/src/content/blog/product-updates/integration-health-alerts.mdx
+++ b/src/content/blog/product-updates/integration-health-alerts.mdx
@@ -1,0 +1,51 @@
+---
+title: 'Promptless Now Alerts You When an Integration Has a Problem'
+subtitle: Published July 2026
+description: >-
+  Promptless now notifies your escalation channel when a connected integration breaks, so a failed connection doesn't silently stall your documentation pipeline.
+date: '2026-07-14T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Promptless now alerts you when a connected integration develops a problem. A broken connection no longer fails silently.
+
+## The problem
+
+When a Promptless integration breaks, documentation suggestions stop generating for any doc collection that depends on it. Before this change, there was no outbound signal. You'd find out when a teammate noticed docs hadn't updated, or when you checked the dashboard after days of silence. The gap between failure and discovery could stretch to a week, and the recovery work grows with every day the connection stays broken.
+
+A lot can break an integration: an access token expires, a Slack workspace revokes a permission, a third-party provider has an outage. None of these are unusual. All of them are fixable quickly if you know about them.
+
+## What changed
+
+Promptless now monitors each connected integration's health and sends a notification to your organization's configured escalation channels (Slack, Microsoft Teams, and/or email) when a connection develops a problem. The message names the specific integration and lists the doc collections that can no longer be updated.
+
+The alert logic distinguishes two states:
+
+**Needs reconnect** fires immediately when Promptless detects that an integration requires action, such as expired credentials or a revoked permission. You get one notification when the problem is first detected.
+
+**Temporary outage** fires only if the problem persists for more than 24 hours. Short provider blips resolve on their own without generating noise. If a temporary outage escalates to a reconnect requirement, Promptless sends a follow-up.
+
+In both cases, you get one notification per problem, not one per day. Each message includes a reconnect link so the recipient can act without navigating to the Integrations page themselves.
+
+<BlogNewsletterCTA />
+
+## Who benefits most
+
+Teams where the person who configured an integration isn't actively checking the dashboard. That's most teams. A developer sets up the GitHub connection during onboarding. If the auth token expires two months later, nothing in their normal workflow surfaces it. This change pushes that signal rather than waiting for someone to notice.
+
+It's also useful for teams with documentation freshness requirements. A broken integration is an undetected documentation gap. Every day it goes unresolved is another day of code changes that won't be picked up. Catching the failure in hours instead of days limits how far things drift.
+
+## Setup
+
+Notifications go to your organization's escalation channels. Configure those in Organization Settings under Notification channels. If you haven't set one up, that's the only required step.
+
+Once escalation channels are configured, integration health monitoring runs automatically. There's no per-integration opt-in.
+
+The Integrations page also shows a health badge for each connected service at any time. The alerts are the push signal when something breaks. The Integrations page is the pull view when you want to confirm the current state.
+
+<BlogRequestDemo />

--- a/src/content/blog/product-updates/integration-health-alerts.mdx
+++ b/src/content/blog/product-updates/integration-health-alerts.mdx
@@ -22,7 +22,7 @@ Integrations break for ordinary reasons, like an expired access token or a revok
 
 ## What changed
 
-Promptless now monitors the health of each connected integration. When a connection develops a problem, Promptless sends a notification to your organization's configured escalation channels. Escalation channels can be Slack, Microsoft Teams, or email. The message names the specific integration. It also lists the doc collections that can no longer update.
+Promptless now monitors the health of each connected integration. When a connection develops a problem, Promptless sends a notification to your organization's configured escalation channels. Escalation channels can be Slack, Microsoft Teams, email, or any combination of these. The message names the specific integration. It also lists the doc collections that can no longer update.
 
 Promptless uses two alert states.
 

--- a/src/content/blog/product-updates/integration-health-alerts.mdx
+++ b/src/content/blog/product-updates/integration-health-alerts.mdx
@@ -16,36 +16,36 @@ Promptless now alerts you when a connected integration develops a problem. A bro
 
 ## The problem
 
-When a Promptless integration breaks, documentation suggestions stop generating for any doc collection that depends on it. Before this change, there was no outbound signal. You'd find out when a teammate noticed docs hadn't updated, or when you checked the dashboard after days of silence. The gap between failure and discovery could stretch to a week, and the recovery work grows with every day the connection stays broken.
+When a Promptless integration breaks, documentation suggestions stop generating for any doc collection that depends on it. Before this change, there was no outbound signal. A teammate might notice the docs had not updated. Or you might discover the problem when you checked the dashboard after days of silence. The gap between failure and discovery could stretch to a week. Recovery work grows with every day the connection stays broken.
 
-A lot can break an integration: an access token expires, a Slack workspace revokes a permission, a third-party provider has an outage. None of these are unusual. All of them are fixable quickly if you know about them.
+Integrations break for ordinary reasons, like an expired access token or a revoked Slack permission. A third-party provider can also have an outage. These problems are common and easy to fix once you notice them.
 
 ## What changed
 
-Promptless now monitors each connected integration's health and sends a notification to your organization's configured escalation channels (Slack, Microsoft Teams, and/or email) when a connection develops a problem. The message names the specific integration and lists the doc collections that can no longer be updated.
+Promptless now monitors the health of each connected integration. When a connection develops a problem, Promptless sends a notification to your organization's configured escalation channels. Escalation channels can be Slack, Microsoft Teams, or email. The message names the specific integration. It also lists the doc collections that can no longer update.
 
-The alert logic distinguishes two states:
+Promptless uses two alert states.
 
-**Needs reconnect** fires immediately when Promptless detects that an integration requires action, such as expired credentials or a revoked permission. You get one notification when the problem is first detected.
+**Needs reconnect** fires immediately when Promptless detects that an integration needs action, such as expired credentials or a revoked permission. You get one notification when Promptless first detects the problem.
 
-**Temporary outage** fires only if the problem persists for more than 24 hours. Short provider blips resolve on their own without generating noise. If a temporary outage escalates to a reconnect requirement, Promptless sends a follow-up.
+**Temporary outage** fires only if the problem lasts more than 24 hours. Short outages usually resolve on their own. Promptless does not send an alert for those. If a temporary outage turns into a reconnect requirement, Promptless sends a follow-up alert.
 
-In both cases, you get one notification per problem, not one per day. Each message includes a reconnect link so the recipient can act without navigating to the Integrations page themselves.
+In both cases you get one notification per problem. Promptless does not send a new notification every day the problem continues. Each message includes a reconnect link. You can act on it without opening the Integrations page first.
 
 <BlogNewsletterCTA />
 
 ## Who benefits most
 
-Teams where the person who configured an integration isn't actively checking the dashboard. That's most teams. A developer sets up the GitHub connection during onboarding. If the auth token expires two months later, nothing in their normal workflow surfaces it. This change pushes that signal rather than waiting for someone to notice.
+This feature helps teams most when the person who configured an integration isn't checking the dashboard. That describes most teams. A developer sets up the GitHub connection during onboarding. The auth token expires two months later. Nothing in the developer's normal workflow reveals the problem. This alert sends that signal instead of waiting for someone to notice.
 
-It's also useful for teams with documentation freshness requirements. A broken integration is an undetected documentation gap. Every day it goes unresolved is another day of code changes that won't be picked up. Catching the failure in hours instead of days limits how far things drift.
+This feature also helps teams with documentation freshness requirements. A broken integration creates an undetected documentation gap. Each unresolved day adds more undocumented code changes. Catching the failure in hours instead of days limits the drift.
 
 ## Setup
 
-Notifications go to your organization's escalation channels. Configure those in Organization Settings under Notification channels. If you haven't set one up, that's the only required step.
+Notifications go to your organization's escalation channels. Configure escalation channels in Organization Settings, under Notification channels. If you haven't configured one, this is the only required step.
 
-Once escalation channels are configured, integration health monitoring runs automatically. There's no per-integration opt-in.
+Once you configure escalation channels, integration health monitoring runs automatically. There's no per-integration opt-in.
 
-The Integrations page also shows a health badge for each connected service at any time. The alerts are the push signal when something breaks. The Integrations page is the pull view when you want to confirm the current state.
+The Integrations page also shows a health badge for each connected service at any time. The alert notifies you automatically when something breaks. The Integrations page shows the current status when you check it yourself.
 
 <BlogRequestDemo />


### PR DESCRIPTION
## Feature
Promptless now notifies your escalation channel when a connected integration breaks, so a failed connection doesn't silently stall your documentation pipeline.

## Entries considered this run

Window: 2026-07-13 → 2026-07-20.

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **Proactive alerts when an integration needs attention** — Promptless now notifies you when a connected integration develops a problem. Notifications go to your organization's configured escalation channel (Slack, Microsoft Teams, and/or email). Needs reconnect notifies immediately; Temporary outage notifies only after 24h+ persistence. One notification per problem. Names impacted doc collections. | QUALIFIES | Significantly improves UX for users with connected integrations: replaces silent pipeline failure with proactive, timely alerts. Adds substantial new capability (outbound integration health monitoring with tiered severity logic). |

1 commit in window. 1 entry considered, 1 qualified.

## Covered entry (full text)

> **Proactive alerts when an integration needs attention:** Promptless now notifies you when a connected integration develops a problem, so a broken connection doesn't quietly stall your documentation. Notifications go to your organization's configured escalation channel—Slack, Microsoft Teams, and/or email. A **Needs reconnect** state notifies you as soon as it's detected, while a **Temporary outage** notifies only once it persists for more than 24 hours, so brief provider blips clear on their own. You get one notification per problem rather than daily repeats. Clearly names any impacted doc collections that can no longer be updated. See [Integrations](/docs/reference/integrations#connection-health).

Source: commit [38b5821](https://github.com/Promptless/promptless.ai/commit/38b5821fd370960fba82e8f3bc9391914e98c404) (PR #742).

## PR(s) researched
- Promptless/promptless#4046 — Notify customers when a prod integration degrades (referenced in docs PR #741 body)

## File
`src/content/blog/product-updates/integration-health-alerts.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpNvyit6W6N4NMVNWVfPcQ)_