### PR TITLE
content: Launch post — Replay Recent GitLab and Bitbucket History at Trigger Setup

### DIFF
--- a/src/content/blog/product-updates/gitlab-bitbucket-pr-replay.mdx
+++ b/src/content/blog/product-updates/gitlab-bitbucket-pr-replay.mdx
@@ -1,0 +1,43 @@
+---
+title: 'Replay Recent GitLab and Bitbucket History When You Set Up a New Trigger'
+subtitle: Published August 2026
+description: >-
+  When you create a new GitLab MR or Bitbucket PR trigger, you can now replay
+  the last 30 days of merge requests and pull requests to generate your first
+  wave of documentation suggestions.
+date: '2026-08-10T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+When you create a new GitLab merge request or Bitbucket pull request trigger, you can now replay up to 30 days of recent activity. Promptless processes your recent MRs and PRs and generates documentation suggestions for them before your first new merge even happens.
+
+## The problem
+
+When GitHub PR triggers added replay support, teams onboarding to Promptless could generate an initial batch of documentation suggestions from recent work, not just from future activity. That made a big difference for pilots and evaluations: you'd see real suggestions for real code within an hour of setup, rather than waiting for the next PR to merge.
+
+Teams on GitLab or Bitbucket didn't have that option. Setting up a trigger meant starting from zero. A team that had shipped a major feature last week, or ten small fixes over the past month, had to wait for future MRs before Promptless had anything to work with. The onboarding experience was thinner than the GitHub equivalent, even if the ongoing behavior was the same.
+
+## What it does now
+
+When creating a new GitLab merge request or Bitbucket pull request trigger, you'll see an option to replay recent activity. Enable it, and Promptless queues up MRs and PRs from the last 30 days for processing. The onboarding preview shows you what's in the queue: counts and recent items, grouped by provider.
+
+The replay runs once at setup. After that, the trigger processes new activity as usual.
+
+<BlogNewsletterCTA />
+
+## Who benefits most
+
+Teams evaluating Promptless on a GitLab or Bitbucket codebase get the most from this. You can seed your first round of suggestions from existing work rather than setting up the integration and then waiting. If you're migrating from GitHub or adding Promptless to a team that's been on GitLab or Bitbucket for years, the replay option lets you onboard with something representative of your actual docs gaps.
+
+## How to use it
+
+When creating a GitLab or Bitbucket trigger, enable the replay option in the trigger creation flow. Promptless handles the rest. No separate configuration is required.
+
+See [GitLab merge requests](/docs/connect/triggers/gitlab-merge-requests) and [Bitbucket pull requests](/docs/reference/integrations/bitbucket) for trigger setup details.
+
+<BlogRequestDemo />


### PR DESCRIPTION
## Feature

When creating a new GitLab MR or Bitbucket PR trigger, you can now enable "Replay recent MRs/PRs" to process the last 30 days of merge requests and pull requests — bringing GitLab and Bitbucket to parity with GitHub's existing replay onboarding option.

## Entries considered this run

Window: 2026-08-03 → 2026-08-10.

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 1 | **GitLab MR comment triggering** — Mention @promptless in a GitLab MR comment to start doc work | SKIP | Duplicate of open PR #835 |
| 2 | **Research breakdown shows KB files and skills** — Breakdown now lists KB files agent read and skills used | SKIP | UX visibility enhancement to existing feature, not a new capability |
| 3 | **Trigger timeline on Triggers page** — Every trigger card shows received/suggestion/completed timeline | SKIP | UI visualization improvement, not a new workflow |
| 4 | **Confluence search OAuth scope bug** — Connections made before new scopes returned 401 on search | SKIP | Bug fix |
| 5 | **Streamlined Slack onboarding** — Connect in place, shows workspace name and icon | SKIP | Minor onboarding polish |
| 6 | **GitLab MR and Bitbucket PR Replay** — Enable replay of last 30 days during trigger setup | QUALIFIES | Adds substantial new onboarding capability for GitLab/Bitbucket users; previously impossible without GitHub |
| 7 | **Instant Slack channel listening** — Removes 10-minute quiet window | SKIP | Behavioral fix, not a new capability |
| 8 | **PR trigger event badges** — Event-type badges on GitHub PR trigger cards | SKIP | Minor UI polish |
| 9 | **Multiple docs sources during onboarding** — Connect multiple doc repos in setup wizard | SKIP | Ambiguous ship status: changelog entry kept but underlying PR #3300 closed without merging |
| 10 | **Slack Passive Listening bug fix** | SKIP | Bug fix |
| 11 | **Closed Suggestion Diffs bug fix** | SKIP | Bug fix |
| 12 | **Slack Mention Display bug fix** | SKIP | Bug fix |
| 13 | **Teams files unavailable bug fix** | SKIP | Bug fix |
| 14 | **Read files/images in Teams 1:1 chats** — File and image reading in personal Teams chats | SKIP | Partially covered by existing teams-private-channel-file-access.mdx |
| 15 | **GitLab MR link resolution** — Fetch MR content via GitLab API, bypassing SSO | SKIP | Borderline; under-the-hood improvement, default NO |
| 16 | **Shareable KB file links** — Deep-linkable URLs for Knowledge Base files | SKIP | UX enhancement to existing feature, not a new capability |
| 17 | **Safer default role for auto-enrolled members** — Admin-only change to default role setting | SKIP | Admin-gating security change, not a user-facing capability |
| 18 | **@promptless in PR review summaries missed 👀 reaction** | SKIP | Bug fix |
| 19 | **Grant file access to private/shared Teams channels** | SKIP | Duplicate of existing teams-private-channel-file-access.mdx |
| 20 | **Self-serve Microsoft Teams connect** — Connect Teams without a setup call | QUALIFIES | Removes significant onboarding friction; in separate PR |

20 commits in window. 20 entries considered, 2 qualified (this PR covers 1; self-serve Teams connect in a separate PR).

## Covered entry (full text)

> **GitLab MR and Bitbucket PR Replay:** When setting up new GitLab or Bitbucket triggers, you can now enable "Replay recent MRs/PRs" to process merge requests and pull requests from the last 30 days—the same onboarding experience previously available only for GitHub PRs. The onboarding preview groups results by provider, showing counts and recent items separately for GitHub PRs, GitLab MRs, and Bitbucket PRs.

Source: commit [bfa7994](https://github.com/Promptless/docs/commit/bfa79941441ee05a47c7e794c823ba892c5db513) (June 2026 changelog entry).

## PR(s) researched

- Promptless/promptless#3497 — Extends replay support to all code review trigger types during onboarding (merged)

## File

`src/content/blog/product-updates/gitlab-bitbucket-pr-replay.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_013crPbnA6pkExSBnHiXzNzX)_