### PR TITLE
content: Translated Developer Docs Have a Drift Problem Your English Docs Don't

### DIFF
--- a/src/content/blog/technical/documentation-translations-drift.mdx
+++ b/src/content/blog/technical/documentation-translations-drift.mdx
@@ -1,0 +1,71 @@
+---
+title: 'Translated Developer Docs Have a Drift Problem Your English Docs Don''t'
+subtitle: Published July 2026
+description: >-
+  Every English doc update opens a gap in every translated version. Most teams have no system to detect or close those gaps. Here's how translation drift compounds.
+date: '2026-07-20T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer in São Paulo opens your quickstart guide, follows the authentication steps, and hits an error. The Portuguese translation still shows the old token format. The English version was updated three months ago. They have no way to know this, because the translated page reads fluently and confidently.
+
+They open a support ticket. Or they close the tab.
+
+This is translation drift: the gap that opens between your source documentation and its translations every time the source changes. It's a specific version of [documentation drift](/blog/technical/documentation-drift-detection-problem), and it's worse in one important way: it has no automatic signal. English pages go stale silently, but at least your team reads English. Translated pages can sit wrong for months before anyone who notices also knows to report it.
+
+## The developer market is not English-first
+
+Shipping translated documentation is not optional for developer-facing companies at scale. English accounts for roughly 25% of internet users. If your product serves developers globally through a public API, an SDK, or a self-service developer platform, the majority of your potential developer audience works in another language.
+
+That doesn't mean every team needs to translate into every language. But for companies that have invested in translation, the investment is wasted if the translated content is stale. A developer who hits a broken integration from an outdated translated guide doesn't switch to the English docs and keep going. [Research finds that roughly 50% of developers abandon an API](https://userguiding.com/blog/user-onboarding-statistics) when documentation fails them. The translated guide doesn't just fail that developer. It fails every developer who hits the same wall until someone fixes it.
+
+## Why translated docs drift faster
+
+The English documentation problem is hard enough. A parameter gets renamed. An authentication flow changes. The source code ships before the writer catches up, or the writer catches up but the docs review got skipped in the sprint rush. [The Postman 2024 State of the API report](https://www.postman.com/state-of-api/2024), which surveyed over 5,600 developers, found that 68% cite outdated documentation as their top frustration when working with APIs.
+
+Translation adds a second layer. Every update to an English page creates a gap in every translated version of that page. If you have documentation in five languages and ship a significant product update, you've now created at least five documentation gaps. The translator — whether human or machine — has to be notified, review the diff, retranslate the affected sections, get the new content reviewed, and push it live. That pipeline takes time. In most teams, it takes long enough that the next product update arrives before the previous translation catches up.
+
+The compounding effect is what makes this different from standard docs maintenance. A single unresolved English drift issue affects one page. A single unresolved English source change potentially creates multiple simultaneous drift issues across all translated versions, each with its own resolution timeline. The [documentation debt](/blog/technical/documentation-debt-accrues-where-your-team-cant-see-it) that results is invisible: translated pages look correct, return no errors, and mislead users without any signal to the team.
+
+<BlogNewsletterCTA />
+
+## The versioning gap nobody tracks
+
+The structural problem underneath this is metadata. Most translated documentation pages carry no record of which version of the English source they reflect.
+
+This is the contrast with code. A branch or release tag tells you exactly which state of the codebase it represents. You can diff two versions and see what changed. With translated documentation, you typically have the current English version and the current translated version, and no machine-readable way to know when they last matched.
+
+Without that metadata, you can't automate staleness detection. You can't build a view showing which translated pages are out of sync. You can't programmatically generate a queue of pages that need retranslation. You're left comparing pages manually, or waiting for a support ticket to surface a discrepancy.
+
+For teams with documentation in three or four languages and hundreds of pages each, manual tracking is not a real strategy. It's why translation drift accumulates undetected.
+
+## What a continuous localization pipeline requires
+
+The underlying problem is treating translations as one-time outputs rather than versioned assets that track against their source. The operational model that works treats translated pages the way version control treats branches: each translation is a derivative of a specific source state, and the gap between the translation's source state and the current source is the staleness indicator.
+
+The practical implementation has a few components:
+
+**Source change detection.** When an English doc page changes, the pipeline needs to know — specifically which content changed, not just that a commit happened. A docs-as-code setup with git makes this feasible: the diff between versions is machine-readable. The harder part is surfacing it in a way a translation workflow can consume.
+
+**Translation queue management.** Changes feed into a queue, tagged by page, source version, and change type. A minor wording fix is lower priority than a changed code sample or a renamed parameter. Treating all changes as equivalent wastes translator time on low-stakes updates while higher-stakes gaps wait.
+
+**Source-version stamping.** Each translated page should carry metadata indicating which version of the English source it reflects. This makes staleness computable rather than estimated.
+
+**Diff-based retranslation.** When a source page changes significantly, translators should receive a structured diff — not the full page for retranslation, but the specific sections that changed. A 2024 Forrester study found that AI-assisted translation reduced overall translation workload by 50% for organizations using it in production. Human post-editing of machine-translated diffs is faster than translating from scratch, which matters when you're handling continuous change rather than one-time projects.
+
+## The prerequisite that comes before translation
+
+None of this works if the English source is already wrong.
+
+Translation pipelines assume the source is accurate. If your English quickstart has drifted from the current product behavior, running it through a translation pipeline doesn't fix the error. It distributes the error into more languages. Teams sometimes discover their English docs have been inaccurate for months precisely because a non-English speaker reported a problem in a translated version that turned out to exist in the original.
+
+Getting translated documentation right starts with maintaining the English source. That means continuous monitoring of documentation against the actual product: watching for API changes, renamed fields, deprecated endpoints, and revised flows, and surfacing those gaps before they propagate.
+
+Promptless monitors your documentation against your codebase and product continuously, flagging gaps and outdated content before they reach users. For teams managing translated documentation, that's the foundation: an accurate English source is the only thing worth translating.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `documentation translations`

## Article plan

**Target keywords:** documentation translations, translation drift

**Thesis:** Every English doc update opens a gap in every translated version. Most teams have no system to detect or close those gaps.

**Target reader:** Technical writers and DevRel engineers at developer-facing companies managing multilingual documentation.

**Key points:**
1. English is only ~25% of internet users — the developer market is global and non-English-first
2. Translation creates a second drift layer: every English update creates gaps in all translated versions simultaneously
3. Translated pages carry no source-version metadata, making staleness undetectable without manual comparison
4. Continuous localization requires source change detection, diff-based queues, and source-version stamping
5. An accurate English source is the prerequisite for translation — stale source docs distribute errors into more languages

**Promptless connection:** Keeping the English source accurate is the foundation of any translation pipeline. Promptless monitors docs against the codebase continuously, ensuring what gets translated is worth translating.

## File

`src/content/blog/technical/documentation-translations-drift.mdx`

---

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsePLXhzCuBKm5C7FDqdVN)_