### PR TITLE
content: Launch post — Connect Microsoft Teams Without a Setup Call

### DIFF
--- a/src/content/blog/product-updates/self-serve-teams-connect.mdx
+++ b/src/content/blog/product-updates/self-serve-teams-connect.mdx
@@ -1,0 +1,47 @@
+---
+title: 'Connect Microsoft Teams to Promptless Without a Setup Call'
+subtitle: Published August 2026
+description: >-
+  Microsoft Teams now connects to Promptless without scheduling a setup call.
+  Download the app package, install it in your tenant, and link it on the
+  Integrations page.
+date: '2026-08-10T00:00:00.000Z'
+author: Frances
+tag: Product Updates
+section: Featured
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+You can now connect Microsoft Teams to Promptless without scheduling a setup call. The process is self-serve: download the Promptless Teams app package, install it into your Teams tenant, then link your tenant to your Promptless account on the Integrations page.
+
+## The problem
+
+Teams integration used to require a call with the Promptless team. That made sense as a starting point, but it created a bottleneck for teams evaluating Promptless or wanting to add Teams during an active deployment. If you were running a pilot and decided mid-evaluation that you wanted to test Teams-triggered documentation updates, you had to stop and schedule time.
+
+It also meant that adding Teams to an existing Promptless setup was not something you could do independently. Any admin who wanted to connect the integration had to wait on Promptless availability.
+
+## What it does now
+
+The Microsoft Teams integration now has a self-serve setup flow on the [Integrations page](https://app.gopromptless.ai/integrations).
+
+Setup has three steps:
+
+1. Download the Promptless app package from the Integrations page.
+2. Install it into your Teams tenant via the Teams Admin Center.
+3. Return to Promptless and click **Link App & Grant Read Channels** to bind your tenant to your Promptless organization.
+
+Once linked, Promptless can receive messages from Teams channels and personal chats where it's been installed, and it uses your Teams conversations as context for documentation suggestions.
+
+<BlogNewsletterCTA />
+
+## Who benefits most
+
+Teams admins evaluating Promptless who want to test the full integration stack without going through a scheduling step. Also useful for existing Promptless customers who are adding Teams to their current setup — the full flow is in the docs and takes roughly as long as any other integration.
+
+If you previously went through the manual connect process, your configuration is unchanged. This only affects new connections.
+
+See the [Microsoft Teams integration guide](/docs/reference/integrations/microsoft-teams) for the complete setup steps.
+
+<BlogRequestDemo />


### PR DESCRIPTION
## Feature

Microsoft Teams now connects to Promptless without a setup call. Download the app package, install it in the Teams tenant, and link the tenant via the Integrations page.

## Entries considered this run

Window: 2026-08-03 → 2026-08-10. Full triage table is in PR #836 (the companion post for this run). This PR covers the second qualifier.

| # | Entry | Decision | Reason |
|---|-------|----------|--------|
| 20 | **Self-serve Microsoft Teams connect** — Connect Teams without a setup call | QUALIFIES | Significantly improves UX for Teams users; removes the setup-call bottleneck that blocked self-service adoption |

## Covered entry (full text)

> **Self-serve Microsoft Teams connect:** You can now connect Microsoft Teams to Promptless on your own—no setup call required. Download the Teams app package, install it into your Teams tenant, then click **Link App & Grant Read Channels** on the [Integrations page](https://app.gopromptless.ai/integrations) to link your tenant to your Promptless organization. See the [Microsoft Teams integration](/docs/reference/integrations/microsoft-teams) setup guide for details.

Source: commit [1f8b498](https://github.com/Promptless/docs/commit/1f8b498bb9e9c63ab902dc729157f59d74be38f0) (June 2026 changelog entry).

## PR(s) researched

- Promptless/promptless#3641 — Self-serve Microsoft Teams connect flow (merged)

## File

`src/content/blog/product-updates/self-serve-teams-connect.mdx`

AI-generated draft — needs human review before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_013crPbnA6pkExSBnHiXzNzX)_