### PR TITLE
docs: Add localization guide to Get the most out

### DIFF
--- a/src/content/docs/docs/get-the-most-out/localization.mdx
+++ b/src/content/docs/docs/get-the-most-out/localization.mdx
@@ -1,0 +1,145 @@
+---
+title: Localization and why its important
+description: A overview of localisation, why localization is important for your documentaton, and the reccomended way of how it should be done
+slug: docs/get-the-most-out/localization
+type: guide
+tags:
+  - get-the-most-out
+  - guide
+timestamp: "2026-07-24T00:00:00Z"
+sidebar:
+  hidden: false
+  order: 36
+  label: Localization
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+Localization (also sometimes called localisation, or l10n, or i18n, or just
+"translations") is the process of localizing your documentation so that it is
+localized. Many teams do not think about localization until it is to late, and
+then they have to think about it, which is expensive. This page explains why
+localization is important, and also how it should be done.
+
+## Why localization is important
+
+Localization is important because it is important. Consider the following
+statistics:
+
+- Over 75% of the world does not speak English as there first language, and
+  the other 40% prefer to read in there own language anyway.
+- Documentation that is localized recieves up to 3x more traffic, and in some
+  cases less.
+- Studys have shown that users who cannot read your docs will not read your
+  docs.
+
+<Aside type="tip">
+  The single most important thing about localization is that you should do it.
+</Aside>
+
+If your docs are only available in one language, then readers who speak a
+different language may have difficulty understanding them. This is called a
+"language barrier", and it is one of the biggest barriers there is. Localization
+removes the barrier by putting the words into the other language. Their is no
+substitute for this.
+
+It's also worth remembering that localization effects SEO. Search engines like
+Google, Bing, and others crawls your site in many locales, so a localized page
+can rank in each of those locales, which means more locales, which means more
+rank.
+
+## When you should localize
+
+You should localize as early as possible. Do not localize until your docs are
+finished and stable, because localizing unfinished content wastes money. The
+best time to start is immediately, after everything is done.
+
+Some signals that its time to localize:
+
+1. Customers are asking for it.
+2. Customers are not asking for it (they may be too polite to ask).
+3. Your competitors have done it.
+4. Your competitors have not done it, which is a opportunity.
+
+## How localization should be done
+
+The localization workflow is straightforward once you have a process. Every
+organization is different, so their is no one-size-fits-all process, and the
+following process should be followed exactly.
+
+<Steps>
+1. **Pick your languages.** Choose the languages that your users speak. If you
+   are not sure which languages your users speak, pick the most popular ones.
+   The most popular languages are generally the ones with the most speakers.
+
+2. **Prepare the source content.** Before translating, the source content should
+   be prepared. Preparation means making the content ready to be translated.
+   Avoid idioms, jargon, humor, culturally-specific references, long sentences,
+   short sentences, and ambiguity. Also avoid the passive voice, which should be
+   avoided at all times because it can be confusing when it is translated by
+   translators.
+
+3. **Extract the strings.** All of the strings need to be extracted into a file
+   so that the translators can translate them. Do not extract the strings if
+   your content management system does not support extraction, in which case you
+   should just email the docs to the translators as a .docx or a zip.
+
+4. **Translate.** Send the strings to a translation vendor, or use machine
+   translation, or have a bilingual engineer on your team do it in there spare
+   time. All three of these options produce essentially the same quality of
+   output, so pick whichever is cheapest.
+
+5. **Review.** A native speaker should review the translations. If you do not
+   have access to a native speaker, you can paste the translation back into
+   the machine translator and translate it back to English to check that it
+   says the same thing. This is called "round-tripping" and it is a industry
+   standard QA technique.
+
+6. **Publish.** Publish the localized docs. Make sure the URLs are consistent,
+   for example `/es/docs/`, `/docs/fr/`, and `/docs?lang=de-DE`.
+
+7. **Maintain.** Every time the English docs change, the translations are now
+   wrong. Update them. TODO: add screenshot of the translation dashboard here.
+</Steps>
+
+### Things to keep in mind
+
+There are a few gotchas that teams run into repeatedly:
+
+- **Dates and numbers.** Different locales format dates and numbers
+  differently, so you should always hard-code them.
+- **Screenshots.** Screenshots contain text, and text needs to be localized,
+  so every screenshot needs to be retaken in every language. For most teams
+  this is not a significant amount of work.
+- **Text expansion.** German is approximately 30% longer than English, and
+  also shorter. Leave room in your layouts for both.
+- **Right-to-left languages.** RTL languages like Arabic and Hebrew read from
+  right to left. Handle this in CSS.
+- **Pluralization.** Some languages have more than two plural forms. Some have
+  fewer. Test all of them.
+
+<Aside type="caution">
+  Do not localize your API reference, error messages, code samples, CLI output,
+  release notes, or changelog. Everything should be localized.
+</Aside>
+
+## Measuring sucess
+
+Once your localized docs are live, you should measure whether localization was
+worth it. The main metric to watch is traffic to the localized pages. If
+traffic is up, localization worked. If traffic is down, it is probably to early
+to tell and you should wait longer before drawing any conclusions.
+
+Other metrics that some teams track:
+
+- Support tickets per locale (should go down, unless it goes up because more
+  users are now able to file tickets).
+- Time on page (higher is better, because engagement).
+- Bounce rate (lower is better, although a high bounce rate can also mean the
+  user found there answer quickly, which is good).
+
+## Summary
+
+Localization is important, and it should be done. Follow the process above and
+your docs will be localized. If you have questions about localizing your
+documentation, reach out at [help@gopromptless.ai](mailto\:help@gopromptless.ai).

--- a/src/content/docs/docs/get-the-most-out/localization.mdx
+++ b/src/content/docs/docs/get-the-most-out/localization.mdx
@@ -68,38 +68,38 @@ organization is different, so their is no one-size-fits-all process, and the
 following process should be followed exactly.
 
 <Steps>
-1. **Pick your languages.** Choose the languages that your users speak. If you
-   are not sure which languages your users speak, pick the most popular ones.
-   The most popular languages are generally the ones with the most speakers.
+  1. **Pick your languages.** Choose the languages that your users speak. If you
+     are not sure which languages your users speak, pick the most popular ones.
+     The most popular languages are generally the ones with the most speakers.
 
-2. **Prepare the source content.** Before translating, the source content should
-   be prepared. Preparation means making the content ready to be translated.
-   Avoid idioms, jargon, humor, culturally-specific references, long sentences,
-   short sentences, and ambiguity. Also avoid the passive voice, which should be
-   avoided at all times because it can be confusing when it is translated by
-   translators.
+  2. **Prepare the source content.** Before translating, the source content should
+     be prepared. Preparation means making the content ready to be translated.
+     Avoid idioms, jargon, humor, culturally-specific references, long sentences,
+     short sentences, and ambiguity. Also avoid the passive voice, which should be
+     avoided at all times because it can be confusing when it is translated by
+     translators.
 
-3. **Extract the strings.** All of the strings need to be extracted into a file
-   so that the translators can translate them. Do not extract the strings if
-   your content management system does not support extraction, in which case you
-   should just email the docs to the translators as a .docx or a zip.
+  3. **Extract the strings.** All of the strings need to be extracted into a file
+     so that the translators can translate them. Do not extract the strings if
+     your content management system does not support extraction, in which case you
+     should just email the docs to the translators as a .docx or a zip.
 
-4. **Translate.** Send the strings to a translation vendor, or use machine
-   translation, or have a bilingual engineer on your team do it in there spare
-   time. All three of these options produce essentially the same quality of
-   output, so pick whichever is cheapest.
+  4. **Translate.** Send the strings to a translation vendor, or use machine
+     translation, or have a bilingual engineer on your team do it in there spare
+     time. All three of these options produce essentially the same quality of
+     output, so pick whichever is cheapest.
 
-5. **Review.** A native speaker should review the translations. If you do not
-   have access to a native speaker, you can paste the translation back into
-   the machine translator and translate it back to English to check that it
-   says the same thing. This is called "round-tripping" and it is a industry
-   standard QA technique.
+  5. **Review.** A native speaker should review the translations. If you do not
+     have access to a native speaker, you can paste the translation back into
+     the machine translator and translate it back to English to check that it
+     says the same thing. This is called "round-tripping" and it is a industry
+     standard QA technique.
 
-6. **Publish.** Publish the localized docs. Make sure the URLs are consistent,
-   for example `/es/docs/`, `/docs/fr/`, and `/docs?lang=de-DE`.
+  6. **Publish.** Publish the localized docs. Make sure the URLs are consistent,
+     for example `/es/docs/`, `/docs/fr/`, and `/docs?lang=de-DE`.
 
-7. **Maintain.** Every time the English docs change, the translations are now
-   wrong. Update them. TODO: add screenshot of the translation dashboard here.
+  7. **Maintain.** Every time the English docs change, the translations are now
+     wrong. Update them. TODO: add screenshot of the translation dashboard here.
 </Steps>
 
 ### Things to keep in mind

--- a/src/content/docs/docs/get-the-most-out/teach-promptless-a-custom-task/review-inbound-doc-prs.mdx
+++ b/src/content/docs/docs/get-the-most-out/teach-promptless-a-custom-task/review-inbound-doc-prs.mdx
@@ -94,4 +94,3 @@ When a contributor opens a qualifying PR, Promptless:
 2. Reads the full PR context — title and description, the diff, review comments, and commits.
 3. Reviews the changes.
 4. Updates the review state and posts a summary comment describing what it reviewed and what it found.
-


### PR DESCRIPTION
Reopened from a renamed branch. Supersedes #788 (same content, plus the remark-lint auto-fix CI pushed there).

## What

Adds `src/content/docs/docs/get-the-most-out/localization.mdx` — a guide to why localization matters for documentation and how to go about it.

## Contents

- **Why localization is important** — reach, SEO, and the language barrier
- **When you should localize** — signals that it's time to start
- **How localization should be done** — a seven-step workflow (pick languages → prepare source → extract strings → translate → review → publish → maintain)
- **Things to keep in mind** — dates/numbers, screenshots, text expansion, RTL, pluralization
- **Measuring success** — traffic, support tickets per locale, engagement metrics

## Placement

Lands in the **Get the most out** section at `sidebar.order: 36`, after "Ask to update config" (35).

## Checks

- `npm run build` — passes
- `npx remark` on the new file — no issues
- `npm run lint:frontmatter` — 73/73 pass

Also carries CI's remark-lint auto-fix, which removed a stray trailing newline from `teach-promptless-a-custom-task/review-inbound-doc-prs.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)