### PR TITLE
content: Documentation Drift Has an Ownership Problem

### DIFF
--- a/src/content/blog/technical/documentation-drift-ownership.mdx
+++ b/src/content/blog/technical/documentation-drift-ownership.mdx
@@ -1,0 +1,75 @@
+---
+title: 'Documentation Drift Has an Ownership Problem'
+subtitle: Published August 2026
+description: >-
+  Detection tools tell you which docs have drifted. They don't tell you who fixes them. That gap is why drift keeps coming back.
+date: '2026-08-06T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Three weeks ago, a PR renamed an authentication parameter. Your monitoring flagged the docs page that referenced the old name. The flag appeared in the team Slack channel. The technical writer assumed the engineer who merged the change would handle it. The engineer assumed documentation updates were the writer's job. This week, a developer filed a support ticket because the docs still use the old parameter name.
+
+The gap between detecting drift and fixing it is where most documentation debt accumulates.
+
+Most conversations about [documentation drift focus on detection](/blog/technical/documentation-drift-detection-problem): knowing which pages have diverged from the product before developers hit a broken path. Detection is necessary. But it solves a different problem than remediation. A monitoring tool surfaces what's wrong. It doesn't determine who fixes it or when.
+
+## Why collective ownership fails
+
+The default documentation ownership model at most companies is implicit: the whole team is responsible. In practice, this means nobody is.
+
+Research from the 2025 State of Docs report found a consistent failure pattern: technical writers assume subject matter experts (the engineers closest to the product) will identify what needs updating; engineers assume the writers are tracking changes. Neither side is watching the same signals. Drift falls between them.
+
+This pattern has a structural cause. When something goes wrong with collectively owned work, the cost gets distributed. No single person is accountable for a specific page being out of date. The support ticket that results from a stale doc gets routed and resolved. The underlying page doesn't always get updated, and the next developer hits the same wall.
+
+The productivity cost compounds. Research consistently estimates that documentation problems consume 15 to 25 percent of total engineering capacity. The cost is downstream: developers reading source code to verify behavior that docs should describe, asking Slack questions that accurate pages would prevent. For a 100-person engineering team, that's the equivalent of 15 to 25 engineers whose time disappears into compensating for missing or incorrect documentation.
+
+This isn't a writing-speed problem. Most teams have enough writing capacity. The bottleneck is accountability for specific pages.
+
+<BlogNewsletterCTA />
+
+## AI coding velocity compounds unowned drift
+
+Engineering teams shipped approximately 986 million commits on GitHub in 2025, a figure shaped heavily by AI-assisted development tools. AI coding tools let engineers write and ship code faster. They don't update documentation.
+
+The math compounds quickly. If your team merged 20 pull requests per week in 2022, your documentation team had a manageable surface to watch. If AI tools bring that to 60 pull requests per week in 2026, with no change to documentation workflows, drift accumulates at three times the rate.
+
+Unowned drift in this environment means alerts fire and queues fill. Without a named person to act on each item, the backlog grows faster than anyone can review manually. Already, 75 percent of APIs in production don't conform to their own OpenAPI specifications. Faster code velocity without documentation ownership makes this worse.
+
+## What page-level ownership looks like
+
+The teams that sustainably reduce drift assign a named owner to every section of their documentation with a defined verification cadence. This is sometimes called the DRI model (Directly Responsible Individual), borrowed from how engineering organizations handle feature ownership.
+
+The assignment describes the current state: who is responsible for this page being accurate right now, and when do they next review it?
+
+Cadences vary by content type:
+
+**API reference and SDK docs** drift faster because they describe specific behaviors that change with every release. Monthly verification is a reasonable cadence for these pages.
+
+**Quickstart guides and tutorials** are more stable but higher-stakes: a broken tutorial is the first thing a new developer encounters. Quarterly review works for most teams, with a triggered review whenever a major feature ships.
+
+**Conceptual and explanatory content** changes least often. Semi-annual review is usually sufficient, with the owner checking in whenever the underlying product area ships a meaningful update.
+
+The owner for API reference is typically the engineer closest to that code. They know when something changed and what the documentation actually needs to say. Writers take conceptual content and tutorials, where explanation craft matters more than proximity to the implementation. For [DevRel docs specifically](/blog/technical/developer-relations-docs), the DevRel engineer often owns accuracy for their area of focus.
+
+## The handoff problem
+
+Ownership breaks at transitions: engineers leave, teams reorganize, products move into maintenance mode. A page with a former owner and no documented succession has, in practice, no owner.
+
+The fix is building handoffs into the ownership model. When an engineer transitions off a product area, documentation section ownership transfers as part of the offboarding checklist, alongside access permissions and runbook assignments. When a new writer joins, the first week includes a documented handoff of which pages they're inheriting.
+
+This sounds like overhead. In practice, it's less overhead than discovering three months later that a section was orphaned and nobody noticed.
+
+## Detection and ownership together
+
+A drift monitoring tool that surfaces stale pages is only useful if someone specific is responsible for acting on each one. The monitor shows what changed. The owner decides what the update should say and makes sure it ships.
+
+The two practices are complementary. Detection narrows the problem from "we might have docs that are wrong somewhere" to "this specific page needs review because this specific thing changed." Ownership closes the loop: the right person gets the signal, makes the call, and updates the page before another developer hits a broken path.
+
+The teams that keep documentation current over time solve both halves. Monitoring without ownership creates a growing alert backlog. Ownership without detection puts the burden back on human surveillance of an expanding codebase. Together, they make the problem tractable at scale.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `documentation drift`

## Article plan

**Thesis:** Detecting documentation drift is necessary but not sufficient. Drift keeps recurring when no single person is accountable for specific pages. Teams that permanently reduce drift assign named owners with defined verification cadences before building monitoring.

**Target reader:** Technical writing leads and engineering managers at API-first companies who have tried audit processes and monitoring and still see drift come back.

**Key angles:**
- Detection finds drift; ownership determines whether it gets fixed
- Collective ownership fails predictably: each person assumes someone else is handling it (State of Docs 2025)
- AI coding tools (986M commits on GitHub in 2025) compound unowned drift
- Page-level DRI model with cadences by content type (reference monthly, guides quarterly)
- Handoff protocols for transitions
- Detection and ownership are complementary, not competing

**Promptless connection:** Promptless surfaces which pages drifted, making it tractable to route fixes to named owners.

## File

`src/content/blog/technical/documentation-drift-ownership.mdx`

This is an AI-generated draft and needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7uzfwFox4Kj6ipPkYoHde)_