### PR TITLE
content: Developer Experience Documentation: Why Accuracy Matters More Than Completeness

### DIFF
--- a/src/content/blog/technical/developer-experience-documentation.mdx
+++ b/src/content/blog/technical/developer-experience-documentation.mdx
@@ -1,0 +1,99 @@
+---
+title: 'Developer Experience Documentation: Why Accuracy Matters More Than Completeness'
+subtitle: Published July 2026
+description: >-
+  Developer experience docs set your API's first impression and activation rate. Most teams ship them once and stop. Here's why accuracy after launch is the real DX lever.
+date: '2026-07-30T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer lands on your quickstart. They copy the code sample. They run it. It fails. The authentication format changed four months ago and the quickstart never caught up.
+
+They try the reference docs. The endpoint is there. The parameters look right. They try again. Still fails. Fifteen minutes in, they open a competitor's docs.
+
+You didn't lose them because your API is bad. You lost them because your documentation told them something that used to be true.
+
+## Documentation is the DX, not support for it
+
+Developer experience covers everything from onboarding to production: SDKs, CLIs, tooling, support channels, community. But the first thing most developers encounter is the docs.
+
+Before writing a single line of code against your API, a developer reads the quickstart. They skim the reference. They look for a tutorial that matches their use case. That reading experience is the product demo for most API evaluations.
+
+Most teams treat documentation as a support resource, something that reduces tickets and helps existing users. That framing is too narrow. Your docs are the interface developers use to decide whether to adopt your product at all.
+
+[Postman's 2024 State of the API survey](https://www.postman.com/state-of-api/2024) found that 44% of developers dig through source code to understand an API because the documentation doesn't give them what they need. These aren't developers who didn't find the docs. They found them, read them, and the docs failed.
+
+## Time to first call is the metric, but most teams don't track it
+
+The clearest signal of DX documentation quality is time to first successful API call. How long does it take a new developer, starting from your landing page, to make a working request?
+
+Teams with strong DX documentation get this number below ten minutes. Developers who can't make a successful call within ten minutes have a measurably higher abandonment rate. The drop-off is steep. Every minute the process takes beyond that threshold increases the chance a developer gives up.
+
+Most teams don't measure this. They measure documentation volume (pages published, words written) or documentation coverage (endpoints documented, parameters described). Those metrics tell you whether docs exist. They don't tell you whether the docs work.
+
+The gap matters because completeness and accuracy are different problems. A complete doc set can still be wrong. A doc that covers every endpoint is still actively harmful if it describes those endpoints inaccurately.
+
+According to [research from DX Index](https://getdx.com/blog/developer-documentation/), each one-point improvement in documentation quality score correlates to 13 minutes saved per developer per week. That's an internal productivity number, but the same dynamic applies to external adoption: accurate docs that get developers to their first success faster convert more of them into active users.
+
+## The trust deficit is already priced in
+
+Here's what makes the accuracy problem hard: developers don't trust documentation by default.
+
+Only 3% of engineers fully trust their documentation repositories. That figure comes from research across engineering teams, and it reflects a rational response to accumulated experience. Developers have been burned enough times by stale docs that they've learned to verify.
+
+This is the trust deficit. Developers read your docs with one hand on the source code or community forum, ready to check. When the docs are accurate, this doesn't matter much. When they're not, a developer who's already skeptical hits one wrong thing and their confidence collapses.
+
+The consequence is silent abandonment. [Research consistently estimates](https://userguiding.com/blog/user-onboarding-statistics) that around 50% of developers abandon an API when documentation fails them. They don't file support tickets explaining what went wrong. They leave. If you're not measuring activation rate and tracing drop-off back to specific documentation failures, you don't see this happening.
+
+73% of development teams struggle with documentation that developers actually use. The 27% that get it right see 40% faster onboarding and 35% fewer support tickets. The gap between those groups is not documentation volume. It's documentation accuracy maintained over time.
+
+<BlogNewsletterCTA />
+
+## AI agents amplify the cost of stale docs
+
+In 2025, a stale doc page misleads one developer at a time. In 2026, it misleads every developer using any AI tool that indexed your documentation.
+
+Coding agents (Cursor, Claude Code, GitHub Copilot, and others) read developer documentation as part of their context. When a developer asks "how do I authenticate against the Acme API?", the agent finds your authentication guide, reads it, and answers from what it finds. If that guide references a deprecated token format, the agent generates code using the deprecated format. The developer gets a confident, wrong answer with no indication anything is off.
+
+This is the same dynamic described in [agent context file maintenance](/blog/technical/agent-context-files-explained): agents don't flag when they're working from stale information. They reason forward from whatever they retrieved. A wrong premise in step two becomes the unquestioned foundation for everything after.
+
+The blast radius is larger than it looks. A single outdated page in your developer docs now propagates its misinformation to every AI-assisted developer who asks a related question. The wrong answer gets served consistently, across tools, until someone traces the error back to the source.
+
+Good DX documentation has the opposite effect. Accurate, well-structured docs reach more developers more efficiently through agents than they ever could through search alone. Agents that can find the right information give correct answers on the first try. Developers who get correct answers on the first try keep building.
+
+## Accuracy after launch is the actual problem
+
+Most DX documentation programs are launch-oriented. A team publishes docs when the API ships. They're accurate at that moment. Then the product evolves.
+
+Endpoints get deprecated. Parameters get renamed. Authentication flows get updated. SDK versions change. The docs don't update automatically. Someone has to notice that a change happened and decide to update the relevant pages.
+
+In practice, this surveillance work fails at scale. Engineers who ship changes know the docs need updating but move on to the next ticket. Documentation owners who don't write the code have to discover changes by watching pull requests or waiting for a support ticket that traces back to a stale page. [Documentation drift](/blog/technical/documentation-drift-detection-problem) is a detection problem: the writing is easy once someone knows what changed.
+
+The teams that keep their DX documentation accurate have converged on a few structural fixes.
+
+Every page has a named owner. Not "the docs team." A specific person whose job includes updating that page when the underlying feature changes. Without that, pages drift until someone notices the damage.
+
+Review triggers are the second piece. Documentation updates belong in the same PR as the code change. When an endpoint is deprecated, the relevant docs get updated in the same commit. Not scheduled for later. Not filed as a follow-up ticket.
+
+The third fix is automation. Manual surveillance (watching PRs, attending standups, waiting for support tickets) doesn't scale past a certain codebase size. Teams that stay ahead of drift use tooling that detects when documentation no longer matches the product, before a developer hits the discrepancy.
+
+The last point is where most programs fall short. Quarterly audits and documentation sprints catch some drift. They miss the gaps that opened between audits. The [changelog communication problem](/blog/technical/api-changelog-best-practices) applies here too: knowing that a change happened isn't enough if the downstream documentation never catches up.
+
+## What DX docs actually need to be
+
+The most accurate framing I've found for developer experience documentation: it's a product, not a document.
+
+Products have owners. Products get updated when the underlying system changes. Products get measured against outcomes: not whether they were published, but whether they work. Documentation that's treated like a product gets maintained like one.
+
+The barrier to this shift is usually organizational: documentation gets owned by a team that isn't in the loop when product changes ship. Fixing that is partly a process problem and partly a tooling problem. You need the right triggers (what change should kick off a doc review?) and the right visibility (how do you know which pages are stale without reading every one of them?).
+
+Both problems are solvable. Teams that solve them have documentation their developers trust. That trust shows up in activation rates, support volume, and, increasingly, in the quality of answers AI agents give on their behalf.
+
+Promptless monitors your documentation against your actual product and codebase, surfacing what's outdated before a developer or their agent encounters it. The same mechanism that keeps your API reference accurate keeps your quickstarts and tutorials accurate. Both fail in the same way when the product moves on without them.
+
+<BlogRequestDemo />

--- a/src/content/blog/technical/developer-experience-documentation.mdx
+++ b/src/content/blog/technical/developer-experience-documentation.mdx
@@ -12,45 +12,45 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-A developer lands on your quickstart. They copy the code sample. They run it. It fails. The authentication format changed four months ago and the quickstart never caught up.
+A developer lands on your quickstart, copies the code sample, and runs it. It fails, because the authentication format changed four months ago and the quickstart never caught up.
 
-They try the reference docs. The endpoint is there. The parameters look right. They try again. Still fails. Fifteen minutes in, they open a competitor's docs.
+They check the reference docs. The endpoint is there, and the parameters look right, but the call still fails. Fifteen minutes in, they open a competitor's docs.
 
-You didn't lose them because your API is bad. You lost them because your documentation told them something that used to be true.
+Your documentation lost this developer. It told them something that used to be true.
 
-## Documentation is the DX, not support for it
+## Documentation is the developer experience
 
-Developer experience covers everything from onboarding to production: SDKs, CLIs, tooling, support channels, community. But the first thing most developers encounter is the docs.
+Developer experience covers everything from onboarding to production. It includes SDKs, CLIs, tooling, support channels, and community. Most developers encounter the docs first.
 
-Before writing a single line of code against your API, a developer reads the quickstart. They skim the reference. They look for a tutorial that matches their use case. That reading experience is the product demo for most API evaluations.
+Before writing a single line of code, a developer reads the quickstart, skims the reference, and looks for a tutorial that matches their use case. That reading experience is the product demo for most API evaluations.
 
 Most teams treat documentation as a support resource, something that reduces tickets and helps existing users. That framing is too narrow. Your docs are the interface developers use to decide whether to adopt your product at all.
 
-[Postman's 2024 State of the API survey](https://www.postman.com/state-of-api/2024) found that 44% of developers dig through source code to understand an API because the documentation doesn't give them what they need. These aren't developers who didn't find the docs. They found them, read them, and the docs failed.
+[Postman's 2024 State of the API survey](https://www.postman.com/state-of-api/2024) found that 44% of developers dig through source code to understand an API because the documentation didn't give them what they needed. These developers found the docs and read them. The docs failed them anyway.
 
-## Time to first call is the metric, but most teams don't track it
+## Time to first call is the metric most teams skip
 
-The clearest signal of DX documentation quality is time to first successful API call. How long does it take a new developer, starting from your landing page, to make a working request?
+The clearest signal of DX documentation quality is time to first successful API call. This measures how long a new developer takes, starting from your landing page, to make a working request.
 
-Teams with strong DX documentation get this number below ten minutes. Developers who can't make a successful call within ten minutes have a measurably higher abandonment rate. The drop-off is steep. Every minute the process takes beyond that threshold increases the chance a developer gives up.
+Teams with strong DX documentation get this number below ten minutes. Developers who can't make a successful call within ten minutes have a measurably higher abandonment rate. The drop-off is steep. Every minute beyond that threshold increases the chance a developer gives up.
 
-Most teams don't measure this. They measure documentation volume (pages published, words written) or documentation coverage (endpoints documented, parameters described). Those metrics tell you whether docs exist. They don't tell you whether the docs work.
+Most teams don't measure this. They track documentation volume instead, the count of pages published and words written. Or they track documentation coverage, the count of endpoints documented and parameters described. Those metrics tell you whether docs exist. They don't tell you whether the docs work.
 
 The gap matters because completeness and accuracy are different problems. A complete doc set can still be wrong. A doc that covers every endpoint is still actively harmful if it describes those endpoints inaccurately.
 
-According to [research from DX Index](https://getdx.com/blog/developer-documentation/), each one-point improvement in documentation quality score correlates to 13 minutes saved per developer per week. That's an internal productivity number, but the same dynamic applies to external adoption: accurate docs that get developers to their first success faster convert more of them into active users.
+[Research from DX Index](https://getdx.com/blog/developer-documentation/) found that each one-point improvement in documentation quality score saves 13 minutes per developer per week. That number measures internal productivity. The same effect applies to external adoption. Accurate docs that get developers to their first success faster convert more of them into active users.
 
-## The trust deficit is already priced in
+## Developers already distrust your docs
 
-Here's what makes the accuracy problem hard: developers don't trust documentation by default.
+The accuracy problem is hard because developers don't trust documentation by default.
 
-Only 3% of engineers fully trust their documentation repositories. That figure comes from research across engineering teams, and it reflects a rational response to accumulated experience. Developers have been burned enough times by stale docs that they've learned to verify.
+Only 3% of engineers fully trust their documentation repositories. This figure comes from research across engineering teams. It reflects a rational response built from experience. Developers have been burned by stale docs before, so they have learned to verify everything.
 
-This is the trust deficit. Developers read your docs with one hand on the source code or community forum, ready to check. When the docs are accurate, this doesn't matter much. When they're not, a developer who's already skeptical hits one wrong thing and their confidence collapses.
+This is the trust deficit. Developers read your docs while keeping the source code or community forum open, ready to check facts. When docs are accurate, this habit costs little. When docs are wrong, a skeptical developer hits one error and loses confidence fast.
 
-The consequence is silent abandonment. [Research consistently estimates](https://userguiding.com/blog/user-onboarding-statistics) that around 50% of developers abandon an API when documentation fails them. They don't file support tickets explaining what went wrong. They leave. If you're not measuring activation rate and tracing drop-off back to specific documentation failures, you don't see this happening.
+The consequence is silent abandonment. [Research estimates](https://userguiding.com/blog/user-onboarding-statistics) that around 50% of developers abandon an API when documentation fails them. They leave without filing a support ticket that explains why. You must measure activation rate and trace drop-off back to specific documentation failures to see this happening.
 
-73% of development teams struggle with documentation that developers actually use. The 27% that get it right see 40% faster onboarding and 35% fewer support tickets. The gap between those groups is not documentation volume. It's documentation accuracy maintained over time.
+73% of development teams struggle with documentation that developers actually use. The 27% that get it right see 40% faster onboarding and 35% fewer support tickets. The gap between those groups is documentation accuracy maintained over time.
 
 <BlogNewsletterCTA />
 
@@ -58,42 +58,42 @@ The consequence is silent abandonment. [Research consistently estimates](https:/
 
 In 2025, a stale doc page misleads one developer at a time. In 2026, it misleads every developer using any AI tool that indexed your documentation.
 
-Coding agents (Cursor, Claude Code, GitHub Copilot, and others) read developer documentation as part of their context. When a developer asks "how do I authenticate against the Acme API?", the agent finds your authentication guide, reads it, and answers from what it finds. If that guide references a deprecated token format, the agent generates code using the deprecated format. The developer gets a confident, wrong answer with no indication anything is off.
+Coding agents such as Cursor, Claude Code, and GitHub Copilot read developer documentation as part of their context. A developer asks the agent how to authenticate against the Acme API. The agent finds your authentication guide, reads it, and answers from what it finds. If that guide references a deprecated token format, the agent generates code using the deprecated format. The developer gets a confident, wrong answer with no warning that anything is off.
 
-This is the same dynamic described in [agent context file maintenance](/blog/technical/agent-context-files-explained): agents don't flag when they're working from stale information. They reason forward from whatever they retrieved. A wrong premise in step two becomes the unquestioned foundation for everything after.
+The same pattern appears in [agent context file maintenance](/blog/technical/agent-context-files-explained). Agents do not flag when they work from stale information. They reason forward from whatever they retrieved. A wrong premise in step two becomes the foundation for every step after.
 
-The blast radius is larger than it looks. A single outdated page in your developer docs now propagates its misinformation to every AI-assisted developer who asks a related question. The wrong answer gets served consistently, across tools, until someone traces the error back to the source.
+The damage spreads wider than it looks. A single outdated page in your developer docs spreads its wrong information to every AI-assisted developer who asks a related question. The wrong answer gets served the same way across tools until someone traces the error back to the source.
 
-Good DX documentation has the opposite effect. Accurate, well-structured docs reach more developers more efficiently through agents than they ever could through search alone. Agents that can find the right information give correct answers on the first try. Developers who get correct answers on the first try keep building.
+Good DX documentation has the opposite effect. Accurate, well-structured docs reach more developers through agents than through search alone. Agents that find the right information give correct answers on the first try. Developers who get correct answers on the first try keep building.
 
 ## Accuracy after launch is the actual problem
 
-Most DX documentation programs are launch-oriented. A team publishes docs when the API ships. They're accurate at that moment. Then the product evolves.
+Most DX documentation programs are launch-oriented. A team publishes docs when the API ships, and the docs are accurate at that moment. Then the product evolves.
 
-Endpoints get deprecated. Parameters get renamed. Authentication flows get updated. SDK versions change. The docs don't update automatically. Someone has to notice that a change happened and decide to update the relevant pages.
+Endpoints get deprecated, parameters get renamed, authentication flows get updated, and SDK versions change. The docs don't update automatically. Someone has to notice each change and decide to update the relevant pages.
 
-In practice, this surveillance work fails at scale. Engineers who ship changes know the docs need updating but move on to the next ticket. Documentation owners who don't write the code have to discover changes by watching pull requests or waiting for a support ticket that traces back to a stale page. [Documentation drift](/blog/technical/documentation-drift-detection-problem) is a detection problem: the writing is easy once someone knows what changed.
+In practice, this surveillance work fails at scale. Engineers who ship changes know the docs need updating but move on to the next ticket. Documentation owners who don't write the code have to discover changes by watching pull requests or waiting for a support ticket that traces back to a stale page. [Documentation drift](/blog/technical/documentation-drift-detection-problem) is a detection problem. The writing is easy once someone knows what changed.
 
 The teams that keep their DX documentation accurate have converged on a few structural fixes.
 
-Every page has a named owner. Not "the docs team." A specific person whose job includes updating that page when the underlying feature changes. Without that, pages drift until someone notices the damage.
+Every page needs a named owner. This is one specific person whose job includes updating the page when the underlying feature changes. Pages without a named owner drift until someone notices the damage.
 
-Review triggers are the second piece. Documentation updates belong in the same PR as the code change. When an endpoint is deprecated, the relevant docs get updated in the same commit. Not scheduled for later. Not filed as a follow-up ticket.
+Review triggers are the second piece. Documentation updates belong in the same pull request as the code change. When an endpoint is deprecated, the relevant docs get updated in that same commit, immediately.
 
-The third fix is automation. Manual surveillance (watching PRs, attending standups, waiting for support tickets) doesn't scale past a certain codebase size. Teams that stay ahead of drift use tooling that detects when documentation no longer matches the product, before a developer hits the discrepancy.
+The third fix is automation. Manual surveillance, meaning someone watches pull requests, attends standups, and waits for support tickets, doesn't scale past a certain codebase size. Teams that stay ahead of drift use tooling that detects when documentation no longer matches the product. This catches the problem before a developer hits the discrepancy.
 
-The last point is where most programs fall short. Quarterly audits and documentation sprints catch some drift. They miss the gaps that opened between audits. The [changelog communication problem](/blog/technical/api-changelog-best-practices) applies here too: knowing that a change happened isn't enough if the downstream documentation never catches up.
+The last point is where most programs fall short. Quarterly audits and documentation sprints catch some drift, but they miss the gaps that open between audits. The [changelog communication problem](/blog/technical/api-changelog-best-practices) applies here too. Knowing that a change happened is not enough on its own. The downstream documentation must catch up as well.
 
-## What DX docs actually need to be
+## What DX docs need to be
 
-The most accurate framing I've found for developer experience documentation: it's a product, not a document.
+Developer experience documentation works best as a product.
 
-Products have owners. Products get updated when the underlying system changes. Products get measured against outcomes: not whether they were published, but whether they work. Documentation that's treated like a product gets maintained like one.
+A product has an owner, and it gets updated when the underlying system changes. Teams measure a product by whether it works. Documentation that follows this model gets maintained like a product.
 
-The barrier to this shift is usually organizational: documentation gets owned by a team that isn't in the loop when product changes ship. Fixing that is partly a process problem and partly a tooling problem. You need the right triggers (what change should kick off a doc review?) and the right visibility (how do you know which pages are stale without reading every one of them?).
+The barrier to this shift is usually organizational. Documentation gets owned by a team that is not in the loop when product changes ship. Fixing this requires both process changes and tooling changes. Teams need clear triggers that tell them which change should start a doc review. Teams also need visibility into which pages have gone stale, without reading every page to find out.
 
-Both problems are solvable. Teams that solve them have documentation their developers trust. That trust shows up in activation rates, support volume, and, increasingly, in the quality of answers AI agents give on their behalf.
+Both problems are solvable. Teams that solve them have documentation their developers trust. That trust shows up in activation rates and support volume. It also shows up in the quality of answers AI agents give on a company's behalf.
 
-Promptless monitors your documentation against your actual product and codebase, surfacing what's outdated before a developer or their agent encounters it. The same mechanism that keeps your API reference accurate keeps your quickstarts and tutorials accurate. Both fail in the same way when the product moves on without them.
+Promptless monitors your documentation against your actual product and codebase. It flags what's outdated before a developer or their agent runs into it. The same mechanism keeps your API reference accurate. It also keeps your quickstarts and tutorials accurate. Both fail the same way when the product moves on without them.
 
 <BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer experience documentation`

## Article plan

**Thesis:** Developer experience documentation fails when teams treat it as a launch deliverable. The teams with better activation rates treat it as a maintained product with ownership, freshness SLAs, and change detection.

**Target reader:** Developer advocates, DevRel engineers, and technical writers at API-first companies who have shipped docs but are seeing developer drop-off or rising support load.

**Key angles:**
- Documentation is the first DX touchpoint — the "try before you buy" surface for most API evaluations
- 10-minute-to-first-call is the most concrete DX docs metric, but most teams don't track it
- Only 3% of engineers fully trust their doc repos — the default developer assumption is that docs are wrong
- AI agents amplify both sides: good docs reach more developers via agents; stale docs mislead all of them
- The fix is ownership + review triggers + automated drift detection, not quarterly audits

**Promptless connection:** DX docs are the highest-traffic, most-visible layer of the knowledge graph and the one that drifts fastest. Promptless surfaces what's outdated before developers (and their agents) hit it.

## File

`src/content/blog/technical/developer-experience-documentation.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_013XYmhLZMaxvdb8UxssdruV)_