### PR TITLE
content: Developer Relations Docs Have a New Primary Reader

### DIFF
--- a/src/content/blog/technical/developer-relations-docs-agent-primary-reader.mdx
+++ b/src/content/blog/technical/developer-relations-docs-agent-primary-reader.mdx
@@ -1,0 +1,75 @@
+---
+title: 'Developer Relations Docs Have a New Primary Reader'
+subtitle: Published August 2026
+description: >-
+  AI coding agents now consume developer relations docs at higher volume than humans on many sites. Here is what that means for what DevRel teams should write.
+date: '2026-08-03T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Fern, a developer docs platform, claims a 90%+ reduction in token usage by serving clean markdown to LLM bot traffic. They made that change because bots were already the majority of their traffic. Mintlify now auto-hosts an MCP server for every docs site. GitBook added llms.txt support in January 2025.
+
+These are infrastructure decisions, and infrastructure follows usage. Someone ran the numbers and concluded that AI agents reading documentation were worth optimizing for.
+
+The question for developer relations teams is what to do about it.
+
+## The gap between what agents need and what DevRel docs provide
+
+The [Stack Overflow Developer Survey 2025](https://survey.stackoverflow.co/2025/) found that 66% of developers cite "AI solutions that are almost right, but not quite" as their top AI pain point. A separate industry analysis from 2025 found that 65% of developers say their AI coding assistant specifically misses relevant context during code review and refactoring.
+
+That gap has a source: the documentation. AI assistants fetch what exists. If what exists is stale or built for a reader who skims, the agent answer will be wrong.
+
+Developer advocates and technical writers have always written for a human reader who can ask a follow-up question and forgive some ambiguity. Agents can't do either. They take what the context window contains and generate from it.
+
+When the documentation is thin or outdated, the agent answer is confidently wrong.
+
+## Context rot is not a model problem
+
+The underlying issue has a name in AI research: context rot. A [2025 study from Chroma](https://www.trychroma.com/engineering/context-rot) evaluated 18 frontier models and found that every one showed performance degradation as input length increased. Context rot happens well before the window fills, on simple tasks, across all major models.
+
+A related effect causes 30%+ accuracy drops for information positioned in the middle of a long context. Agents do not read top-to-bottom and weight everything equally. They lose track of things buried in the middle.
+
+What this means for developer relations docs: length actively works against you. Every stale endpoint and deprecated parameter in your documentation degrades the outputs agents produce for developers using your product.
+
+<BlogNewsletterCTA />
+
+## More is not better
+
+The natural instinct when told that agents are consuming your docs is to write more: more guides, more context files. The research suggests this instinct is wrong.
+
+A [February 2026 paper from ETH Zurich](https://arxiv.org/abs/2602.11988) studied AGENTS.md files across more than 60,000 open-source repositories. AGENTS.md is a context file format that gives AI coding agents product-specific instructions. The finding: providing these context files did not generally improve task success rates. It increased inference cost by more than 20% on average.
+
+The researchers recommended omitting LLM-generated context files and including only minimal, specific requirements: which test runner to use, which commands to avoid, constraints specific to the project.
+
+The pattern holds in practice. More content increases the probability that an agent's context window fills with material that is not relevant to the current task. Signal-to-noise ratio matters more than completeness.
+
+## What DevRel teams should actually change
+
+DevRelCon 2026 opened a dedicated track for writing docs for both human and agent users. The framing that came out of that work aligns with the research: the goal is documentation with a higher standard of precision and a lower tolerance for drift.
+
+Three specific changes have the most impact.
+
+**Task-scoped content over comprehensive reference.** Agents retrieve documentation for a specific task. A guide that answers "how do I paginate the responses API" outperforms a reference page that covers the entire responses object with every parameter. Break long pages into task-scoped units. Give each one a specific title that matches how developers phrase the question. The [practical guide to optimizing docs for agents](/blog/technical/agent-docs) covers how agents actually access your content and which structural changes matter most.
+
+**Freshness markers.** Agents cannot tell when your documentation was last updated. If your docs describe an API that changed six months ago, the agent will give your user instructions for the old behavior. Explicit version tags and last-updated dates give agents a signal about reliability. They also create internal pressure to keep content current.
+
+**Minimal, high-signal context files.** If you maintain a CLAUDE.md, AGENTS.md, or [llms.txt](/blog/technical/llms-txt-is-not-what-most-teams-think) for your product, keep them short. Based on the ETH Zurich data, under 200 lines is a reasonable ceiling. Focus on what is genuinely non-obvious: authentication quirks and rate limits that are lower than developers expect. Do not restate what the reference docs already say.
+
+## The second problem: stale docs now fail two audiences
+
+There is a reason documentation decay has always been a problem for developer relations teams. Docs go out of date because products change faster than documentation workflows catch up. The typical result was a frustrated developer who found the wrong answer and had to try something else.
+
+Now it is two audiences. A developer using an AI coding assistant to integrate your API will get the wrong answer from the assistant. They may not know the answer came from your documentation. They will see a confident response and try to implement it.
+
+[Zylos AI's 2025 analysis](https://zylosai.com/) attributed 65% of enterprise AI failures to context drift or memory loss during multi-step reasoning. Agents working from bad inputs fail at higher rates than agents working from accurate ones.
+
+The documentation your DevRel team publishes is now part of the reasoning chain for millions of developer tasks per day. Keeping it accurate and current has always been the goal. The consequences of missing that goal are now larger, and [documentation drift](/blog/technical/documentation-drift-detection-problem) is harder to catch than it looks.
+
+If you want to see where your docs stand today on accuracy and coverage, [Promptless monitors for documentation drift](/), flagging gaps and outdated content before they reach developers or the agents working on their behalf.
+
+<BlogRequestDemo />

--- a/src/content/blog/technical/developer-relations-docs-agent-primary-reader.mdx
+++ b/src/content/blog/technical/developer-relations-docs-agent-primary-reader.mdx
@@ -12,64 +12,64 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-Fern, a developer docs platform, claims a 90%+ reduction in token usage by serving clean markdown to LLM bot traffic. They made that change because bots were already the majority of their traffic. Mintlify now auto-hosts an MCP server for every docs site. GitBook added llms.txt support in January 2025.
+Fern, a developer docs platform, claims a 90%+ reduction in token usage. It serves clean markdown to LLM bot traffic instead of full HTML pages. Bots already sent more traffic than humans, so Fern made the change. Mintlify now auto-hosts an MCP server for every docs site. GitBook added llms.txt support in January 2025.
 
-These are infrastructure decisions, and infrastructure follows usage. Someone ran the numbers and concluded that AI agents reading documentation were worth optimizing for.
+These are infrastructure decisions, and infrastructure follows usage. Someone measured the traffic and decided that AI agents reading documentation were worth the investment.
 
-The question for developer relations teams is what to do about it.
+Developer relations teams must now decide what to do about it.
 
 ## The gap between what agents need and what DevRel docs provide
 
-The [Stack Overflow Developer Survey 2025](https://survey.stackoverflow.co/2025/) found that 66% of developers cite "AI solutions that are almost right, but not quite" as their top AI pain point. A separate industry analysis from 2025 found that 65% of developers say their AI coding assistant specifically misses relevant context during code review and refactoring.
+The [Stack Overflow Developer Survey 2025](https://survey.stackoverflow.co/2025/) found that 66% of developers cite "AI solutions that are almost right, but not quite" as their top AI pain point. A separate 2025 industry analysis found that 65% of developers say their AI coding assistant misses relevant context during code review and refactoring.
 
-That gap has a source: the documentation. AI assistants fetch what exists. If what exists is stale or built for a reader who skims, the agent answer will be wrong.
+Your docs cause that gap. AI assistants fetch whatever docs exist. If your docs are stale, the agent gives a wrong answer. If your docs are written for a reader who skims, the agent still gives a wrong answer.
 
-Developer advocates and technical writers have always written for a human reader who can ask a follow-up question and forgive some ambiguity. Agents can't do either. They take what the context window contains and generate from it.
+Developer advocates and technical writers write for a human reader. A human reader can ask a follow-up question and forgive some ambiguity. Agents cannot do either. They take only what fits in the context window and generate an answer from it.
 
-When the documentation is thin or outdated, the agent answer is confidently wrong.
+Thin or outdated docs produce a confidently wrong agent answer.
 
 ## Context rot is not a model problem
 
-The underlying issue has a name in AI research: context rot. A [2025 study from Chroma](https://www.trychroma.com/engineering/context-rot) evaluated 18 frontier models and found that every one showed performance degradation as input length increased. Context rot happens well before the window fills, on simple tasks, across all major models.
+AI research calls this issue context rot. A [2025 study from Chroma](https://www.trychroma.com/engineering/context-rot) tested 18 frontier models. Every model showed performance loss as input length increased. Context rot starts well before the context window fills up. It happens on simple tasks. It happens across all major models.
 
-A related effect causes 30%+ accuracy drops for information positioned in the middle of a long context. Agents do not read top-to-bottom and weight everything equally. They lose track of things buried in the middle.
+A related effect causes accuracy drops of 30%+ for information placed in the middle of a long context. Agents do not read top to bottom, and they do not weight every part of the input equally. They lose track of information buried in the middle.
 
-What this means for developer relations docs: length actively works against you. Every stale endpoint and deprecated parameter in your documentation degrades the outputs agents produce for developers using your product.
+Length works against developer relations docs. Every stale endpoint in your docs lowers the quality of agent answers. Every deprecated parameter in your docs does the same.
 
 <BlogNewsletterCTA />
 
 ## More is not better
 
-The natural instinct when told that agents are consuming your docs is to write more: more guides, more context files. The research suggests this instinct is wrong.
+When agents start reading your docs, the natural instinct is to write more. Teams add more guides. Teams add more context files. A [February 2026 paper from ETH Zurich](https://arxiv.org/abs/2602.11988) shows this instinct is wrong.
 
-A [February 2026 paper from ETH Zurich](https://arxiv.org/abs/2602.11988) studied AGENTS.md files across more than 60,000 open-source repositories. AGENTS.md is a context file format that gives AI coding agents product-specific instructions. The finding: providing these context files did not generally improve task success rates. It increased inference cost by more than 20% on average.
+The ETH Zurich study examined AGENTS.md files across more than 60,000 open-source repositories. AGENTS.md is a context file format. It gives AI coding agents product-specific instructions. The study found that these context files did not generally improve task success rates. Adding them increased inference cost by more than 20% on average.
 
-The researchers recommended omitting LLM-generated context files and including only minimal, specific requirements: which test runner to use, which commands to avoid, constraints specific to the project.
+The researchers recommended a simpler approach. Omit LLM-generated context files. Include only specific instructions the agent cannot infer on its own, such as which test runner to use and which commands to avoid. Add any constraints that are unique to the project.
 
-The pattern holds in practice. More content increases the probability that an agent's context window fills with material that is not relevant to the current task. Signal-to-noise ratio matters more than completeness.
+The pattern holds in practice, too. More content raises the chance that an agent's context window fills with irrelevant material. Signal-to-noise ratio matters more than completeness.
 
-## What DevRel teams should actually change
+## What DevRel teams should change
 
-DevRelCon 2026 opened a dedicated track for writing docs for both human and agent users. The framing that came out of that work aligns with the research: the goal is documentation with a higher standard of precision and a lower tolerance for drift.
+DevRelCon 2026 opened a dedicated track for writing docs for both human and agent readers. This new framing matches the research. Docs need a higher standard of precision and a lower tolerance for drift.
 
-Three specific changes have the most impact.
+Three changes have the most impact.
 
-**Task-scoped content over comprehensive reference.** Agents retrieve documentation for a specific task. A guide that answers "how do I paginate the responses API" outperforms a reference page that covers the entire responses object with every parameter. Break long pages into task-scoped units. Give each one a specific title that matches how developers phrase the question. The [practical guide to optimizing docs for agents](/blog/technical/agent-docs) covers how agents actually access your content and which structural changes matter most.
+**Task-scoped content over complete reference.** Agents retrieve docs for one specific task. A guide that answers "how do I paginate the responses API" beats a reference page that covers the entire responses object with every parameter. Break long pages into task-scoped units. Give each unit a specific title that matches how developers phrase the question. The [practical guide to optimizing docs for agents](/blog/technical/agent-docs) explains how agents access your content and which structural changes matter most.
 
-**Freshness markers.** Agents cannot tell when your documentation was last updated. If your docs describe an API that changed six months ago, the agent will give your user instructions for the old behavior. Explicit version tags and last-updated dates give agents a signal about reliability. They also create internal pressure to keep content current.
+**Freshness markers.** Agents cannot tell when your docs were last updated. If your docs describe an API that changed six months ago, the agent gives your user instructions for the old behavior. Explicit version tags and last-updated dates give agents a signal about reliability. These markers also create internal pressure to keep content current.
 
-**Minimal, high-signal context files.** If you maintain a CLAUDE.md, AGENTS.md, or [llms.txt](/blog/technical/llms-txt-is-not-what-most-teams-think) for your product, keep them short. Based on the ETH Zurich data, under 200 lines is a reasonable ceiling. Focus on what is genuinely non-obvious: authentication quirks and rate limits that are lower than developers expect. Do not restate what the reference docs already say.
+**Minimal, high-signal context files.** If you maintain a CLAUDE.md, AGENTS.md, or [llms.txt](/blog/technical/llms-txt-is-not-what-most-teams-think) for your product, keep it short. The ETH Zurich data suggests under 200 lines as a reasonable ceiling. Focus on what is non-obvious. Cover authentication quirks and rate limits that are lower than developers expect. Do not restate what the reference docs already say.
 
-## The second problem: stale docs now fail two audiences
+## Stale docs now fail two audiences
 
-There is a reason documentation decay has always been a problem for developer relations teams. Docs go out of date because products change faster than documentation workflows catch up. The typical result was a frustrated developer who found the wrong answer and had to try something else.
+Documentation decay has always been a problem for developer relations teams. Products change faster than documentation workflows can track, so docs go out of date. In the past, this produced one frustrated developer who found the wrong answer and tried something else.
 
-Now it is two audiences. A developer using an AI coding assistant to integrate your API will get the wrong answer from the assistant. They may not know the answer came from your documentation. They will see a confident response and try to implement it.
+Now stale docs fail two audiences. A developer using an AI coding assistant to integrate your API gets a wrong answer from the assistant. The developer may not know the answer came from your docs. The developer sees a confident response and tries to implement it.
 
-[Zylos AI's 2025 analysis](https://zylosai.com/) attributed 65% of enterprise AI failures to context drift or memory loss during multi-step reasoning. Agents working from bad inputs fail at higher rates than agents working from accurate ones.
+[Zylos AI's 2025 analysis](https://zylosai.com/) attributed 65% of enterprise AI failures to context drift or memory loss during multi-step reasoning. Agents working from bad inputs fail more often than agents working from accurate inputs.
 
-The documentation your DevRel team publishes is now part of the reasoning chain for millions of developer tasks per day. Keeping it accurate and current has always been the goal. The consequences of missing that goal are now larger, and [documentation drift](/blog/technical/documentation-drift-detection-problem) is harder to catch than it looks.
+The docs your DevRel team publishes are now part of the reasoning chain for millions of developer tasks per day. Keeping docs accurate and current has always been the goal. The stakes are now higher. [Documentation drift](/blog/technical/documentation-drift-detection-problem) is harder to catch than it looks.
 
-If you want to see where your docs stand today on accuracy and coverage, [Promptless monitors for documentation drift](/), flagging gaps and outdated content before they reach developers or the agents working on their behalf.
+If you want to see where your docs stand today on accuracy and coverage, [Promptless monitors for documentation drift](/). Promptless flags gaps and outdated content before they reach developers or the agents working on their behalf.
 
 <BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer relations docs`

## Article plan

**Thesis:** AI coding agents now consume developer relations documentation at higher volume than humans on many sites, and this changes what "good docs" means: not more comprehensive, but more minimal, task-scoped, and current.

**Target reader:** Developer advocates and technical writers at developer-tools companies who know AI matters but are unsure what specifically to change about their docs.

**Key points:**
1. AI coding agents now read DevRel docs at higher volume than humans on many sites (Fern 90%+ token reduction data; Mintlify MCP server for every site)
2. 65% of developers say their AI coding assistant misses relevant context during code review — the gap comes from documentation gaps (Stack Overflow 2025)
3. Context rot: all 18 frontier models show performance degradation as input length increases, even well before context fills (Chroma 2025)
4. ETH Zurich Feb 2026 study of 60,000+ repos: AGENTS.md files increased inference cost 20%+ with no improvement in task success — more content is not better
5. Three concrete structural changes: task-scoped content, freshness markers, minimal context files
6. Docs going stale now harms two audiences simultaneously: human developers and the AI agents working on their behalf

**Sources:**
- Stack Overflow Developer Survey 2025
- Chroma context rot research (18 frontier models)
- ETH Zurich arXiv 2602.11988 (AGENTS.md study)
- Zylos AI 2025 enterprise analysis (65% of AI failures attributed to context drift)
- Fern, Mintlify, GitBook platform data

## File

`src/content/blog/technical/developer-relations-docs-agent-primary-reader.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVieDsJWDDzcWW2PTj7VkF)_