### PR TITLE
fix(edu-campaign): make the duplicate-topic check blocking and slug-aware

### DIFF
--- a/.claude/skills/generate-article/SKILL.md
+++ b/.claude/skills/generate-article/SKILL.md
@@ -16,17 +16,37 @@ Automated content pipeline for the Promptless blog. This skill replaces the `gen
 
 ## Overview
 
-1. Pick a keyword (from user input or randomly from the keyword list)
+1. Pick a keyword and clear the pre-flight duplicate gate
 2. Research the topic thoroughly using web search
 3. Write a publication-ready MDX article
 4. Commit to a new branch, push, and open a GitHub PR
 5. Post the PR link to the `#gtm` Slack channel
 
-## Step 1: Pick a keyword
+## Step 1: Pick a keyword and clear the pre-flight gate
 
 If the user provides a keyword or topic, use it directly.
 
-Otherwise, read the keyword list at `scripts/edu_campaign/keywords.txt` (relative to repo root). Pick one at random. Lines starting with `#` are comments — skip them. Tell the user which keyword was selected.
+Otherwise, read the keyword list at `scripts/edu_campaign/keywords.txt` (relative to repo root). Lines starting with `#` are comments — skip them.
+
+Do NOT pick at random. Random selection has no memory, so it re-picks recently used keywords: it produced ten articles on "docs site search optimization" in four months. Instead, prefer the keyword with the least existing coverage. Work down the list from the top and pick the first keyword that clears the gate below.
+
+### The pre-flight gate is blocking
+
+Before doing any research, run:
+
+```bash
+scripts/edu_campaign/preflight-keyword.sh --keyword "<keyword>"
+```
+
+**If it exits non-zero, stop. Do not research, do not write, do not open a PR.** Either pick a different keyword and re-run, or report the blockage to the user and end the run. This gate is the one step that is allowed to halt the pipeline, and it must.
+
+The script checks two things the pipeline previously missed:
+- How many articles on this keyword are already **published** on `origin/main` (cap: 2)
+- Whether any **open or closed PR** already covers this keyword
+
+That second check is the important one. The old duplicate check ran late and looked only at merged content, so nine unmerged siblings were invisible to it and every run concluded it was the first on the keyword.
+
+Tell the user which keyword was selected and paste the gate's output.
 
 ## Step 2: Research
 
@@ -64,9 +84,18 @@ Output the plan to the user for review before writing.
 ## Step 4: Write the article
 
 Before writing, scan the existing articles in `src/content/blog/technical/` to:
-- Confirm your topic doesn't duplicate an existing article
 - Find posts to link to internally (read titles/descriptions of a few to understand voice)
 - Calibrate your tone to match the existing body of work
+
+Duplicate detection is NOT this step's job. It happens at Step 1, before the expensive research, and it is blocking. A check that runs here can only tell you that you have already wasted the research budget.
+
+If your research in Step 2 surfaced a related keyword and you decided in Step 3 to target that instead of the original, re-run the gate for the new keyword now:
+
+```bash
+scripts/edu_campaign/preflight-keyword.sh --keyword "<the keyword you actually chose>"
+```
+
+Retargeting mid-run is how a cleared keyword turns into a duplicate of something else.
 
 Then write a complete, publication-ready MDX article strictly following the plan and the style guide.
 
@@ -129,7 +158,21 @@ The article file goes at:
 src/content/blog/technical/{slug}.mdx
 ```
 
-Generate the slug from the article title: lowercase, remove special characters, replace spaces with hyphens, truncate to 60 characters.
+Generate the slug from the article **title**, not from the keyword: lowercase, remove special characters, replace spaces with hyphens, truncate to 60 characters.
+
+Derive it from the part of the title that is specific to THIS article. Seven PRs slugged themselves `docs-site-search-optimization` because they all shared that title prefix and the distinguishing half of each title was dropped. If two candidate titles would produce the same slug, the slug is wrong: use the specific angle instead (`developer-docs-search-three-channels`, not `docs-site-search-optimization`).
+
+### Slug uniqueness is a hard precondition
+
+Once the title is settled, and before creating the branch, re-run the gate with the slug:
+
+```bash
+scripts/edu_campaign/preflight-keyword.sh --keyword "<keyword>" --slug "<slug>"
+```
+
+**If it exits non-zero, stop and pick a different slug.** Do not create the branch.
+
+This checks the slug against `origin/main` AND against every open PR. Both matter: seven PRs collided with each other rather than with anything merged, so each one passed a main-only check and still produced a conflict. Two PRs adding the same path will always conflict, no matter how cleanly each merges against main today.
 
 ## Step 7: Create a branch and PR
 
@@ -192,5 +235,6 @@ agent-slack message send --workspace promptless "#gtm" "New blog article draft r
 ## Important notes
 
 - Always set `hidden: false` in the frontmatter.
-- If any step fails (e.g. git push, PR creation, Slack), report the error but continue with remaining steps.
+- **Continue-on-failure applies only to the delivery steps (Steps 7 and 8).** If `git push`, `gh pr create`, or the Slack notification fails, report the error and continue with the remaining steps: the article is already written and losing it is worse than a missing Slack ping.
+- **The pre-flight gates in Step 1, Step 4, and Step 6 are the exception. A non-zero exit from `preflight-keyword.sh` halts the run.** Do not "report the error but continue" past a blocked gate. The old blanket continue-on-failure rule is why nine duplicate articles reached the PR queue: nothing in the pipeline had the authority to stop.
 - The article should be genuinely useful content, not thinly-veiled marketing. Promptless connections should feel natural.

--- a/scripts/edu_campaign/keywords.txt
+++ b/scripts/edu_campaign/keywords.txt
@@ -2,6 +2,26 @@
 # One keyword per line. Lines starting with # are ignored.
 # Audience: technical writers, DevRel, developer advocates, solutions engineers, EMs
 # at companies with developer-facing products.
+#
+# SELECTION: do not pick at random. Work down the list and take the first
+# keyword that clears the pre-flight gate:
+#
+#     scripts/edu_campaign/preflight-keyword.sh --keyword "<keyword>"
+#
+# Random selection has no memory of what it already picked. That is how ten
+# articles on "docs site search optimization" got generated between
+# 2026-04-06 and 2026-08-05, seven of them colliding on one filename.
+#
+# RETIREMENT: a keyword is exhausted at 2 published articles. Comment it out
+# with a "# retired:" marker and the reason, rather than deleting it, so the
+# history stays visible.
+#
+# NOTE: several entries below are near-duplicates of each other and will tend
+# to generate overlapping articles even with the gate in place. Consider
+# consolidating: "AI automated docs" / "AI automated documentation";
+# "agent context" / "agent context engineering"; "knowledge graph" /
+# "living knowledge graph". Left in place because pruning them is an
+# editorial decision, not a mechanical one.
 
 documentation drift
 llms.txt for developer docs
@@ -25,7 +45,12 @@ developer education
 developer relations docs
 changelog communication for developers
 documentation coverage
-docs site search optimization
+# retired: docs site search optimization
+#   Exhausted. 2 published (docs-site-search-optimization,
+#   docs-site-search-optimization-content-bottleneck) plus 2 spokes in flight
+#   (#786 developer docs SEO, #771 documentation search analytics).
+#   10 articles were generated on this one keyword; 5 PRs were closed as
+#   redundant. See docs-search-editorial-plan.md.
 interactive API documentation
 developer documentation ROI
 SDK documentation best practices

--- a/scripts/edu_campaign/preflight-keyword.sh
+++ b/scripts/edu_campaign/preflight-keyword.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Pre-flight gate for the generate-article pipeline.
+#
+# Between 2026-04-06 and 2026-08-05 the pipeline produced ten articles on
+# "docs site search optimization", seven of which resolved to the identical
+# filename. Each run checked for duplicates against merged content only, so
+# every run correctly concluded it was the first on that keyword while nine
+# siblings sat unmerged in the PR queue.
+#
+# This script makes that check mechanical and blocking. Run it BEFORE the
+# research step (which is the expensive part) and again once a slug is known.
+#
+# Usage:
+#   preflight-keyword.sh --keyword "<keyword>"
+#   preflight-keyword.sh --keyword "<keyword>" --slug "<slug>"
+#
+# Exit codes:
+#   0  clear to proceed
+#   1  blocked: existing coverage or a slug collision. Do not continue.
+#   2  usage error, or a dependency is missing.
+
+set -euo pipefail
+
+KEYWORD=""
+SLUG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keyword) KEYWORD="${2:-}"; shift 2 ;;
+    --slug)    SLUG="${2:-}"; shift 2 ;;
+    -h|--help) sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$KEYWORD" ]] || { echo "error: --keyword is required" >&2; exit 2; }
+
+for dep in git gh jq; do
+  command -v "$dep" >/dev/null 2>&1 || { echo "error: '$dep' is required but not on PATH" >&2; exit 2; }
+done
+
+BLOG_DIR="src/content/blog/technical"
+BLOCKED=0
+
+note()  { printf '  %s\n' "$1"; }
+block() { printf '\n  BLOCKED: %s\n' "$1"; BLOCKED=1; }
+
+git fetch -q origin main
+
+echo
+echo "Pre-flight for keyword: '$KEYWORD'"
+echo
+
+# --- Check A: already-published articles on this keyword -------------------
+# Match the keyword against title and description, not the whole body: a
+# passing mention in body text is normal and is not evidence of duplication.
+echo "A. Published articles matching the keyword (origin/main)"
+PUBLISHED=0
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+  frontmatter="$(git show "origin/main:$path" 2>/dev/null | sed -n '1,12p' || true)"
+  if grep -qi -- "$KEYWORD" <<<"$frontmatter"; then
+    note "$(basename "$path")"
+    PUBLISHED=$((PUBLISHED + 1))
+  fi
+done < <(git ls-tree -r --name-only origin/main -- "$BLOG_DIR" | grep '\.mdx$' || true)
+
+if [[ $PUBLISHED -eq 0 ]]; then
+  note "none"
+else
+  note "count: $PUBLISHED"
+fi
+if [[ $PUBLISHED -ge 2 ]]; then
+  block "$PUBLISHED articles are already published on this keyword. Two is the cap; the keyword is exhausted. Retire it from keywords.txt, or pick a distinct long-tail angle and record that angle in the PR body."
+fi
+
+# --- Check B: unmerged work on this keyword -------------------------------
+# This is the check whose absence caused the pileup. The pipeline records
+# "Keyword: <keyword>" in every PR body, so the PR queue is authoritative
+# about in-flight work in a way the merged tree is not.
+echo
+echo "B. Existing PRs recording this keyword (any state)"
+PR_JSON="$(gh pr list --state all --limit 300 \
+  --search "\"Keyword: $KEYWORD\" in:body" \
+  --json number,state,title 2>/dev/null || echo '[]')"
+
+PR_COUNT="$(jq 'length' <<<"$PR_JSON")"
+OPEN_COUNT="$(jq '[.[] | select(.state == "OPEN")] | length' <<<"$PR_JSON")"
+
+if [[ "$PR_COUNT" -eq 0 ]]; then
+  note "none"
+else
+  jq -r '.[] | "  #\(.number) \(.state): \(.title)"' <<<"$PR_JSON"
+fi
+
+if [[ "$OPEN_COUNT" -gt 0 ]]; then
+  block "$OPEN_COUNT open PR(s) already cover this keyword. Review or close them before generating another. If your angle is genuinely distinct, state how in the PR body and name the different long-tail keyword you are targeting."
+fi
+
+# --- Check C: slug collision on main -------------------------------------
+if [[ -n "$SLUG" ]]; then
+  echo
+  echo "C. Slug availability: $SLUG.mdx"
+  if git cat-file -e "origin/main:$BLOG_DIR/$SLUG.mdx" 2>/dev/null; then
+    block "$BLOG_DIR/$SLUG.mdx already exists on origin/main. Pick a slug that reflects this article's specific angle rather than the bare keyword."
+  else
+    note "available on origin/main"
+  fi
+
+  # --- Check D: slug claimed by an open PR -------------------------------
+  # Seven PRs each passed a main-only check and still collided, because they
+  # collided with each other rather than with anything merged.
+  echo
+  echo "D. Slug claimed by an open PR"
+  CLAIMED="$(gh pr list --state open --limit 300 --json number,title,files 2>/dev/null \
+    | jq -r --arg p "$BLOG_DIR/$SLUG.mdx" \
+        '.[] | select(any(.files[]?; .path == $p)) | "  #\(.number): \(.title)"' || true)"
+  if [[ -n "$CLAIMED" ]]; then
+    printf '%s\n' "$CLAIMED"
+    block "an open PR already writes to $BLOG_DIR/$SLUG.mdx. Two PRs adding the same path will conflict with each other even though both merge cleanly against main today."
+  else
+    note "not claimed"
+  fi
+else
+  echo
+  echo "C/D. Slug checks skipped (no --slug given)"
+  note "re-run with --slug once the title is settled, before creating the branch"
+fi
+
+echo
+if [[ $BLOCKED -eq 1 ]]; then
+  echo "RESULT: blocked. Do not proceed to research or article generation."
+  echo "Resolve the items above, or pick a different keyword, then re-run."
+  exit 1
+fi
+
+echo "RESULT: clear to proceed."
+exit 0


### PR DESCRIPTION
## Why

The content pipeline generated **ten articles on "docs site search optimization"** between 2026-04-06 and 2026-08-05. Seven resolved to the identical filename `src/content/blog/technical/docs-site-search-optimization.mdx`. Five of those PRs (#736, #645, #639, #631, #596) have now been closed as redundant; #818 and #806 both merged and are live as near-duplicates; #786 and #771 survive as reslugged spokes.

This PR fixes the generator so it stops happening. It does not touch any article content.

## Root cause

Three defects in `generate-article/SKILL.md` combined:

1. **The duplicate check ran too late and looked in the wrong place.** It sat in Step 4, *after* the expensive research, and scanned only `src/content/blog/technical/` on the merged tree. Nine of the ten articles never merged, so every run was blind to its siblings and concluded, correctly by its own lights, that it was the first on the keyword. Nothing ever consulted the PR queue.

2. **Slug generation had no uniqueness check at all.** Titles sharing the `Docs Site Search Optimization:` prefix slugged identically once truncation dropped the distinguishing half.

3. **Nothing could halt a run.** `If any step fails ... report the error but continue with remaining steps` applied to every step, including checks.

## Changes

**New: `scripts/edu_campaign/preflight-keyword.sh`** — a blocking gate, `shellcheck` clean, four checks:

| | Check | Blocks when |
|---|---|---|
| A | Published articles on `origin/main` matching the keyword in frontmatter | >= 2 (keyword exhausted) |
| B | Open/closed PRs recording `Keyword: <kw>` in the body | any open PR exists |
| C | Slug exists on `origin/main` | collision |
| D | Slug written by any open PR | collision |

**B and D are the load-bearing ones.** Seven PRs collided *with each other*, not with anything merged, so each passed a main-only check and still conflicted.

**`SKILL.md`** — duplicate detection moves from Step 4 to Step 1 (before the research spend), with a re-check if Step 3 retargets the keyword; slugs must derive from the article's specific angle with a hard uniqueness precondition before branch creation; continue-on-failure is scoped to the delivery steps only, so a blocked gate halts the run.

**`keywords.txt`** — random selection replaced with least-coverage-first; `docs site search optimization` retired as exhausted; near-duplicate entries flagged in a comment but left in place, since pruning them is an editorial call.

## Verification

Tested against the case that actually broke. The keyword and slug that produced ten articles:

```
A. count: 2                      -> BLOCKED (exhausted)
B. 9 PRs found, 2 open           -> BLOCKED (open coverage)
C. exists on origin/main         -> BLOCKED (collision)
RESULT: blocked. EXIT=1
```

Check D verified separately against #786's new slug: correctly identifies the claiming PR and blocks.

Negative case, to confirm it is not just blocking everything: keyword `documentation versioning` with a distinct slug reports 1 published article and 1 merged PR, both under threshold, and returns `RESULT: clear to proceed` (exit 0).

Also checked: `bash -n` clean, `shellcheck` clean, `--help` works, missing `--keyword` exits 2, and `keywords.txt` still parses to 30 active keywords (31 minus the retired one).

## Note on scope

Same collision pattern is visible on `api-documentation-automation` (6 branches), `developer-relations-docs`, and `documentation-translations`. This PR fixes the generator; those existing queues still need their own editorial passes. Full analysis of the search cluster is in `docs-search-editorial-plan.md` (not committed here).

There is also an unmerged branch `articles/2026-04-06-documentation-search-analytics-content-gaps` with **no PR**, covering the same ground as #771. Because it has no PR, check B cannot see it. Branches without PRs remain a blind spot.