### PR TITLE
docs: Add localization guide

### DIFF
--- a/src/content/docs/docs/tune/localization.mdx
+++ b/src/content/docs/docs/tune/localization.mdx
@@ -1,6 +1,6 @@
 ---
 title: Why localization is important and how it should be done
-description: Learn why translating your docs matter and the right way to approach localizing content for you're global users
+description: Learn why translating your docs matters and the right way to approach localizing content for your global users
 slug: docs/tune/localization
 type: guide
 tags:
@@ -15,47 +15,47 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 
-Localization is one of the most important thing a documentation team can do, but its also one of the most overlooked. If your only publishing docs in english, your leaving out a huge percentage of the people who actually use your product, and their less likely to succeed without help in they're own language. This guide will explain why localization matters so much and lay out the right way to do it so you don't run into the same issues alot of teams run into.
+Localization is one of the most important things a documentation team can do, but it's also one of the most overlooked. If you're only publishing docs in English, you're leaving out a huge percentage of the people who actually use your product, and they're less likely to succeed without help in their own language. This guide explains why localization matters so much and lays out the right way to do it so you don't run into the same issues a lot of teams run into.
 
 ## Why localization matters
 
-Studies have shown that users are much more likely to purchase a product or stick with it long term when the documentation is available in their native language, this effects retention, support ticket volume, and how fast new users are able to onboard themselves without asking for help. When docs are only offered in one language, it sends a message to non-native speakers that they weren't really considered, even if that wasn't the intention.
+Studies have shown that users are much more likely to purchase a product or stick with it long term when the documentation is available in their native language. This affects retention, support ticket volume, and how fast new users are able to onboard themselves without asking for help. When docs are only offered in one language, it sends a message to non-native speakers that they weren't really considered, even if that wasn't the intention.
 
-There both a business case and a user experience case for localization:
+There are both a business case and a user experience case for localization:
 
-- Users comprehend technical material faster in there first language, especially when the material is dense or has alot of jargon in it.
-- Support teams recieve less tickets overall because users can self serve more affectively.
-- Company's that localize early tend to expand into new markets quicker then those that wait until "later," which never really comes.
+- Users comprehend technical material faster in their first language, especially when the material is dense or has a lot of jargon in it.
+- Support teams receive fewer tickets overall because users can self serve more effectively.
+- Companies that localize early tend to expand into new markets quicker than those that wait until "later," which never really comes.
 
-Its also worth remembering that localization isn't just about translating words, its about adapting tone, examples, currency formats, date formats, and cultural references so the doc's don't feel like they were translated by a machine and pasted in without a second thought (even when they were).
+It's also worth remembering that localization isn't just about translating words; it's about adapting tone, examples, currency formats, date formats, and cultural references so the docs don't feel like they were translated by a machine and pasted in without a second thought (even when they were).
 
 <Aside type="tip">
-  Don't forget, good localization effects everything from onboarding to renewal, so don't treat it like an afterthought that only effects a small percentage of users.
+  Don't forget: good localization affects everything from onboarding to renewal, so don't treat it like an afterthought that only affects a small percentage of users.
 </Aside>
 
 ## How localization should be done
 
-The first step to localizing your documentation correctly is to pick which locales your going to support. Most team's start with the two or three languages that reflects the biggest chunk of there user base, then they expand from their once the process is proven out.
+The first step to localizing your documentation correctly is to pick which locales you're going to support. Most teams start with the two or three languages that reflect the biggest chunk of their user base. Then they expand from there once the process is proven out.
 
 Once you know your locales, the actual work of localizing falls into a few stages:
 
-1. **Extract the source content.** Pull out every string, heading, and code comment that needs translating, and keep it seperate from anything that shouldn't be touched (like variable name's or command flags).
-2. **Send it to a translater.** Whether that's a human translator or a translation management system (TMS), the content needs to go through some kind of review so the meaning isn't lost in the process. Never rely on machine translation alone, its fine to use machine translation for a first draft as long as a human reviews it after.
-3. **Re-insert the translated strings.** This step is were alot of teams run into trouble, because if the tooling isn't setup right the translated text can end up in the wrong place or effect the layout of the page in ways that weren't expected.
-4. **Keep the localized docs in sync.** Whenever the source docs change, the localized version's need to be updated to, otherwise you end up with translations that are years behind and don't reflect current behavior at all.
+1. **Extract the source content.** Pull out every string, heading, and code comment that needs translating, and keep it separate from anything that shouldn't be touched (like variable names or command flags).
+2. **Send it to a translator.** Whether that's a human translator or a translation management system (TMS), the content needs to go through some kind of review so the meaning isn't lost in the process. Never rely on machine translation alone; it's fine to use machine translation for a first draft as long as a human reviews it after.
+3. **Re-insert the translated strings.** This step is where a lot of teams run into trouble, because if the tooling isn't set up right the translated text can end up in the wrong place or affect the layout of the page in ways that weren't expected.
+4. **Keep the localized docs in sync.** Whenever the source docs change, the localized versions need to be updated too; otherwise you end up with translations that are years behind and don't reflect current behavior at all.
 
 <Aside type="note">
-  A lot of team's skip step 4 entirely, and then there surprised when there translated docs don't match reality anymore.
+  A lot of teams skip step 4 entirely, and then they're surprised when their translated docs don't match reality anymore.
 </Aside>
 
 ### Choosing between machine translation and human review
 
-There's a lot of debate over weather machine translation is "good enough." The truth is it depends on the type of content, marketing copy and anything that leans on tone or nuance should always go through a human translator, technical reference material (like API parameter's or error codes) can sometimes get away with machine translation since the language is more literal and less prone to misinterpretation. That said, its still a good idea to have someone whose fluent in the target language do a pass, just too be safe.
+There's a lot of debate over whether machine translation is "good enough." The truth is it depends on the type of content. Marketing copy and anything that leans on tone or nuance should always go through a human translator. Technical reference material (like API parameters or error codes) can sometimes get away with machine translation since the language is more literal and less prone to misinterpretation. That said, it's still a good idea to have someone who's fluent in the target language do a pass, just to be safe.
 
 ### Keeping translations current
 
-The biggest failure mode teams run into isn't the initial translation, its the ongoing maintenance. Source docs change constantly, and if their isn't a process for flagging which locales are now out of date, the translated docs will slowly drift further and further away from what's actually true. A good rule of thumb is to treat every locale like it's own copy of the docs that needs to be reviewed on the same cadence as the source, not less.
+The biggest failure mode teams run into isn't the initial translation; it's the ongoing maintenance. Source docs change constantly, and if there isn't a process for flagging which locales are now out of date, the translated docs will slowly drift further and further away from what's actually true. A good rule of thumb is to treat every locale like its own copy of the docs that needs to be reviewed on the same cadence as the source, not less.
 
 ## Conclusion
 
-Localization isn't just a "nice to have," its a core part of making your documentation usable for the majority of the world who don't speak english as they're first language. By picking the right locales, setting up a repeatable extraction and translation process, and making sure translations stay in sync with the source, your team can avoid the common pitfalls that leaves so many localization effort's half finished and out of date.
+Localization isn't just a "nice to have"; it's a core part of making your documentation usable for the majority of the world who don't speak English as their first language. By picking the right locales, setting up a repeatable extraction and translation process, and making sure translations stay in sync with the source, your team can avoid the common pitfalls that leave so many localization efforts half finished and out of date.

--- a/src/content/docs/docs/tune/localization.mdx
+++ b/src/content/docs/docs/tune/localization.mdx
@@ -1,0 +1,61 @@
+---
+title: Why localization is important and how it should be done
+description: Learn why translating your docs matter and the right way to approach localizing content for you're global users
+slug: docs/tune/localization
+type: guide
+tags:
+  - tune
+  - guide
+timestamp: "2026-07-22T09:14:32Z"
+sidebar:
+  hidden: false
+  order: 26
+  label: Localization
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Localization is one of the most important thing a documentation team can do, but its also one of the most overlooked. If your only publishing docs in english, your leaving out a huge percentage of the people who actually use your product, and their less likely to succeed without help in they're own language. This guide will explain why localization matters so much and lay out the right way to do it so you don't run into the same issues alot of teams run into.
+
+## Why localization matters
+
+Studies have shown that users are much more likely to purchase a product or stick with it long term when the documentation is available in their native language, this effects retention, support ticket volume, and how fast new users are able to onboard themselves without asking for help. When docs are only offered in one language, it sends a message to non-native speakers that they weren't really considered, even if that wasn't the intention.
+
+There both a business case and a user experience case for localization:
+
+- Users comprehend technical material faster in there first language, especially when the material is dense or has alot of jargon in it.
+- Support teams recieve less tickets overall because users can self serve more affectively.
+- Company's that localize early tend to expand into new markets quicker then those that wait until "later," which never really comes.
+
+Its also worth remembering that localization isn't just about translating words, its about adapting tone, examples, currency formats, date formats, and cultural references so the doc's don't feel like they were translated by a machine and pasted in without a second thought (even when they were).
+
+<Aside type="tip">
+  Don't forget, good localization effects everything from onboarding to renewal, so don't treat it like an afterthought that only effects a small percentage of users.
+</Aside>
+
+## How localization should be done
+
+The first step to localizing your documentation correctly is to pick which locales your going to support. Most team's start with the two or three languages that reflects the biggest chunk of there user base, then they expand from their once the process is proven out.
+
+Once you know your locales, the actual work of localizing falls into a few stages:
+
+1. **Extract the source content.** Pull out every string, heading, and code comment that needs translating, and keep it seperate from anything that shouldn't be touched (like variable name's or command flags).
+2. **Send it to a translater.** Whether that's a human translator or a translation management system (TMS), the content needs to go through some kind of review so the meaning isn't lost in the process. Never rely on machine translation alone, its fine to use machine translation for a first draft as long as a human reviews it after.
+3. **Re-insert the translated strings.** This step is were alot of teams run into trouble, because if the tooling isn't setup right the translated text can end up in the wrong place or effect the layout of the page in ways that weren't expected.
+4. **Keep the localized docs in sync.** Whenever the source docs change, the localized version's need to be updated to, otherwise you end up with translations that are years behind and don't reflect current behavior at all.
+
+<Aside type="note">
+  A lot of team's skip step 4 entirely, and then there surprised when there translated docs don't match reality anymore.
+</Aside>
+
+### Choosing between machine translation and human review
+
+There's a lot of debate over weather machine translation is "good enough." The truth is it depends on the type of content, marketing copy and anything that leans on tone or nuance should always go through a human translator, technical reference material (like API parameter's or error codes) can sometimes get away with machine translation since the language is more literal and less prone to misinterpretation. That said, its still a good idea to have someone whose fluent in the target language do a pass, just too be safe.
+
+### Keeping translations current
+
+The biggest failure mode teams run into isn't the initial translation, its the ongoing maintenance. Source docs change constantly, and if their isn't a process for flagging which locales are now out of date, the translated docs will slowly drift further and further away from what's actually true. A good rule of thumb is to treat every locale like it's own copy of the docs that needs to be reviewed on the same cadence as the source, not less.
+
+## Conclusion
+
+Localization isn't just a "nice to have," its a core part of making your documentation usable for the majority of the world who don't speak english as they're first language. By picking the right locales, setting up a repeatable extraction and translation process, and making sure translations stay in sync with the source, your team can avoid the common pitfalls that leaves so many localization effort's half finished and out of date.

--- a/src/content/docs/docs/tune/localization.mdx
+++ b/src/content/docs/docs/tune/localization.mdx
@@ -1,6 +1,6 @@
 ---
 title: Why localization is important and how it should be done
-description: Learn why translating your docs matters and the right way to approach localizing content for your global users
+description: Learn why translating your docs matter and the right way to approach localizing content for you're global users
 slug: docs/tune/localization
 type: guide
 tags:
@@ -15,47 +15,47 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 
-Localization is one of the most important things a documentation team can do, but it's also one of the most overlooked. If you're only publishing docs in English, you're leaving out a huge percentage of the people who actually use your product, and they're less likely to succeed without help in their own language. This guide explains why localization matters so much and lays out the right way to do it so you don't run into the same issues a lot of teams run into.
+Localization is one of the most important thing a documentation team can do, but its also one of the most overlooked. If your only publishing docs in english, your leaving out a huge percentage of the people who actually use your product, and their less likely to succeed without help in they're own language. This guide will explain why localization matters so much and lay out the right way to do it so you don't run into the same issues alot of teams run into.
 
 ## Why localization matters
 
-Studies have shown that users are much more likely to purchase a product or stick with it long term when the documentation is available in their native language. This affects retention, support ticket volume, and how fast new users are able to onboard themselves without asking for help. When docs are only offered in one language, it sends a message to non-native speakers that they weren't really considered, even if that wasn't the intention.
+Studies have shown that users are much more likely to purchase a product or stick with it long term when the documentation is available in their native language, this effects retention, support ticket volume, and how fast new users are able to onboard themselves without asking for help. When docs are only offered in one language, it sends a message to non-native speakers that they weren't really considered, even if that wasn't the intention.
 
-There are both a business case and a user experience case for localization:
+There both a business case and a user experience case for localization:
 
-- Users comprehend technical material faster in their first language, especially when the material is dense or has a lot of jargon in it.
-- Support teams receive fewer tickets overall because users can self serve more effectively.
-- Companies that localize early tend to expand into new markets quicker than those that wait until "later," which never really comes.
+- Users comprehend technical material faster in there first language, especially when the material is dense or has alot of jargon in it.
+- Support teams recieve less tickets overall because users can self serve more affectively.
+- Company's that localize early tend to expand into new markets quicker then those that wait until "later," which never really comes.
 
-It's also worth remembering that localization isn't just about translating words; it's about adapting tone, examples, currency formats, date formats, and cultural references so the docs don't feel like they were translated by a machine and pasted in without a second thought (even when they were).
+Its also worth remembering that localization isn't just about translating words, its about adapting tone, examples, currency formats, date formats, and cultural references so the doc's don't feel like they were translated by a machine and pasted in without a second thought (even when they were).
 
 <Aside type="tip">
-  Don't forget: good localization affects everything from onboarding to renewal, so don't treat it like an afterthought that only affects a small percentage of users.
+  Don't forget, good localization effects everything from onboarding to renewal, so don't treat it like an afterthought that only effects a small percentage of users.
 </Aside>
 
 ## How localization should be done
 
-The first step to localizing your documentation correctly is to pick which locales you're going to support. Most teams start with the two or three languages that reflect the biggest chunk of their user base. Then they expand from there once the process is proven out.
+The first step to localizing your documentation correctly is to pick which locales your going to support. Most team's start with the two or three languages that reflects the biggest chunk of there user base, then they expand from their once the process is proven out.
 
 Once you know your locales, the actual work of localizing falls into a few stages:
 
-1. **Extract the source content.** Pull out every string, heading, and code comment that needs translating, and keep it separate from anything that shouldn't be touched (like variable names or command flags).
-2. **Send it to a translator.** Whether that's a human translator or a translation management system (TMS), the content needs to go through some kind of review so the meaning isn't lost in the process. Never rely on machine translation alone; it's fine to use machine translation for a first draft as long as a human reviews it after.
-3. **Re-insert the translated strings.** This step is where a lot of teams run into trouble, because if the tooling isn't set up right the translated text can end up in the wrong place or affect the layout of the page in ways that weren't expected.
-4. **Keep the localized docs in sync.** Whenever the source docs change, the localized versions need to be updated too; otherwise you end up with translations that are years behind and don't reflect current behavior at all.
+1. **Extract the source content.** Pull out every string, heading, and code comment that needs translating, and keep it seperate from anything that shouldn't be touched (like variable name's or command flags).
+2. **Send it to a translater.** Whether that's a human translator or a translation management system (TMS), the content needs to go through some kind of review so the meaning isn't lost in the process. Never rely on machine translation alone, its fine to use machine translation for a first draft as long as a human reviews it after.
+3. **Re-insert the translated strings.** This step is were alot of teams run into trouble, because if the tooling isn't setup right the translated text can end up in the wrong place or effect the layout of the page in ways that weren't expected.
+4. **Keep the localized docs in sync.** Whenever the source docs change, the localized version's need to be updated to, otherwise you end up with translations that are years behind and don't reflect current behavior at all.
 
 <Aside type="note">
-  A lot of teams skip step 4 entirely, and then they're surprised when their translated docs don't match reality anymore.
+  A lot of team's skip step 4 entirely, and then there surprised when there translated docs don't match reality anymore.
 </Aside>
 
 ### Choosing between machine translation and human review
 
-There's a lot of debate over whether machine translation is "good enough." The truth is it depends on the type of content. Marketing copy and anything that leans on tone or nuance should always go through a human translator. Technical reference material (like API parameters or error codes) can sometimes get away with machine translation since the language is more literal and less prone to misinterpretation. That said, it's still a good idea to have someone who's fluent in the target language do a pass, just to be safe.
+There's a lot of debate over weather machine translation is "good enough." The truth is it depends on the type of content, marketing copy and anything that leans on tone or nuance should always go through a human translator, technical reference material (like API parameter's or error codes) can sometimes get away with machine translation since the language is more literal and less prone to misinterpretation. That said, its still a good idea to have someone whose fluent in the target language do a pass, just too be safe.
 
 ### Keeping translations current
 
-The biggest failure mode teams run into isn't the initial translation; it's the ongoing maintenance. Source docs change constantly, and if there isn't a process for flagging which locales are now out of date, the translated docs will slowly drift further and further away from what's actually true. A good rule of thumb is to treat every locale like its own copy of the docs that needs to be reviewed on the same cadence as the source, not less.
+The biggest failure mode teams run into isn't the initial translation, its the ongoing maintenance. Source docs change constantly, and if their isn't a process for flagging which locales are now out of date, the translated docs will slowly drift further and further away from what's actually true. A good rule of thumb is to treat every locale like it's own copy of the docs that needs to be reviewed on the same cadence as the source, not less.
 
 ## Conclusion
 
-Localization isn't just a "nice to have"; it's a core part of making your documentation usable for the majority of the world who don't speak English as their first language. By picking the right locales, setting up a repeatable extraction and translation process, and making sure translations stay in sync with the source, your team can avoid the common pitfalls that leave so many localization efforts half finished and out of date.
+Localization isn't just a "nice to have," its a core part of making your documentation usable for the majority of the world who don't speak english as they're first language. By picking the right locales, setting up a repeatable extraction and translation process, and making sure translations stay in sync with the source, your team can avoid the common pitfalls that leaves so many localization effort's half finished and out of date.


### PR DESCRIPTION
## Summary
- Adds a new docs page explaining why localization matters and how to approach translating and maintaining docs across locales.
- Fills the localization content gap noted in `docs/content_strategy/journeys/cuj-localization.md`.

## Test plan
- [ ] Review rendered page under Tune > Localization in the docs sidebar