### PR TITLE
content: Why Developer Education Content Breaks Faster Than Reference Docs

### DIFF
--- a/src/content/blog/technical/developer-education-content-maintenance.mdx
+++ b/src/content/blog/technical/developer-education-content-maintenance.mdx
@@ -1,0 +1,86 @@
+---
+title: 'Why Developer Education Content Breaks Faster Than Reference Docs'
+subtitle: Published July 2026
+description: >-
+  Teams invest heavily in tutorials but rarely budget for maintaining them. Here's why developer education content drifts faster than reference docs.
+date: '2026-07-22T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer advocate at a mid-size API company ships a tutorial series in Q1: six articles, twelve code samples, a sample app on GitHub. The launch goes well. Search rankings improve. The DevRel team moves on to conference season.
+
+By Q3, the tutorial is generating more support tickets than the reference docs.
+
+This pattern is common. It has a specific cause that most teams overlook when planning developer education programs.
+
+## Reference Docs Fail Locally. Tutorials Fail Completely.
+
+When a parameter gets renamed and the reference docs don't reflect it, a developer hits a single bad page. They note the discrepancy, file a ticket, or find the right value in another way. The failure is local.
+
+When that same renamed parameter appears in step 3 of an 8-step tutorial, everything from step 3 onward fails. The developer doesn't know if step 4 would have worked. They don't know if they made an error or if the tutorial is wrong. The failure is complete.
+
+This is the structural difference between reference documentation and educational content. Reference docs have local failures. Tutorials have cascade failures.
+
+A misnamed endpoint in an API reference is an inconvenience. The same error inside a tutorial that a developer is following end-to-end is a dead end. The [Postman State of the API 2024](https://www.postman.com/state-of-api/2024) found that 73% of developers cite poor or incomplete documentation as the primary obstacle to API integration. A significant fraction of that friction comes from tutorials that were accurate at launch and drifted in the months after.
+
+## Why Educational Content Drifts Faster
+
+Most developer education content is a snapshot. A tutorial captures the product's state at the time of writing: which endpoints existed and what each one required. Reference documentation updates more frequently because someone has to notice when the spec is wrong. Tutorials update when someone notices the tutorial is broken, which usually requires a developer to tell you. [Documentation drift](/blog/technical/documentation-drift-detection-problem) is well-understood for API references. For tutorial content, it's even less visible.
+
+Educational content also contains more surface area for drift. A tutorial includes:
+
+- Working code samples (which break when APIs change)
+- Screenshots or UI references (which break when the interface changes)
+- Setup instructions (which break when dependencies update)
+- Links to other content (which break when that content is moved or removed)
+
+Any one of these can invalidate the tutorial without the tutorial's text changing at all. A code sample that no longer compiles will fail silently in the repository until someone runs it.
+
+<BlogNewsletterCTA />
+
+## The Budget Mismatch
+
+Developer education programs tend to launch with a creation budget. Design, writing, video production, and interactive demo tooling: all funded. Maintenance budgets for the same content are rare. When they exist, they're a fraction of what the creation budget was.
+
+The ratio should be roughly equal for technical content. A tutorial requires ongoing testing against each product release, prompt updates when dependencies shift, and periodic re-evaluation of whether the use case it demonstrates still reflects how developers are actually using the product. Treating that as zero-cost maintenance produces the pattern above: impressive launch, slow degradation, spike in support tickets.
+
+[Stripe](https://stripe.com/docs) and [Twilio](https://www.twilio.com/docs) are often cited as developer education benchmarks. Both treat tutorials as maintained products, not published artifacts. Stripe's code samples have automated tests that run against the live API. Twilio builds tutorial updates into their release process as a named deliverable alongside the API changes that would break them.
+
+Most companies don't do this. They publish the tutorial, move on, and discover the breakage when developers complain.
+
+## What Sustainable Developer Education Requires
+
+### Test code samples against every release
+
+Any code sample that runs is executable documentation. It should be treated like product code: tested in CI, updated when the test fails, blocked from merging if the sample breaks. This is technically straightforward but requires treating the education repository as a first-class code artifact.
+
+The alternative is to discover broken code samples from developer feedback. That's a slower, more expensive feedback loop.
+
+### Track which tutorials exist for which product surfaces
+
+Documentation coverage (whether every major product surface has accurate documentation) applies to tutorials as much as to reference docs. A map of which tutorials cover which API endpoints, SDK methods, or product flows makes it possible to flag that a tutorial needs updating when the relevant product surface changes.
+
+Without this map, tutorial maintenance is reactive. With it, you can catch the gap before a developer does.
+
+### Build tutorial reviews into the release process
+
+For each release that changes an API, someone should own the question: which tutorials reference endpoints or behaviors that this release changes? That question should be answered before the release ships, not after the next round of support tickets arrives.
+
+This is an ownership question as much as a tooling one. The [Port.io 2025 State of Internal Developer Portals](https://www.port.io/blog/developer-onboarding-checklist) found that only 6% of engineers update documentation daily. Tutorials fall further down the priority list than reference docs. Making tutorial review an explicit release task changes the default.
+
+## The Attribution Problem
+
+When a developer hits a broken tutorial, they rarely conclude that the tutorial is outdated. More often, they conclude that the API is unreliable or the product is difficult to use.
+
+This attribution makes tutorial drift particularly damaging. A company can have a well-maintained API reference and a library of tutorials that has quietly degraded, and the developer experience data will show the degraded tutorials as a product quality problem rather than a documentation maintenance problem.
+
+Research consistently estimates that around [50% of developers abandon an API](https://userguiding.com/blog/user-onboarding-statistics) when documentation fails them. That abandonment doesn't generate support tickets. It generates silence, which looks like success until someone audits activation data carefully.
+
+Developer education programs work when the content is accurate. The investment in creating that content produces returns proportional to how long the content stays accurate. That depends entirely on whether someone has a budget and a process for maintaining it.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer education`

## Article plan

**Format:** Problem-framing explainer showing why tutorial content breaks differently than reference documentation, with concrete maintenance patterns for DevRel teams.

**Thesis:** Developer education programs fail not at launch but in the months after, because maintaining tutorial content requires a fundamentally different system than maintaining documentation.

**Target reader:** Developer advocates and DevRel engineers who have built tutorials that keep breaking after each release.

**Promptless connection:** Promptless monitors when product changes would break documentation, including the tutorial and sample code content built on top of it.

## File

`src/content/blog/technical/developer-education-content-maintenance.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDiiTNQQ5wjgPNoxmidQP4)_