### PR TITLE
content: Developer Relations Docs: Why They Go Stale and Who Should Own Them

### DIFF
--- a/src/content/blog/technical/developer-relations-docs.mdx
+++ b/src/content/blog/technical/developer-relations-docs.mdx
@@ -1,0 +1,85 @@
+---
+title: 'Developer Relations Docs: Why They Go Stale and Who Should Own Them'
+subtitle: Published August 2026
+description: >-
+  DevRel docs break because responsibility is spread across too many teams, so nobody actually owns accuracy. Here's how to fix the ownership model.
+date: '2026-08-04T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Your API team shipped a new authentication flow three weeks ago. The migration guide is in your changelog. The getting-started guide on your developer portal still shows the old flow. Support tickets are piling up from developers who followed the documented path and hit a wall.
+
+Nobody meant for this to happen. The engineer who built the new auth flow updated the API reference. A developer advocate wrote the changelog entry. The getting-started guide lives in a CMS that three people have access to and none of them knew it needed updating.
+
+This is the structural problem with developer relations documentation. And it is not a writing problem.
+
+## The ownership gap at the center of DevRel docs
+
+Most developer relations teams produce a lot of documentation. Getting-started guides, tutorials, SDK reference docs, changelog entries, sample apps, blog posts. The volume is not the issue.
+
+The issue is that documentation responsibility in DevRel organizations tends to be distributed across teams that don't share a trigger for updates.
+
+Engineering owns the API reference. Product owns the changelog. DevRel writes the tutorials and guides. Technical writers, where they exist, help with structure and clarity. No single team owns the question: "Is everything still accurate?"
+
+When the product changes, the API reference gets updated because engineering's definition of done includes it. The changelog gets an entry because product runs the release process. The getting-started guide, the code samples, the tutorial that walks developers through the old authentication flow: those update on a slower cycle, if at all.
+
+After six months, documentation becomes unreliable. After a year, developers learn to distrust it by default and go straight to the source code or open a support ticket. That distrust, once established, is expensive to rebuild. One case study tracked the downstream cost of a single stale tutorial to 47 support hours, three churned customers, and a six-month period before developer community trust recovered.
+
+<BlogNewsletterCTA />
+
+## Two audiences, one set of docs
+
+The stakes for accuracy in developer relations documentation just got higher.
+
+In 2026, AI coding assistants have become the primary consumers of developer documentation. When a developer asks their coding agent to integrate with your API, the agent reads your docs first. It does not read between the lines. It does not cross-reference your changelog or ask a colleague if this function is still current. It reads what is there and generates code accordingly.
+
+65% of developers say their AI coding assistant misses relevant context during code review and refactoring. The missing context comes from gaps and inaccuracies in documentation. When docs are stale, agents produce confidently wrong code that looks right until it hits runtime.
+
+This matters for DevRel teams specifically. Human developers can compensate for incomplete documentation by drawing on experience and community resources. A coding agent cannot. It will follow the documented path exactly, which means a stale getting-started guide produces broken integrations at scale, one for every developer using an AI assistant to onboard to your product.
+
+The feedback loop has also tightened. When a developer follows broken docs, they might file a support ticket after a day of debugging. When an AI agent follows broken docs, the developer knows within seconds that something is wrong. The error surface is larger and faster.
+
+For more on how AI agents consume developer documentation and what that means for accuracy, see [Agent Context Files Explained: AGENTS.md, CLAUDE.md, and llms.txt](/blog/technical/agent-context-files-explained).
+
+## API changes are the main driver of doc staleness
+
+Developer documentation doesn't go stale uniformly. Conceptual content (what your API does, why you built it a certain way) stays accurate much longer than procedural content (how to authenticate, which endpoints to call, what the response schema looks like).
+
+Procedural content breaks when the API changes. And API changes are constant in developer-facing products. New endpoints, deprecated parameters, revised authentication flows, updated rate limits: each of these is a potential gap between what the docs say and what the API does.
+
+The reason this gap persists is that API changes don't automatically trigger documentation reviews. Engineering's release process ends when the code ships. The downstream documentation review is a separate action that requires someone to remember it and have bandwidth to do it. In practice, it often happens late or not at all.
+
+[Documentation drift](/blog/technical/documentation-drift-detection-problem) is a detection problem: teams don't discover stale docs through a monitoring system, they discover them through developer complaints. By the time a support ticket arrives, a lot of developers have already hit the same broken path and silently moved on.
+
+The documentation versioning problem is related. Every API version you support multiplies your maintenance surface. A tutorial written for v2 may be partially accurate for v3, but "partially accurate" is worse than no tutorial at all when an AI agent is following it literally. See [Documentation Versioning Best Practices for API Teams](/blog/technical/documentation-versioning-maintenance-multiplier) for how teams structure this.
+
+## What the ownership model needs to look like
+
+The fix is not better writers or more documentation tooling. It is a change in how teams assign responsibility for accuracy.
+
+Three things need to be explicit:
+
+**Who owns each piece of documentation.** Not "DevRel owns docs" but "this getting-started guide is owned by this person, and this SDK reference is owned by that team." Shared ownership with no individual accountable is the same as no ownership.
+
+**What triggers a documentation review.** An API change is a trigger. A deprecation is a trigger. A new SDK release is a trigger. These triggers should be documented in the same place as the ownership assignments. When the trigger fires, the owner reviews.
+
+**How drift is detected when triggers are missed.** Ownership and triggers work when everyone follows the process. They fail when a change ships without the right people knowing about it, or when a doc page isn't connected to the code it describes. Automated monitoring that compares documentation against the current API spec or codebase closes this gap.
+
+This is what [treating documentation like code](/blog/technical/help-center-to-docs-as-code) actually means in practice. Explicit ownership, version-controlled content, and a process for detecting when content diverges from the system it describes.
+
+## The developer trust calculation
+
+Developer trust in your documentation is an asset that takes time to build and almost no time to lose. A developer who follows your getting-started guide, hits a wall because the docs are wrong, and spends two hours debugging an issue that would have taken ten minutes with accurate documentation: that developer does not come back and try again. Most often, they move on.
+
+At scale, this affects your developer experience metrics. Time to First Call, a standard measure of how long it takes a developer to make a successful API call, is directly correlated with documentation accuracy. Inaccurate getting-started guides inflate this number without any change to the API itself.
+
+[Developer Documentation ROI: The Metrics That Actually Matter](/blog/technical/developer-documentation-roi) covers how to make this case to leadership in terms they can act on.
+
+The cost of accurate documentation is the time it takes to maintain it. The cost of inaccurate documentation is developer trust, support load, and integration failures at scale. For most developer-facing companies, the comparison is not close.
+
+<BlogRequestDemo />

--- a/src/content/blog/technical/developer-relations-docs.mdx
+++ b/src/content/blog/technical/developer-relations-docs.mdx
@@ -14,72 +14,70 @@ import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
 Your API team shipped a new authentication flow three weeks ago. The migration guide is in your changelog. The getting-started guide on your developer portal still shows the old flow. Support tickets are piling up from developers who followed the documented path and hit a wall.
 
-Nobody meant for this to happen. The engineer who built the new auth flow updated the API reference. A developer advocate wrote the changelog entry. The getting-started guide lives in a CMS that three people have access to and none of them knew it needed updating.
+Nobody meant for this to happen. The engineer who built the new authentication flow updated the API reference. A developer advocate wrote the changelog entry. The getting-started guide lives in a CMS that three people can access, and none of them knew it needed an update.
 
-This is the structural problem with developer relations documentation. And it is not a writing problem.
+Developer relations documentation has a structural problem. The way teams assign ownership causes it.
 
-## The ownership gap at the center of DevRel docs
+## The ownership gap in DevRel docs
 
-Most developer relations teams produce a lot of documentation. Getting-started guides, tutorials, SDK reference docs, changelog entries, sample apps, blog posts. The volume is not the issue.
+Most developer relations teams produce a lot of documentation. They write getting-started guides, tutorials, SDK reference docs, changelog entries, sample apps, and blog posts.
 
-The issue is that documentation responsibility in DevRel organizations tends to be distributed across teams that don't share a trigger for updates.
+The real problem is how teams share responsibility for that documentation. Different teams own different pieces. No single trigger tells them to update at the same time.
 
-Engineering owns the API reference. Product owns the changelog. DevRel writes the tutorials and guides. Technical writers, where they exist, help with structure and clarity. No single team owns the question: "Is everything still accurate?"
+Engineering owns the API reference, and product owns the changelog. DevRel writes the tutorials and guides. Technical writers, when present, help with structure and clarity. No single team owns the question of overall accuracy.
 
-When the product changes, the API reference gets updated because engineering's definition of done includes it. The changelog gets an entry because product runs the release process. The getting-started guide, the code samples, the tutorial that walks developers through the old authentication flow: those update on a slower cycle, if at all.
+When the product changes, the API reference gets updated. Engineering's definition of done requires it. The changelog gets an entry because product runs the release process. The getting-started guide, the code samples, and the tutorial for the old authentication flow update on a slower cycle. Sometimes they do not update at all.
 
-After six months, documentation becomes unreliable. After a year, developers learn to distrust it by default and go straight to the source code or open a support ticket. That distrust, once established, is expensive to rebuild. One case study tracked the downstream cost of a single stale tutorial to 47 support hours, three churned customers, and a six-month period before developer community trust recovered.
+After six months, documentation becomes unreliable. After a year, developers learn to distrust it by default. They go straight to the source code, or they open a support ticket. Once developers lose trust, it is expensive to rebuild. One case study measured this cost for a single stale tutorial. The stale tutorial caused 47 support hours of extra work and three churned customers. Developer community trust took six months to recover.
 
 <BlogNewsletterCTA />
 
 ## Two audiences, one set of docs
 
-The stakes for accuracy in developer relations documentation just got higher.
+Accuracy in developer relations documentation matters more now than before.
 
-In 2026, AI coding assistants have become the primary consumers of developer documentation. When a developer asks their coding agent to integrate with your API, the agent reads your docs first. It does not read between the lines. It does not cross-reference your changelog or ask a colleague if this function is still current. It reads what is there and generates code accordingly.
+In 2026, AI coding assistants became the primary consumers of developer documentation. When a developer asks an AI coding assistant to integrate with an API, the assistant reads the docs first. The assistant takes the documentation at face value. It skips the changelog, and it skips asking a colleague whether a function still works. Then it generates code directly from what the docs say.
 
-65% of developers say their AI coding assistant misses relevant context during code review and refactoring. The missing context comes from gaps and inaccuracies in documentation. When docs are stale, agents produce confidently wrong code that looks right until it hits runtime.
+65% of developers say their AI coding assistant misses relevant context during code review and refactoring. The missing context comes from gaps and inaccuracies in documentation. When docs are stale, AI coding assistants produce confidently wrong code. The code looks correct until it fails at runtime.
 
-This matters for DevRel teams specifically. Human developers can compensate for incomplete documentation by drawing on experience and community resources. A coding agent cannot. It will follow the documented path exactly, which means a stale getting-started guide produces broken integrations at scale, one for every developer using an AI assistant to onboard to your product.
+This matters most for DevRel teams. Human developers can compensate for incomplete documentation by drawing on experience and community resources, but an AI coding assistant cannot. It follows the documented path exactly. A stale getting-started guide then produces broken integrations at scale, one for every developer who uses an AI coding assistant to onboard.
 
-The feedback loop has also tightened. When a developer follows broken docs, they might file a support ticket after a day of debugging. When an AI agent follows broken docs, the developer knows within seconds that something is wrong. The error surface is larger and faster.
+The feedback loop has also become faster. When a developer follows broken docs, they may debug for a day before filing a support ticket. When an AI coding assistant follows broken docs, the developer sees the error within seconds. Errors now surface more often, and they surface faster.
 
-For more on how AI agents consume developer documentation and what that means for accuracy, see [Agent Context Files Explained: AGENTS.md, CLAUDE.md, and llms.txt](/blog/technical/agent-context-files-explained).
+For more on how AI coding assistants consume developer documentation, see [Agent Context Files Explained: AGENTS.md, CLAUDE.md, and llms.txt](/blog/technical/agent-context-files-explained).
 
-## API changes are the main driver of doc staleness
+## API changes drive documentation staleness
 
-Developer documentation doesn't go stale uniformly. Conceptual content (what your API does, why you built it a certain way) stays accurate much longer than procedural content (how to authenticate, which endpoints to call, what the response schema looks like).
+Developer documentation does not go stale at the same rate for every type of content. Conceptual content explains what your API does and why you built it that way. This content stays accurate for a long time. Procedural content explains how to authenticate, which endpoints to call, and what the response schema looks like. This content goes stale fast.
 
-Procedural content breaks when the API changes. And API changes are constant in developer-facing products. New endpoints, deprecated parameters, revised authentication flows, updated rate limits: each of these is a potential gap between what the docs say and what the API does.
+Procedural content breaks when the API changes. API changes happen constantly in developer-facing products. New endpoints, deprecated parameters, revised authentication flows, and updated rate limits each create a potential gap. That gap sits between what the docs say and what the API does.
 
-The reason this gap persists is that API changes don't automatically trigger documentation reviews. Engineering's release process ends when the code ships. The downstream documentation review is a separate action that requires someone to remember it and have bandwidth to do it. In practice, it often happens late or not at all.
+This gap persists because API changes do not automatically trigger a documentation review. Engineering's release process ends when the code ships. The documentation review is a separate step. It requires someone to remember it and have time to do it. In practice, teams often do this late, or they skip it entirely.
 
-[Documentation drift](/blog/technical/documentation-drift-detection-problem) is a detection problem: teams don't discover stale docs through a monitoring system, they discover them through developer complaints. By the time a support ticket arrives, a lot of developers have already hit the same broken path and silently moved on.
+[Documentation drift](/blog/technical/documentation-drift-detection-problem) is a detection problem. Teams rarely discover stale docs through a monitoring system. Instead, they discover stale docs through developer complaints. By the time a support ticket arrives, many other developers have already hit the same broken path. Most of them just move on without reporting it.
 
-The documentation versioning problem is related. Every API version you support multiplies your maintenance surface. A tutorial written for v2 may be partially accurate for v3, but "partially accurate" is worse than no tutorial at all when an AI agent is following it literally. See [Documentation Versioning Best Practices for API Teams](/blog/technical/documentation-versioning-maintenance-multiplier) for how teams structure this.
+The documentation versioning problem is related. Every API version you support adds more work to keep docs accurate. A tutorial written for v2 may be partially accurate for v3. But partially accurate documentation is worse than no documentation, because an AI coding assistant follows it literally. See [Documentation Versioning Best Practices for API Teams](/blog/technical/documentation-versioning-maintenance-multiplier) for how teams structure this.
 
-## What the ownership model needs to look like
+## What the ownership model needs
 
-The fix is not better writers or more documentation tooling. It is a change in how teams assign responsibility for accuracy.
+The fix changes how teams assign responsibility for accuracy. Three things need to be explicit:
 
-Three things need to be explicit:
+**Who owns each piece of documentation.** Each piece needs a named owner. One person owns the getting-started guide, and one team owns the SDK reference. Shared ownership without a named individual equals no ownership at all.
 
-**Who owns each piece of documentation.** Not "DevRel owns docs" but "this getting-started guide is owned by this person, and this SDK reference is owned by that team." Shared ownership with no individual accountable is the same as no ownership.
+**What triggers a documentation review.** An API change, a deprecation, or a new SDK release should each trigger a review. Document these triggers in the same place as the ownership assignments. When a trigger fires, the owner reviews the affected docs.
 
-**What triggers a documentation review.** An API change is a trigger. A deprecation is a trigger. A new SDK release is a trigger. These triggers should be documented in the same place as the ownership assignments. When the trigger fires, the owner reviews.
+**How drift is detected when triggers are missed.** Ownership and triggers work only when everyone follows the process. They fail when a change ships without the right people knowing. They also fail when a doc page isn't connected to the code it describes. Automated monitoring compares documentation against the current API spec or codebase. This monitoring closes the gap.
 
-**How drift is detected when triggers are missed.** Ownership and triggers work when everyone follows the process. They fail when a change ships without the right people knowing about it, or when a doc page isn't connected to the code it describes. Automated monitoring that compares documentation against the current API spec or codebase closes this gap.
+This is what [treating documentation like code](/blog/technical/help-center-to-docs-as-code) means in practice. Teams assign explicit ownership. They keep content under version control. They build a process that detects when content diverges from the system it describes.
 
-This is what [treating documentation like code](/blog/technical/help-center-to-docs-as-code) actually means in practice. Explicit ownership, version-controlled content, and a process for detecting when content diverges from the system it describes.
+## The cost of losing developer trust
 
-## The developer trust calculation
+Developer trust in your documentation takes a long time to build. It takes almost no time to lose. Picture a developer who follows your getting-started guide and hits a wall because the docs are wrong. That developer spends two hours debugging an issue that accurate documentation would have solved in ten minutes. Most of these developers do not try again. They move on.
 
-Developer trust in your documentation is an asset that takes time to build and almost no time to lose. A developer who follows your getting-started guide, hits a wall because the docs are wrong, and spends two hours debugging an issue that would have taken ten minutes with accurate documentation: that developer does not come back and try again. Most often, they move on.
+At scale, this affects developer experience metrics across your whole product. Time to First Call measures how long it takes a developer to make a successful API call. Documentation accuracy directly affects this metric. Inaccurate getting-started guides inflate the number, even when the API itself has not changed.
 
-At scale, this affects your developer experience metrics. Time to First Call, a standard measure of how long it takes a developer to make a successful API call, is directly correlated with documentation accuracy. Inaccurate getting-started guides inflate this number without any change to the API itself.
+[Developer Documentation ROI: The Metrics That Actually Matter](/blog/technical/developer-documentation-roi) covers how to make this case to leadership.
 
-[Developer Documentation ROI: The Metrics That Actually Matter](/blog/technical/developer-documentation-roi) covers how to make this case to leadership in terms they can act on.
-
-The cost of accurate documentation is the time it takes to maintain it. The cost of inaccurate documentation is developer trust, support load, and integration failures at scale. For most developer-facing companies, the comparison is not close.
+The cost of accurate documentation is the time it takes to maintain it. The cost of inaccurate documentation is much higher, because it drains developer trust and increases support load over time. Integration failures increase too, at scale. For most developer-facing companies, accurate documentation costs far less than inaccurate documentation.
 
 <BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `developer relations docs`

## Article plan

**Thesis:** DevRel documentation breaks because ownership is shared across too many teams, so accuracy defaults to nobody's job.

**Target reader:** Developer advocates, DevRel leads, and DX engineers at companies shipping APIs or SDKs.

**Key points:**
1. DevRel docs now serve two audiences — human developers and AI coding agents — and the AI audience does not compensate for gaps
2. The "everyone contributes" model produces initial coverage but structural neglect over time
3. API and SDK changes are the primary driver of staleness, and they happen without triggering doc reviews
4. Lost developer trust is measurable (one case: 47 support hours, 3 churned customers, 6 months to rebuild)
5. Fix: explicit per-section ownership, defined update triggers, and automated drift detection

**Promptless connection:** Promptless monitors documentation for drift from the codebase and API specs — the automated piece of the ownership model DevRel teams need.

## File

`src/content/blog/technical/developer-relations-docs.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_017jQgRjVz9YvwJHeDa2Gib4)_