### PR TITLE
content: Launch post — Comment @promptless on a GitLab merge request

### DIFF
--- a/src/content/blog/product-updates/gitlab-merge-request-comment-trigger.mdx
+++ b/src/content/blog/product-updates/gitlab-merge-request-comment-trigger.mdx
@@ -31,7 +31,7 @@ Leave a comment on any GitLab merge request with `@promptless` in the text. Prom
 Specifics:
 
 - **Matching is case-insensitive.** `@Promptless`, `@PROMPTLESS`, and `@promptless` all work.
-- **Commenting on an MR Promptless already has a suggestion for revises that suggestion.** It doesn't create a second one.
+- **Commenting on a merge request Promptless opened revises that suggestion.** It doesn't create a second one.
 - **Commenting on any other MR starts a fresh documentation review.**
 - **The project doesn't have to be in your trigger configuration.** Promptless just needs your GitLab connection to have read access to the project. This matters for repos that are outside your standard trigger scope but occasionally produce changes worth documenting.
 - **Use `@promptless-for-oss` for OSS projects.**
@@ -53,8 +53,8 @@ If your trigger rules already cover the projects and events you care about, you 
 
 ## How to use it
 
-No configuration needed. Add a comment to any GitLab merge request that includes `@promptless`. Your existing GitLab connection handles authentication. If the project is in a private GitLab group, Promptless uses your GitLab group access token automatically.
+No configuration needed. Add a comment to any GitLab merge request that includes `@promptless`. Your existing GitLab connection handles authentication — Promptless uses your connected GitLab group access token automatically.
 
-The 👀 reaction on your comment confirms Promptless saw the mention and started working.
+When Promptless picks up the mention, it adds a 👀 reaction to your comment to acknowledge it and starts working.
 
 <BlogRequestDemo />

--- a/src/content/blog/product-updates/gitlab-merge-request-comment-trigger.mdx
+++ b/src/content/blog/product-updates/gitlab-merge-request-comment-trigger.mdx
@@ -1,0 +1,60 @@
+---
+title: 'Comment @promptless on a GitLab Merge Request to Request Documentation'
+subtitle: Published August 2026
+description: >-
+  Mention @promptless in any GitLab merge request comment to trigger a documentation review. Works on any project your GitLab connection can access, including projects outside your trigger config.
+date: '2026-08-07T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Mention `@promptless` in a GitLab merge request comment and Promptless reviews the MR and opens a documentation suggestion. It works on any project your GitLab connection has read access to, whether or not that project is in your trigger configuration.
+
+This brings GitLab comment-mention triggering to parity with the existing GitHub behavior.
+
+## The problem
+
+Documentation trigger rules cover the routine case. You configure them once: every MR in these projects, on open, or on merge. They run automatically without thinking about it.
+
+The gaps show up when documentation needs arise outside the routine. A reviewer reading an MR notices the behavior it introduces isn't documented. A tech writer participating in a review wants to request a suggestion while the context is fresh. An older MR gets referenced in a ticket and someone wonders whether it was ever documented.
+
+Previously, GitLab teams had no way to ask Promptless for documentation from inside the MR. They'd have to open the Promptless dashboard and create a task manually, or add the project to their trigger config and wait for the next event. Either way, the request was disconnected from the conversation where it came up.
+
+## What it does now
+
+Leave a comment on any GitLab merge request with `@promptless` in the text. Promptless reads the MR, identifies relevant sections of your docs, and opens a suggestion PR.
+
+Specifics:
+
+- **Matching is case-insensitive.** `@Promptless`, `@PROMPTLESS`, and `@promptless` all work.
+- **Commenting on an MR Promptless already has a suggestion for revises that suggestion.** It doesn't create a second one.
+- **Commenting on any other MR starts a fresh documentation review.**
+- **The project doesn't have to be in your trigger configuration.** Promptless just needs your GitLab connection to have read access to the project. This matters for repos that are outside your standard trigger scope but occasionally produce changes worth documenting.
+- **Use `@promptless-for-oss` for OSS projects.**
+- **`/promptless` at the start of a comment line is a less-reliable alternative** if you'd rather not include the `@` mention in the comment text.
+
+One difference from GitHub: a mention in an MR title or description doesn't trigger Promptless. Only comments do.
+
+<BlogNewsletterCTA />
+
+## Who benefits most
+
+Teams using GitLab for code review who want to request documentation on specific MRs, not every MR that matches a trigger rule. In practice:
+
+- Reviewers who spot an undocumented behavior mid-review and want to flag it without leaving GitLab
+- Tech writers embedded in engineering teams who follow MR reviews and want to kick off documentation work at the right moment
+- Teams with repos that fall outside their standard trigger scope but occasionally ship changes worth documenting
+
+If your trigger rules already cover the projects and events you care about, you won't use this for every MR. But when a specific MR needs a suggestion and your rules won't catch it, a comment is the fastest path.
+
+## How to use it
+
+No configuration needed. Add a comment to any GitLab merge request that includes `@promptless`. Your existing GitLab connection handles authentication. If the project is in a private GitLab group, Promptless uses your GitLab group access token automatically.
+
+The 👀 reaction on your comment confirms Promptless saw the mention and started working.
+
+<BlogRequestDemo />


### PR DESCRIPTION
## Feature

Mention `@promptless` in any GitLab merge request comment to trigger a documentation review. Works on any project your GitLab connection can access, including projects outside your trigger config. Brings GitLab comment-mention triggering to parity with existing GitHub behavior.

## Entries considered this run

Window: 2026-08-03 → 2026-08-10.

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **GitLab merge-request comment triggering** — `@promptless` in a GitLab MR comment triggers documentation work (PR #4461) | QUALIFIES | New trigger surface for GitLab users; works outside trigger repo list; parity-adding but distinct from GitHub version |
| 2 | **Trigger timeline on Triggers page** — every card shows received→suggestion→completion timeline | SKIP | UI improvement showing existing data; doesn't unlock new capability |
| 3 | **Confluence search OAuth scopes** — search failed until Atlassian reconnect | SKIP | Bug fix |
| 4 | **Streamlined Slack onboarding** — connects in place, no separate page | SKIP | Onboarding UX polish |
| 5 | **GitLab MR and Bitbucket PR Replay** — replay recent MRs/PRs during trigger setup | SKIP | Onboarding feature parity; limited to setup flow; borderline, default NO |
| 6 | **Instant Slack channel listening** — passive listening now triggers immediately, no 10-min window | SKIP | Improvement to existing behavior, not new capability |
| 7 | **PR trigger event badges** — event-type badges on GitHub PR trigger cards | SKIP | UI polish |
| 8 | **Multiple docs sources during onboarding** — connect multiple GitHub doc repos in setup wizard | SKIP | Onboarding UX; previously skipped in PR #653 review |
| 9 | **Slack passive listening reliability** — fixed intermittent message drops | SKIP | Bug fix |
| 10 | **Closed suggestion diffs** — fixed "No changes detected" on closed/merged suggestions | SKIP | Bug fix |
| 11 | **GitLab MR link resolution** — fetches MR content via REST API when sharing links | SKIP | Backend improvement; doesn't change user workflow |
| 12 | **Read files and images in Microsoft Teams** — file/image reading in 1:1 chats and channels | SKIP | Adjacent to existing `teams-private-channel-file-access.mdx`; topic area already covered |
| 13 | **Teams channel files showed as unavailable** — fixed sharing-link file resolution | SKIP | Bug fix |
| 14 | **@promptless in PR review summaries missed 👀 reaction** | SKIP | Bug fix |
| 15 | **Shareable Agent Knowledge Base file links** — ?file= query param added to KB editor URLs | SKIP | Minor UX improvement |
| 16 | **Safer default role for auto-enrolled members** — admin-only to change | SKIP | Admin security policy, not user workflow capability |
| 17 | **Microsoft Teams connect flow** — link tenant after install via 'Link App & Grant Read Channels' | SKIP | Documentation of existing connect flow steps |

14 commit(s) in window. 17 entries considered, 1 qualified.

## Covered entry (full text)

> **Trigger documentation work from a GitLab merge-request comment:** Mentioning `@promptless` anywhere in a merge-request comment now starts documentation work, bringing GitLab to parity with the existing GitHub comment-mention behavior. Matching is case-insensitive. Use `@promptless-for-oss` for OSS. GitLab also recognizes `/promptless` at the start of a comment line as a less-reliable alternative. A comment on a merge request Promptless opened revises that suggestion, while a comment on any other merge request starts a new documentation review for it. Because a mention is an explicit request, Promptless reviews that merge request even if the project isn't in your trigger's repo list—it only needs your GitLab connection to have access to the project. Unlike GitHub, a mention in a merge-request title or description does not trigger; only comments do. See [GitLab merge requests](/docs/connect/triggers/gitlab-merge-requests#request-documentation-via-merge-request-comments).

Source: commit [3acf80c](https://github.com/Promptless/promptless.ai/commit/3acf80ce6423aff14701993baf8a7418853ceb7c). Backs Promptless/promptless#4461.

## PR(s) researched

Changelog entry references Promptless/promptless#4461. GitHub access is scoped to promptless.ai only; article written from changelog entry details.

## File

`src/content/blog/product-updates/gitlab-merge-request-comment-trigger.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_014bV2yyhuS2VcyqjneHqDRg)_