### PR TITLE
content: consolidate API documentation automation coverage

### DIFF
--- a/src/content/blog/technical/api-documentation-automation.mdx
+++ b/src/content/blog/technical/api-documentation-automation.mdx
@@ -12,66 +12,64 @@ hidden: false
 import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
 import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
 
-A developer calls your API. They get a 400 error. They check the request body format in your docs. Everything looks right. They try again. Same error.
+A developer calls your API and gets a 400 error. The documented request body looks correct, but a second attempt fails. Support explains that the parameter changed three sprints ago. The documentation generator used an OpenAPI spec that nobody had updated.
 
-They ping your support channel. The response: that parameter was renamed three sprints ago. A tool generated the docs from an OpenAPI spec. No one updated the spec.
-
-The generation tool did its job correctly. The problem was upstream.
+The generator worked from the source it received. The source was stale.
 
 ## Two different problems, one name
 
-When teams talk about automating API documentation, they usually have one of two distinct problems in mind.
+API documentation automation covers generation and maintenance. Generation tools render a machine-readable spec, usually an OpenAPI file, as a formatted reference site. Mintlify, ReadMe, Redocly, and Stoplight provide this established capability. A team maintains one spec while the tools update the rendered reference.
 
-The first is generation. A tool takes a machine-readable spec, usually an OpenAPI file. It renders that spec into a formatted reference site. This is a well-understood problem. Mintlify, ReadMe, Redocly, and Stoplight all do it reliably. You maintain one spec file. The rendered docs update on their own. The tooling here is mature.
-
-The second is maintenance. You keep documentation accurate as the API changes. This means you detect when code changes diverge from the published spec. It also means you surface which pages need attention before developers find the problem themselves.
-
-Most tooling solves the first problem. Most documentation failures come from the second.
+Maintenance keeps that documentation accurate as the API changes. The process must detect differences between code and the published spec. It must also identify affected pages before developers encounter stale instructions. Most tools focus on generation, while maintenance remains the harder problem.
 
 ## What generation actually delivers
 
-Generation from a spec is useful. Modern tools handle rendering. They add search. They produce multi-language code samples. They manage versioning. They provide interactive try-it consoles. If your OpenAPI file is accurate and complete, these tools produce usable reference documentation with little effort.
+Generation from a spec provides clear value. Modern tools render references with search and versioning. They can also provide code samples in several languages and interactive consoles. An accurate, complete OpenAPI file therefore produces usable reference documentation with little manual work.
+
+OpenAPI adoption is broad enough to make this workflow practical. The [State of Docs Report 2025](https://www.stateofdocs.com/2025/documentation-tooling-and-api-docs) found that almost 74% of companies offering APIs use the OpenAPI specification.
 
 The constraint is the spec itself.
 
-A [report on API drift](https://zivodoc.com/blog/api-documentation-drift-prevention/) found that 75% of APIs don't conform to their own specifications. Engineers add a required field. No one updates the spec that sprint. A PR merges without a matching spec change. Over time, the gap between what the code does and what the spec says widens. The tool renders the outdated spec into polished documentation, exactly as designed. The source is wrong, not the renderer.
+A [report on API drift](https://zivodoc.com/blog/api-documentation-drift-prevention/) found that 75% of APIs don't conform to their own specifications. An engineer may add a required field while the spec remains unchanged. A PR can then merge without the matching spec update. The gap between code and specification grows over time. A generation tool turns that outdated source into polished documentation as designed, so the result remains inaccurate.
 
 ## Why maintenance resists automation
 
-Accurate documentation requires knowledge that doesn't live in the spec file.
+Accurate documentation requires knowledge beyond the spec file. A renamed field may still accept its former name for legacy clients. A deprecated authentication flow may remain unmarked. This context appears in commit messages and PR descriptions. Some details remain with the engineers who shipped the change.
 
-Take a field that was renamed. The spec still accepts the old name for legacy clients. Or take a deprecated authentication flow. No one marks it in the spec yet. This context lives in commit messages, Slack threads, and PR descriptions. It also lives in the heads of the engineers who shipped the change.
+The spec also covers reference material better than explanatory prose. Quickstarts and tutorials usually live outside it. Authentication walkthroughs and SDK examples do as well, so teams continue to maintain these pages by hand.
 
-According to the [Postman 2025 State of the API report](https://www.postman.com/state-of-api/), 55% of API teams report struggling with inconsistent documentation. The State of Docs Report 2025 found that keeping documentation current is the top challenge for more than half of all documentation teams. These numbers hold despite years of investment in generation tooling, because generation doesn't touch the maintenance problem.
+According to the [Postman 2025 State of the API report](https://www.postman.com/state-of-api/), 55% of API teams struggle with inconsistent documentation. The State of Docs Report 2025 found that keeping documentation current is the top challenge for more than half of all documentation teams. Investment in generation tooling has left this maintenance work in place.
 
-LLM-based tools can draft descriptions and fill gaps in coverage. They cannot verify that what they write matches what the API actually does. Fed an outdated spec, a language model produces fluent documentation for endpoints that no longer work as described. The output looks correct. The inaccuracy stays hidden until a developer hits it.
+LLM-based tools can draft descriptions and fill coverage gaps. Verification requires evidence about current API behavior. Given an outdated spec, a language model can produce fluent documentation for endpoints that work differently. The polished output may hide the error until a developer encounters it.
 
 <BlogNewsletterCTA />
 
 ## Where detection fits in
 
-The bottleneck in documentation maintenance is detection, not drafting. Before anyone can update documentation, something has to surface that it needs updating.
+Detection controls the pace of documentation maintenance. A team can update a page only after someone or something identifies the need.
 
-Docs-as-code workflows help once detection has already happened. A PR template asks "did you update the docs?" This works when the developer knows which docs are affected. It fails when the change touches something the developer didn't flag as documentation-relevant. It also fails when the impact shows up through a behavior change rather than a schema change.
+Docs-as-code workflows help after detection. A PR template can require a documentation update when the developer knows which pages are affected. It misses changes that developers do not classify as documentation work. Behavioral changes can also escape checks that look only for schema changes.
 
-The [documentation drift problem](/blog/technical/documentation-drift-detection-problem) is about this gap. Most teams discover outdated docs through developer complaints or support tickets. By then, developers have already hit the inaccuracy. Some stop trusting the docs entirely. Rebuilding that trust takes longer than preventing the original oversight would have.
+The [documentation drift problem](/blog/technical/documentation-drift-detection-problem) describes this gap. Many teams discover outdated docs through developer complaints or support tickets. Those reports arrive after a developer has encountered the error. Repeated errors can also reduce trust in the rest of the documentation.
 
-Some teams run documentation checks in CI. A test validates the OpenAPI spec against the live service. This catches drift at the source. If the spec doesn't match actual API responses, the build fails. Spec accuracy comes before anyone generates documentation.
+Some teams run documentation checks in CI. A test validates the OpenAPI spec against the live service and catches drift at its source. When actual API responses differ from the spec, the build fails before documentation generation begins.
 
-This approach works. It also needs engineering buy-in. The team has to treat spec changes as a required part of every feature delivery, not a post-shipping cleanup item.
+Runtime traffic provides another detection source through [APItoolkit](https://apitoolkit.io/docs/dashboard/dashboard-pages/endpoints/), which tracks production endpoints and their request-response shapes. The tool detects new endpoints and field additions, while also identifying field updates or deletions and using acknowledged endpoint and anomaly data to generate an OpenAPI spec.
+
+Both approaches require engineering support. Teams must include spec changes in feature delivery instead of leaving them for later cleanup.
 
 ## What useful automation actually does
 
-The automation that improves documentation accuracy does two things teams currently do manually.
+Useful automation detects documentation risk and lowers the cost of a response. [Automated API documentation updates](/blog/technical/automated-api-documentation-updates) can connect change signals to the review workflow.
 
-It surfaces when documentation needs attention. It watches where change happens: pull requests, commit history, support ticket volume, and search queries with no results. It then flags which documentation pages are at risk before developers discover the problem.
+Detection can watch pull requests and commit history. Support ticket volume or search queries with no results provide additional signals. The system can then flag affected pages before more developers encounter the problem.
 
-It reduces the cost of acting on those signals. One system detects a spec divergence and drafts the updated section for human review. Another only files the alert. The first is more useful. Drafting removes the blank page problem.
+The response should help a reviewer act on each signal. A system that detects spec divergence can draft the affected section for human review. A basic system may only file an alert, which leaves the drafting work to the team.
 
-A useful framing from changelog work applies here: developers need to know what changed and what they have to do differently, not just that something changed. As covered in [API changelog best practices](/blog/technical/api-changelog-best-practices), the failure mode is often that a team announces a change without the actionable context developers need to adapt. The same failure mode shows up in stale reference documentation.
+Changelog work offers a useful model. Developers need to know what changed and how their work must change. As covered in [API changelog best practices](/blog/technical/api-changelog-best-practices), a change announcement may omit the context needed for action. Stale reference documentation creates the same problem.
 
-The teams making progress on documentation accuracy treat it as a continuous process, not a post-shipping phase. Automation handles detection and initial drafting. Judgment on accuracy still requires someone who understands the product. The goal is to make that judgment faster and cheaper, not to remove it.
+Teams improve documentation accuracy through a continuous process. Automation handles detection and initial drafting. A person who understands the product reviews the result for accuracy. Faster review keeps the documentation closer to the current API.
 
-For the 55% of API teams still reporting inconsistent documentation, the generation tooling is probably adequate. The gap is on the maintenance side: detecting what changed, identifying which docs are affected, and acting on it quickly enough that developers don't encounter the inaccuracy first.
+For the 55% of API teams that report inconsistent documentation, generation tooling is probably adequate. Better maintenance starts with early detection. Teams then identify the affected pages and respond before developers encounter the error.
 
 <BlogRequestDemo />


### PR DESCRIPTION
## Motivation

Five articles targeted API documentation automation. PR #603 is the published canonical page, so the distinct evidence from #548 and #508 belongs there instead of on competing pages.

## Summary

- add the validated State of Docs OpenAPI adoption statistic from #508
- explain which API guides remain outside generated reference docs
- add the APItoolkit runtime-traffic detection mechanism from #548 with an official source
- link the canonical page to the retargeted #751 operational spoke
- rewrite the article in Simplified Technical English

## Validation

- promptless slop-cop: 16 errors before, 0 after
- 960 words
- frontmatter and imports unchanged
- existing URLs and statistics preserved
- only three approved URLs added
- zero em dashes
- git diff --check passed

Related consolidation: #751, #759, #548, #508.