### PR TITLE
content: Your Developer Relations Docs Have a New Primary Audience

### DIFF
--- a/src/content/blog/technical/developer-relations-docs-new-primary-audience.mdx
+++ b/src/content/blog/technical/developer-relations-docs-new-primary-audience.mdx
@@ -1,0 +1,75 @@
+---
+title: 'Your Developer Relations Docs Have a New Primary Audience'
+subtitle: Published July 2026
+description: >-
+  84% of developers now use AI tools to evaluate APIs. Those tools read your DevRel docs first. Here's what documentation accuracy means now.
+date: '2026-07-29T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+84% of developers now use AI coding tools at work. When one of them encounters your product for the first time, they rarely start by opening your quickstart guide. They open their AI assistant and ask: "How do I authenticate with this API in Python?"
+
+The assistant answers from your documentation.
+
+If your docs are accurate, it recommends the right approach. If your docs are stale, it recommends a deprecated authentication method, the developer's code fails, and they're already skeptical before they've written a line that works.
+
+That's the new first-touch problem in developer relations. The audience for your docs changed. Most DevRel teams haven't changed how they maintain them.
+
+## AI tools are the first reader
+
+The traditional mental model puts the human developer at the center. You write a quickstart for someone who opens a browser tab, reads your steps, and copies your code. Your job is to make that experience clear and fast.
+
+That model still describes part of what happens. It no longer describes the first thing that happens.
+
+AI coding assistants, including Claude, GitHub Copilot, and Cursor, ground their answers in developer documentation. When a developer asks one of these tools how to use your API, the tool answers from whatever it can access in your docs. If that answer is right, it builds trust in your product. If it's wrong, the trust loss attaches to both the tool and your product.
+
+Developer trust in AI tools is already eroding. A 2026 Stack Overflow survey found that while 84% of developers use AI tools, only 29% say they trust AI outputs. That's down from 40% the year before. The most cited reasons: incorrect suggestions and missing context. Both trace directly to documentation quality.
+
+65% of developers in the same survey reported that AI coding assistants missed relevant context during code review or integration work. That missing context comes from gaps in the documentation the AI used.
+
+## What DevRel docs get used for now
+
+Developer relations documentation serves two overlapping audiences that used to behave more similarly than they do now.
+
+Human developers read contextually. They notice when something feels outdated. They run a code sample before trusting it. If your quickstart shows an endpoint that returns a 404, they search for alternatives, check your changelog, or ask in your community Slack. They work around problems.
+
+AI tools consume documentation literally. They extract information and produce answers as if that information is current. A deprecation notice buried in a footnote gets missed. An outdated code example gets reproduced verbatim. The tool doesn't check when the page was last updated. It reads what's there and uses it.
+
+[Documentation drift](/blog/technical/documentation-drift-detection-problem) already costs teams significantly. Compensating for inaccurate docs consumes 15-25% of total engineering capacity, as developers read source code instead of reading the docs and ask Slack questions that docs should answer. When AI tools join that picture, they extend the blast radius. One stale getting-started guide doesn't just mislead one developer. It misleads every developer who asks an AI assistant the same question.
+
+68% of developers cite outdated documentation as their top frustration when working with APIs, according to a Postman survey. That frustration used to show up as support tickets and community Slack threads. Now it shows up first as an AI tool giving bad advice that the developer only discovers after spending time debugging.
+
+<BlogNewsletterCTA />
+
+## The measurement gap
+
+DevRel teams traditionally measure documentation success through page traffic and developer satisfaction scores. These metrics don't detect documentation drift.
+
+A page can have high traffic and a four-star satisfaction rating while quietly containing outdated information. Developers who notice the inaccuracy don't always leave a review. They debug the problem, find a workaround, and move on. The bad rating goes to the support ticket, not the doc page.
+
+With AI tools in the picture, this gap becomes more consequential. A page isn't just being read by the developers who visit it. It's being ingested by AI tools that serve answers to many more developers who never visit the page directly. The traffic signal gets noisier while the accuracy signal stays invisible.
+
+[Reaching a perfect score on agent-readability benchmarks](/blog/technical/agent-friendly-docs-necessary-not-sufficient) doesn't help if the content the agent successfully reads is wrong. Most frameworks for making docs "AI-native" focus on format: structured Markdown and [llms.txt indexes](/blog/technical/llms-txt-is-not-what-most-teams-think). These are necessary. They solve the delivery problem. They don't solve the accuracy problem. They make it easier for an AI tool to consume your docs. They don't ensure what it consumes is correct.
+
+## What this means for DevRel
+
+DevRel teams own the content that sits between the product and the developer. That content has always required keeping up with product changes. In practice, this has been hard. Developer advocates are often closer to the community than to the engineering sprint cycle. They learn about deprecations through Slack notifications or changelog entries, not from the PR that shipped the change.
+
+The stakes of that lag have gone up. When AI tools read and repeat your documentation, outdated content spreads faster and with more authority than when developers had to find it themselves.
+
+The practical implication: documentation maintenance needs a signal. Periodic audits aren't sufficient. A quarterly review of the docs repo doesn't catch a parameter rename that shipped last week and is already producing wrong AI recommendations. The signal needs to be close to real-time, tied to what's actually changing in the product.
+
+[Agent context engineering](/blog/technical/agent-context-engineering) research frames this as a knowledge layer problem. The accuracy of what agents retrieve matters more than how they retrieve it. For DevRel teams, that means documentation accuracy is now load-bearing for product adoption in a way it wasn't before AI tools became the primary first-touch for developer evaluation.
+
+## How Promptless closes the loop
+
+Promptless monitors your documentation against your actual product and codebase continuously. When a product change creates a gap between what your docs say and what your API does, Promptless surfaces it before AI tools start serving the stale version to developers.
+
+For DevRel teams, this closes the loop that's always been hard to close manually: knowing when content that was accurate at publish time has become inaccurate since. The result is documentation that AI tools can read and use correctly, not just documentation that AI tools can access.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer relations docs`

## Article plan

- **Thesis:** The audience for DevRel documentation has shifted. AI tools now consume it before human developers do, which means documentation accuracy directly drives (or breaks) developer trust and adoption.
- **Target reader:** Developer advocates and DevRel engineers at API/dev-tools companies who write tutorials and reference docs but haven't yet treated docs maintenance as a continuous operational responsibility.
- **Format:** Explainer that reframes a familiar DevRel task (writing docs) around an urgent new constraint (AI tools are the primary reader now).
- **Key data:** 84% of developers use AI tools (Stack Overflow 2026); only 29% trust AI outputs (down from 40%); 65% report AI misses relevant context from docs; 68% cite outdated docs as top API frustration (Postman).
- **Promptless connection:** Promptless monitors docs against the actual product continuously, closing the loop between what DevRel published and what's currently true.

## File

`src/content/blog/technical/developer-relations-docs-new-primary-audience.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaygoiiTRBb63fY9D6gQou)_