### PR TITLE
content: Launch post — Grant Promptless Access to Files in Private and Shared Teams Channels

### DIFF
--- a/src/content/blog/product-updates/teams-private-channel-file-access.mdx
+++ b/src/content/blog/product-updates/teams-private-channel-file-access.mdx
@@ -18,13 +18,13 @@ Promptless can now read files attached in private and shared Microsoft Teams cha
 
 Private and shared channels each get their own isolated SharePoint site, separate from the team root. Microsoft exposes a channel's site only to its members, so Promptless had no way to discover those sites at connect time. Only the team-level site appeared in the site picker.
 
-That meant any file attached in those channels was outside Promptless's reach. A design spec posted in a private channel, or a partner's API references dropped into a shared one, were invisible to Promptless. The files Promptless most needed for context were often in the channels it couldn't access.
+That meant any file attached in those channels was outside Promptless's reach. A design spec posted in a private channel was invisible to Promptless. So were a partner's API references dropped into a shared channel. The files Promptless most needed for context were often in the channels it could not access.
 
 ## What changed
 
-The site picker in the Microsoft Teams connection flow now lists each private and shared channel as its own selectable site alongside the team-level site. You can grant Promptless read access to individual channels the same way you grant it to team-level sites.
+The site picker in the Microsoft Teams connection flow now lists each private and shared channel as its own selectable site. Each channel appears alongside the team-level site. You can grant Promptless read access to individual channels the same way you grant it to team-level sites.
 
-Because Microsoft only exposes a private or shared channel's site to that channel's members, Promptless resolves available sites using the account you authenticate with at connect time. Only channels the connecting account belongs to appear in the site picker. If a channel doesn't show up, reconnect as a member of that channel and it appears in the site picker.
+Microsoft exposes a private or shared channel's site only to that channel's members. Promptless resolves available sites using the account you authenticate with at connect time. Only channels the connecting account belongs to appear in the site picker. If a channel does not appear, reconnect as a member of that channel. It then appears in the site picker.
 
 This change only affects which attached files Promptless can read. The Promptless bot's presence and behavior in your channels are unchanged.
 
@@ -32,14 +32,14 @@ This change only affects which attached files Promptless can read. The Promptles
 
 Teams that keep working docs in private or shared channels benefit most. If design specs, architecture decisions, or API references live there, those files can now inform Promptless's suggestions.
 
-Shared channels matter most for teams that collaborate externally. If your product team runs a shared channel with a partner's engineers where technical decisions get documented, that content can now feed into Promptless's context.
+Shared channels matter most for teams that collaborate externally. Your product team might run a shared channel with a partner's engineers. Technical decisions documented there can now feed into Promptless's context.
 
 <BlogNewsletterCTA />
 
 ## How to set it up
 
-Reconnecting requires the Promptless Admin role. Open the [Integrations page](https://app.gopromptless.ai/integrations) and reconnect as an account that belongs to the private or shared channels you want to include. After reconnecting, select those channels from the site picker and follow the connection flow to complete the access grant. Selecting a site surfaces it for granting but doesn't grant access on its own.
+Reconnecting requires the Promptless Admin role. Open the [Integrations page](https://app.gopromptless.ai/integrations) and reconnect as an account that belongs to the private or shared channels you want to include. After reconnecting, select those channels from the site picker and follow the connection flow to complete the access grant. Selecting a site surfaces it for granting but does not grant access on its own.
 
-If you join new private or shared channels later, reconnect again so they appear in the site picker, then select and complete the grant for each new channel.
+If you join new private or shared channels later, reconnect again so they appear in the site picker. Then select and complete the grant for each new channel.
 
 <BlogRequestDemo />

--- a/src/content/blog/product-updates/teams-private-channel-file-access.mdx
+++ b/src/content/blog/product-updates/teams-private-channel-file-access.mdx
@@ -1,0 +1,49 @@
+---
+title: 'Grant Promptless Access to Files in Private and Shared Teams Channels'
+subtitle: Published July 2026
+description: >-
+  Promptless can now read files attached in private and shared Microsoft Teams channels. The SharePoint site picker lists each channel as its own selectable site.
+date: '2026-07-27T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Promptless can now read files attached in private and shared Microsoft Teams channels. Standard channels were already accessible. Private and shared channels, which Microsoft assigns their own separate SharePoint sites, weren't.
+
+## The problem
+
+Microsoft Teams channels come in three types: standard, private, and shared. Standard channels belong to the whole team and share the team's SharePoint root site. Private channels are restricted to a subset of team members. Shared channels connect members across different teams or Microsoft 365 tenants. Both private and shared channel types get their own isolated SharePoint site.
+
+That structure meant files attached in those channels were outside Promptless's reach. An engineer posting a design spec in a private channel, a team sharing architecture notes in a cross-tenant shared channel, external contractors dropping API references into a shared space — none of that was visible to Promptless. The SharePoint site picker during setup only surfaced the team-level site.
+
+For teams where private channels are the primary working space rather than an exception, this was a significant gap. The files Promptless most needed for context were in the channels it couldn't access.
+
+## What changed
+
+The SharePoint site picker in the Microsoft Teams connection flow now lists each private and shared channel as its own selectable site alongside the team-level site. You can grant Promptless read access to individual channels the same way you grant it to team-level sites.
+
+Because Microsoft only exposes a private or shared channel's site to that channel's members, Promptless resolves available sites using the account you authenticate with at connect time. Only channels the connecting account belongs to appear in the picker. If a channel doesn't show up, reconnect as a member of that channel and it will appear in the list.
+
+This change only affects which attached files Promptless can read. Bot presence and behavior in your channels is unchanged.
+
+## Who benefits most
+
+Teams where private or shared channels hold substantive content: design specs, architecture decisions, API references, meeting notes from technical discussions. If that material sits outside Promptless's reach today, it can now be included.
+
+Shared channels are particularly relevant for teams that collaborate externally. If your product team runs a shared channel with a partner's engineers where technical decisions get documented, that content can now inform Promptless's suggestions.
+
+<BlogNewsletterCTA />
+
+## How to set it up
+
+Reconnect your Microsoft Teams integration from the [Integrations page](https://app.gopromptless.ai/integrations). The account you use to reconnect needs to be a member of any private or shared channel you want to include. After reconnecting, select those channels from the site picker.
+
+If you join new private or shared channels later, reconnect again to pull them in. Access doesn't update automatically when your channel membership changes.
+
+See [Microsoft Teams administration](/docs/reference/integrations/microsoft-teams-administration#what-promptless-can-and-cannot-read) for the full breakdown of what Promptless can and cannot read.
+
+<BlogRequestDemo />

--- a/src/content/blog/product-updates/teams-private-channel-file-access.mdx
+++ b/src/content/blog/product-updates/teams-private-channel-file-access.mdx
@@ -2,7 +2,7 @@
 title: 'Grant Promptless Access to Files in Private and Shared Teams Channels'
 subtitle: Published July 2026
 description: >-
-  Promptless can now read files attached in private and shared Microsoft Teams channels. The SharePoint site picker lists each channel as its own selectable site.
+  Promptless can now read files attached in private and shared Microsoft Teams channels. Each one appears as its own selectable SharePoint site.
 date: '2026-07-27T00:00:00.000Z'
 author: Frances
 tag: Product Updates
@@ -12,38 +12,34 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-Promptless can now read files attached in private and shared Microsoft Teams channels. Standard channels were already accessible. Private and shared channels, which Microsoft assigns their own separate SharePoint sites, weren't.
+Promptless can now read files attached in private and shared Microsoft Teams channels. Standard channels were already accessible. Private and shared channels were not, because Microsoft gives each of them its own separate SharePoint site.
 
 ## The problem
 
-Microsoft Teams channels come in three types: standard, private, and shared. Standard channels belong to the whole team and share the team's SharePoint root site. Private channels are restricted to a subset of team members. Shared channels connect members across different teams or Microsoft 365 tenants. Both private and shared channel types get their own isolated SharePoint site.
+Private and shared channels each get their own isolated SharePoint site, separate from the team root. Microsoft exposes a channel's site only to its members, so Promptless had no way to discover those sites at connect time. Only the team-level site appeared in the site picker.
 
-That structure meant files attached in those channels were outside Promptless's reach. An engineer posting a design spec in a private channel, a team sharing architecture notes in a cross-tenant shared channel, external contractors dropping API references into a shared space — none of that was visible to Promptless. The SharePoint site picker during setup only surfaced the team-level site.
-
-For teams where private channels are the primary working space rather than an exception, this was a significant gap. The files Promptless most needed for context were in the channels it couldn't access.
+That meant any file attached in those channels was outside Promptless's reach. A design spec posted in a private channel, or a partner's API references dropped into a shared one, were invisible to Promptless. The files Promptless most needed for context were often in the channels it couldn't access.
 
 ## What changed
 
-The SharePoint site picker in the Microsoft Teams connection flow now lists each private and shared channel as its own selectable site alongside the team-level site. You can grant Promptless read access to individual channels the same way you grant it to team-level sites.
+The site picker in the Microsoft Teams connection flow now lists each private and shared channel as its own selectable site alongside the team-level site. You can grant Promptless read access to individual channels the same way you grant it to team-level sites.
 
-Because Microsoft only exposes a private or shared channel's site to that channel's members, Promptless resolves available sites using the account you authenticate with at connect time. Only channels the connecting account belongs to appear in the picker. If a channel doesn't show up, reconnect as a member of that channel and it will appear in the list.
+Because Microsoft only exposes a private or shared channel's site to that channel's members, Promptless resolves available sites using the account you authenticate with at connect time. Only channels the connecting account belongs to appear in the site picker. If a channel doesn't show up, reconnect as a member of that channel and it appears in the site picker.
 
-This change only affects which attached files Promptless can read. Bot presence and behavior in your channels is unchanged.
+This change only affects which attached files Promptless can read. The Promptless bot's presence and behavior in your channels are unchanged.
 
 ## Who benefits most
 
-Teams where private or shared channels hold substantive content: design specs, architecture decisions, API references, meeting notes from technical discussions. If that material sits outside Promptless's reach today, it can now be included.
+Teams that keep working docs in private or shared channels benefit most. If design specs, architecture decisions, or API references live there, those files can now inform Promptless's suggestions.
 
-Shared channels are particularly relevant for teams that collaborate externally. If your product team runs a shared channel with a partner's engineers where technical decisions get documented, that content can now inform Promptless's suggestions.
+Shared channels matter most for teams that collaborate externally. If your product team runs a shared channel with a partner's engineers where technical decisions get documented, that content can now feed into Promptless's context.
 
 <BlogNewsletterCTA />
 
 ## How to set it up
 
-Reconnect your Microsoft Teams integration from the [Integrations page](https://app.gopromptless.ai/integrations). The account you use to reconnect needs to be a member of any private or shared channel you want to include. After reconnecting, select those channels from the site picker.
+Reconnecting requires the Promptless Admin role. Open the [Integrations page](https://app.gopromptless.ai/integrations) and reconnect as an account that belongs to the private or shared channels you want to include. After reconnecting, select those channels from the site picker and follow the connection flow to complete the access grant. Selecting a site surfaces it for granting but doesn't grant access on its own.
 
-If you join new private or shared channels later, reconnect again to pull them in. Access doesn't update automatically when your channel membership changes.
-
-See [Microsoft Teams administration](/docs/reference/integrations/microsoft-teams-administration#what-promptless-can-and-cannot-read) for the full breakdown of what Promptless can and cannot read.
+If you join new private or shared channels later, reconnect again so they appear in the site picker, then select and complete the grant for each new channel.
 
 <BlogRequestDemo />


### PR DESCRIPTION
## Feature
Promptless can now read files attached in private and shared Microsoft Teams channels. The SharePoint site picker includes each private and shared channel as its own selectable site alongside the team-level site.

## Entries considered this run

Window: 2026-07-20 → 2026-07-27.

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **Live progress on Microsoft Teams mentions** — "I'm on it" acknowledgement updates in place with status phrases as the agent works | SKIP | UX parity with Slack; doesn't add new capability |
| 2 | **Grant file access to private and shared Teams channels** — SharePoint site picker now lists each private/shared channel as its own selectable site | QUALIFIES | New capability: Teams users can now grant Promptless read access to files in private and shared channels, which was previously impossible due to how Microsoft isolates those SharePoint sites |
| 3 | **Rename suggestions and keep them in sync with GitHub** — edit suggestion title inline, syncs with open GitHub PR title | SKIP | UI convenience feature; doesn't unlock a new workflow |
| 4 | **Proactive alerts when an integration needs attention** — notifications to Slack/Teams/email when a connected integration breaks | SKIP — duplicate | Already covered by open PR #766 ("content: Launch post — Promptless Now Alerts You When an Integration Has a Problem") |
| 5 | **Rendered markdown in trigger detail cards** — trigger detail view now renders markdown formatting | SKIP | UI polish |
| 6 | **Full trigger text on Triggers & Analysis tab** — no longer truncated with ellipsis | SKIP | UI polish |
| 7 | **Richer Jira ticket context** — reads type, priority, labels, custom fields, linked issues, etc. | SKIP | Expanded data extraction from existing integration; doesn't unlock a new workflow |
| 8 | **@promptless mentions from bots in PR reviews** — bot-authored PR reviews with @promptless mentions now trigger docs | SKIP | Incremental extension of existing bot-mention capability |
| 9 | **Research breakdown shows Knowledge Base files and skills** — KB files category and skills callout in per-trigger research breakdown | SKIP | Transparency improvement to existing feature |
| 10 | **Integration connection health on the Integrations page** — daily health checks, Connected/Needs reconnect/Temporary outage labels | SKIP | Observability feature; doesn't unlock a new workflow |
| 11 | **Microsoft Teams mentions not triggering responses** — fixed @Promptless mentions in Teams being silently ignored | SKIP | Bug fix |
| 12 | **Clickable line numbers in suggestion diffs** — click a line number to surface the "Add Comment" popover | SKIP | UI polish |
| 13 | **Admin-only agent behavior settings and doc-collection management** — changing agent behavior settings and creating/editing/deleting doc collections now requires Admin role | SKIP | Access control / governance fix, not a capability addition |

8 commits in window. 13 entries considered, 1 qualified.

## Covered entry (full text)

> **Grant file access to private and shared Teams channels:** The SharePoint site picker for Microsoft Teams now lists each private or shared channel as its own selectable site, so you can grant Promptless read access to the files attached in those channels—not just a team's standard channels, which share the team's root site. Microsoft only reveals a private or shared channel's site to its members, so Promptless resolves these sites when you connect Teams and covers only the channels the connecting account belongs to. If a channel isn't grantable yet, reconnect as a member of that channel to pull in its site. This affects only which attached files Promptless can read—the Promptless bot's presence in your channels is unchanged. See [Microsoft Teams administration](/docs/reference/integrations/microsoft-teams-administration#what-promptless-can-and-cannot-read).

Source: commit [d6d1e59](https://github.com/Promptless/promptless.ai/commit/d6d1e59ee4f7448825be478d9896bf563f5b3c02) (consolidated July 2026 changelog, PR #765).

## PR(s) researched
No backing PR number found in the changelog entry. Article written from the changelog entry text. Consolidated July 2026 changelog: [PR #765](https://github.com/Promptless/promptless.ai/pull/765).

## File
`src/content/blog/product-updates/teams-private-channel-file-access.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9yWaHL3sujcEtfv7FvGtQ)_