### PR TITLE
content: Docs Site Search Optimization: Why Content Accuracy Comes First

### DIFF
--- a/src/content/blog/technical/docs-site-search-optimization.mdx
+++ b/src/content/blog/technical/docs-site-search-optimization.mdx
@@ -1,0 +1,83 @@
+---
+title: 'Docs Site Search Optimization: Why Content Accuracy Comes First'
+subtitle: Published August 2026
+description: >-
+  Most teams optimize search tooling while leaving stale content in place. Here's why docs search quality starts with accuracy, not configuration.
+date: '2026-08-05T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+A developer searches your docs for "authenticate request." Algolia returns the top result in 18 milliseconds. The page loads. It describes an OAuth flow your product replaced six months ago.
+
+The search worked. The developer got bad information.
+
+This is the failure mode most teams don't track. They measure search installation and search uptime. They rarely measure how often search surfaces accurate content versus stale content. The most common docs search problem in 2026 has shifted. Teams now have search widgets. The failure is that those widgets return confident wrong answers.
+
+## What docs site search optimization actually involves
+
+Most teams approach docs search in this order: pick a search tool, configure the index, write good titles and descriptions, add internal links. These steps are worth doing. They are also not the most important part.
+
+Docs search optimization has two distinct layers.
+
+**The tooling layer** covers the search widget, index configuration, result ranking, and on-site UX. Algolia DocSearch, Mintlify, and Kapa.ai all operate here. Sub-20 millisecond response times are standard. The tooling layer is a solved problem.
+
+**The content layer** covers whether the pages being indexed are accurate. The tooling layer can surface a page instantly and rank it correctly. If the page describes a deprecated authentication flow, the accuracy of the search engine is irrelevant to the developer who just broke their integration following it.
+
+Most docs search optimization advice focuses on the tooling layer. The content layer is where the actual failures live.
+
+## Two ways on-site search fails
+
+On-site search produces two distinct failure types.
+
+**Zero results.** A developer searches for a feature using a name your product adopted six months ago, but the documentation still uses the old terminology. Or a page was moved and the index wasn't rebuilt. Zero-result searches create the impression that the feature doesn't exist or isn't documented.
+
+According to [Stack Overflow's 2024 developer survey](https://survey.stackoverflow.co/2024/), 61% of engineers spend more than 30 minutes per day searching for information they can't find. A meaningful share of those failures happen in documentation that has a search widget installed.
+
+**Misleading results.** The search finds something. It ranks first. The content is stale. A developer reads it and builds on bad information. This failure is harder to measure than zero results because it produces no visible error signal. The cost shows up later as a support ticket, or a developer who quietly abandoned the integration.
+
+Both failure types trace back to the content layer.
+
+<BlogNewsletterCTA />
+
+## How AI coding tools changed the stakes
+
+Beyond on-site search, your documentation competes for visibility in Google and in AI-powered tools that developers use in their daily workflow.
+
+[Postman's 2024 State of the API report](https://www.postman.com/state-of-api/) found that 68% of developers cite outdated documentation as their top frustration when working with APIs. That frustration now has a new surface: AI coding assistants. Tools like Cursor, GitHub Copilot, and Claude retrieve your API reference in real time when developers ask questions about your product. They read documentation literally.
+
+A human developer who encounters a deprecated parameter in your reference page might recognize it from experience and adapt. An AI coding assistant reads the parameter as current, generates code using it, and the developer spends time debugging the AI's output without knowing your docs were the source of the problem. This is the same dynamic that makes [spec drift so damaging in interactive API docs](https://promptless.ai/blog/technical/interactive-api-documentation). When agents read your specification, there is no error recovery from a wrong page.
+
+Research tracking API failures in production found that contract drift affects roughly 70% of failures, many of which trace back to documentation that didn't follow code changes.
+
+Content freshness also matters for how AI search tools decide what to cite. Analysis of AI-generated answers found that 50% of cited content is less than 13 weeks old. Stale docs can rank well on Google but get passed over by AI retrieval systems that weight recency. This means stale documentation can hurt you twice: it misleads developers who land on it from Google, and it gets deprioritized by the AI tools developers now use to search your docs.
+
+## What structural SEO work does and doesn't do
+
+Structural improvements to documentation are table stakes for any team publishing developer content publicly. Specific page titles that match what developers search for, accurate meta descriptions that reflect what the page actually covers, logical heading hierarchies, and internal links connecting related content all help external search engines understand and rank your docs.
+
+[Redocly's SEO guidance for documentation sites](https://redocly.com/blog/seo-best-practices-documentation) frames the goal as removing barriers between your content and the developers who need it. Descriptive URLs and clean navigation help developers and search crawlers find the right page. Content accuracy determines whether that page was worth finding.
+
+What structural SEO work cannot do is fix the content underneath it. Better page titles and internal links make inaccurate content more findable. The search optimization problem that matters is keeping the content accurate in the first place.
+
+## Where to invest in practice
+
+The highest-leverage docs search optimization work happens before the search layer.
+
+**Map which pages cover which product surfaces.** When an API endpoint changes, which documentation pages describe it? Most teams don't maintain this map. Without it, a code change can break the accuracy of five pages and none of them get updated until a support ticket surfaces the problem.
+
+**Connect code changes to documentation review.** When a PR touches a public API endpoint, the documentation pages covering that endpoint should surface for review. This is the same principle as linting: catch the drift at the point of change, not weeks later when it reaches users.
+
+**Track documentation-related support tickets.** Tag tickets by whether the root cause was inaccurate or missing documentation. This gives you a direct signal about which content failures are actively reaching users, and which pages need attention before your next optimization sprint.
+
+These three practices address the content layer. Combined with good search tooling and structural SEO work, they close the gap between "our search returned a result" and "our search returned a useful result."
+
+The same detection gap that [drives documentation drift](https://promptless.ai/blog/technical/documentation-drift-detection-problem) is what degrades search quality over time: teams have enough capacity to fix docs when they know what's wrong. The bottleneck is knowing.
+
+Good search tooling makes the content you have more findable. Keeping that content accurate is what makes search actually useful.
+
+<BlogRequestDemo />

--- a/src/content/blog/technical/docs-site-search-optimization.mdx
+++ b/src/content/blog/technical/docs-site-search-optimization.mdx
@@ -16,29 +16,29 @@ A developer searches your docs for "authenticate request." Algolia returns the t
 
 The search worked. The developer got bad information.
 
-This is the failure mode most teams don't track. They measure search installation and search uptime. They rarely measure how often search surfaces accurate content versus stale content. The most common docs search problem in 2026 has shifted. Teams now have search widgets. The failure is that those widgets return confident wrong answers.
+This is the failure mode most teams don't track. They measure whether search is installed and whether it stays online. They rarely measure how often search surfaces accurate content instead of stale content. The most common docs search problem in 2026 has changed. Teams have search widgets now. Those widgets return wrong answers with confidence.
 
 ## What docs site search optimization actually involves
 
-Most teams approach docs search in this order: pick a search tool, configure the index, write good titles and descriptions, add internal links. These steps are worth doing. They are also not the most important part.
+Most teams approach docs search in the same order. They pick a search tool, configure the index, write good titles and descriptions, and add internal links. Each of these steps matters, and the content layer matters even more.
 
 Docs search optimization has two distinct layers.
 
-**The tooling layer** covers the search widget, index configuration, result ranking, and on-site UX. Algolia DocSearch, Mintlify, and Kapa.ai all operate here. Sub-20 millisecond response times are standard. The tooling layer is a solved problem.
+**The tooling layer** covers the search widget, the index configuration, result ranking, and on-site UX. Algolia DocSearch, Mintlify, and Kapa.ai all operate at this layer. Sub-20 millisecond response times are now standard here. For most teams, this layer is a solved problem.
 
-**The content layer** covers whether the pages being indexed are accurate. The tooling layer can surface a page instantly and rank it correctly. If the page describes a deprecated authentication flow, the accuracy of the search engine is irrelevant to the developer who just broke their integration following it.
+**The content layer** covers whether the indexed pages are accurate. The tooling layer can surface a page instantly and rank it correctly. If the page describes a deprecated authentication flow, the correctness of the search engine does not matter to the developer who just broke their integration by following it.
 
-Most docs search optimization advice focuses on the tooling layer. The content layer is where the actual failures live.
+Most docs search optimization advice focuses on the tooling layer. The actual failures live in the content layer.
 
 ## Two ways on-site search fails
 
 On-site search produces two distinct failure types.
 
-**Zero results.** A developer searches for a feature using a name your product adopted six months ago, but the documentation still uses the old terminology. Or a page was moved and the index wasn't rebuilt. Zero-result searches create the impression that the feature doesn't exist or isn't documented.
+**Zero results.** A developer searches for a feature using the name your product adopted six months ago. The documentation still uses the old name. Or a page moved and nobody rebuilt the index. Zero-result searches make a feature look undocumented, even when it exists.
 
 According to [Stack Overflow's 2024 developer survey](https://survey.stackoverflow.co/2024/), 61% of engineers spend more than 30 minutes per day searching for information they can't find. A meaningful share of those failures happen in documentation that has a search widget installed.
 
-**Misleading results.** The search finds something. It ranks first. The content is stale. A developer reads it and builds on bad information. This failure is harder to measure than zero results because it produces no visible error signal. The cost shows up later as a support ticket, or a developer who quietly abandoned the integration.
+**Misleading results.** The search finds a page and ranks it first, but the page is stale. A developer reads it and builds on bad information. This failure is harder to measure than zero results, because it produces no visible error signal. The cost shows up later, as a support ticket or as a developer who abandons the integration without explanation.
 
 Both failure types trace back to the content layer.
 
@@ -48,36 +48,36 @@ Both failure types trace back to the content layer.
 
 Beyond on-site search, your documentation competes for visibility in Google and in AI-powered tools that developers use in their daily workflow.
 
-[Postman's 2024 State of the API report](https://www.postman.com/state-of-api/) found that 68% of developers cite outdated documentation as their top frustration when working with APIs. That frustration now has a new surface: AI coding assistants. Tools like Cursor, GitHub Copilot, and Claude retrieve your API reference in real time when developers ask questions about your product. They read documentation literally.
+[Postman's 2024 State of the API report](https://www.postman.com/state-of-api/) found that 68% of developers cite outdated documentation as their top frustration when working with APIs. AI coding assistants now add a new surface for that frustration. Tools like Cursor, GitHub Copilot, and Claude retrieve your API reference in real time when developers ask questions about your product. These tools read documentation literally.
 
-A human developer who encounters a deprecated parameter in your reference page might recognize it from experience and adapt. An AI coding assistant reads the parameter as current, generates code using it, and the developer spends time debugging the AI's output without knowing your docs were the source of the problem. This is the same dynamic that makes [spec drift so damaging in interactive API docs](https://promptless.ai/blog/technical/interactive-api-documentation). When agents read your specification, there is no error recovery from a wrong page.
+A human developer who finds a deprecated parameter might recognize it from experience and adapt. An AI coding assistant reads the same parameter as current. It generates code that uses the parameter and leaves the developer to debug the result. The developer often never learns that the docs caused the problem. This is the same pattern that makes [spec drift so damaging in interactive API docs](https://promptless.ai/blog/technical/interactive-api-documentation). When an agent reads your specification, a wrong page has no chance for error recovery.
 
-Research tracking API failures in production found that contract drift affects roughly 70% of failures, many of which trace back to documentation that didn't follow code changes.
+Research tracking API failures in production found that contract drift affects roughly 70% of failures. Many of these failures trace back to documentation that did not follow code changes.
 
-Content freshness also matters for how AI search tools decide what to cite. Analysis of AI-generated answers found that 50% of cited content is less than 13 weeks old. Stale docs can rank well on Google but get passed over by AI retrieval systems that weight recency. This means stale documentation can hurt you twice: it misleads developers who land on it from Google, and it gets deprioritized by the AI tools developers now use to search your docs.
+Content freshness also affects how AI search tools decide what to cite. Analysis of AI-generated answers found that 50% of cited content is less than 13 weeks old. Stale docs can still rank well on Google, but AI retrieval systems that weight recency pass them over. Stale documentation hurts you twice. It misleads developers who land on it from Google. It also gets deprioritized by the AI tools developers now use to search your docs.
 
 ## What structural SEO work does and doesn't do
 
-Structural improvements to documentation are table stakes for any team publishing developer content publicly. Specific page titles that match what developers search for, accurate meta descriptions that reflect what the page actually covers, logical heading hierarchies, and internal links connecting related content all help external search engines understand and rank your docs.
+Structural improvements to documentation are table stakes for teams that publish developer content publicly. Page titles should match what developers search for. Meta descriptions should accurately reflect what the page covers. Logical heading hierarchies and internal links between related content also help. Together, these signals help search engines understand and rank your docs.
 
 [Redocly's SEO guidance for documentation sites](https://redocly.com/blog/seo-best-practices-documentation) frames the goal as removing barriers between your content and the developers who need it. Descriptive URLs and clean navigation help developers and search crawlers find the right page. Content accuracy determines whether that page was worth finding.
 
-What structural SEO work cannot do is fix the content underneath it. Better page titles and internal links make inaccurate content more findable. The search optimization problem that matters is keeping the content accurate in the first place.
+Structural SEO work cannot fix the content underneath it. Better page titles and internal links only make inaccurate content easier to find. Keeping the content accurate is the search optimization problem that matters most.
 
 ## Where to invest in practice
 
-The highest-leverage docs search optimization work happens before the search layer.
+The most valuable docs search optimization work happens before the search layer, in the content layer itself.
 
-**Map which pages cover which product surfaces.** When an API endpoint changes, which documentation pages describe it? Most teams don't maintain this map. Without it, a code change can break the accuracy of five pages and none of them get updated until a support ticket surfaces the problem.
+**Map which pages cover which product surfaces.** Most teams do not track which documentation pages describe each API endpoint. Without this map, a single code change can break the accuracy of five pages. None of those pages get fixed until a support ticket surfaces the problem.
 
-**Connect code changes to documentation review.** When a PR touches a public API endpoint, the documentation pages covering that endpoint should surface for review. This is the same principle as linting: catch the drift at the point of change, not weeks later when it reaches users.
+**Connect code changes to documentation review.** When a PR touches a public API endpoint, the documentation pages for that endpoint should come up for review. This follows the same principle as linting. Catch the drift at the point of change, before it reaches users.
 
-**Track documentation-related support tickets.** Tag tickets by whether the root cause was inaccurate or missing documentation. This gives you a direct signal about which content failures are actively reaching users, and which pages need attention before your next optimization sprint.
+**Track documentation-related support tickets.** Tag tickets by whether the root cause was inaccurate or missing documentation. This gives you a direct signal about which content failures are actively reaching users. It also tells you which pages need attention before your next optimization sprint.
 
 These three practices address the content layer. Combined with good search tooling and structural SEO work, they close the gap between "our search returned a result" and "our search returned a useful result."
 
-The same detection gap that [drives documentation drift](https://promptless.ai/blog/technical/documentation-drift-detection-problem) is what degrades search quality over time: teams have enough capacity to fix docs when they know what's wrong. The bottleneck is knowing.
+The same detection gap that [drives documentation drift](https://promptless.ai/blog/technical/documentation-drift-detection-problem) also degrades search quality over time. Teams have enough capacity to fix docs once they know what is wrong. The bottleneck is knowing.
 
-Good search tooling makes the content you have more findable. Keeping that content accurate is what makes search actually useful.
+Good search tooling makes the content you have more findable. Keeping that content accurate is what makes search useful.
 
 <BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `docs site search optimization`

## Article plan

**Target keywords:** "docs site search optimization" (primary), "developer documentation SEO" (secondary)

**Thesis:** Documentation search quality is a content accuracy problem first. You can't optimize your way to good results from inaccurate pages.

**Target reader:** DevRel engineers, technical writers, and engineering managers at developer-facing companies who have search tooling installed but still see developers fail to find what they need, or see support tickets for content that exists in the docs.

**Key points:**
1. Teams install good search tooling and assume the search problem is solved. The failure mode shifts to "search that surfaces wrong answers"
2. On-site search fails in two ways: zero results (missing/renamed content) and misleading results (stale content ranked highly). Both are content problems
3. AI coding assistants (Cursor, Copilot, Claude) retrieve docs literally. A deprecated parameter generates broken code — the blast radius of stale pages grew in 2025
4. Structural SEO (titles, headings, internal links) is table stakes but amplifies inaccurate content if the content isn't accurate
5. The highest-leverage fix: map which pages cover which product surfaces and connect code changes to doc review

**Promptless connection:** Accurate content is the prerequisite for good search. Promptless monitors for content drift, which is the upstream cause of search failures.

## File

`src/content/blog/technical/docs-site-search-optimization.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8DPJkgGpsktnrEtFAmNGD)_