### PR TITLE
Expand homepage agent governance story

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -75,7 +75,7 @@ section per page load.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-differentiation`, `agent-impact-examples`, `agent-learning-loop`, `agent-use-cases`, `agent-governance`, `agent-faq`, or `agent-final-cta` |
+| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-differentiation`, `agent-impact-examples`, `agent-learning-loop`, `agent-governance`, `agent-faq`, or `agent-final-cta` |
 | `page` | string | Pathname (always `/` for homepage) |
 
 **Component**: Inline IntersectionObserver in `posthog.astro`. Elements opt in

--- a/docs/events.md
+++ b/docs/events.md
@@ -75,7 +75,7 @@ section per page load.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-differentiation`, `agent-impact-examples`, `agent-learning-loop`, `agent-use-cases`, `agent-governance`, `agent-proof`, `agent-faq`, or `agent-final-cta` |
+| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-differentiation`, `agent-impact-examples`, `agent-learning-loop`, `agent-use-cases`, `agent-governance`, `agent-faq`, or `agent-final-cta` |
 | `page` | string | Pathname (always `/` for homepage) |
 
 **Component**: Inline IntersectionObserver in `posthog.astro`. Elements opt in

--- a/docs/events.md
+++ b/docs/events.md
@@ -75,7 +75,7 @@ section per page load.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-impact-examples`, `agent-use-cases`, `agent-governance`, `agent-proof`, `agent-faq`, or `agent-final-cta` |
+| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-differentiation`, `agent-impact-examples`, `agent-use-cases`, `agent-governance`, `agent-proof`, `agent-faq`, or `agent-final-cta` |
 | `page` | string | Pathname (always `/` for homepage) |
 
 **Component**: Inline IntersectionObserver in `posthog.astro`. Elements opt in

--- a/docs/events.md
+++ b/docs/events.md
@@ -50,7 +50,7 @@ Current `action` values:
 
 | action | locations |
 |--------|-----------|
-| `book_demo` | `hero`, `nav`, `mobile_menu`, `pricing_growth`, `pricing_enterprise`, `docs_welcome` |
+| `book_demo` | `hero`, `nav`, `mobile_menu`, `pricing_growth`, `pricing_enterprise`, `docs_welcome`, `agent_governance_footer` |
 | `sign_up` | `nav`, `mobile_menu`, `pricing_startup` |
 | `sign_in` | `nav`, `mobile_menu` |
 | `watch_demo` | `jobs_page` |
@@ -75,7 +75,7 @@ section per page load.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai` |
+| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-instruction-drift`, `agent-session-comparison`, `agent-improvement-loop`, `agent-use-cases`, `agent-governance`, `agent-proof`, `agent-faq`, or `agent-final-cta` |
 | `page` | string | Pathname (always `/` for homepage) |
 
 **Component**: Inline IntersectionObserver in `posthog.astro`. Elements opt in

--- a/docs/events.md
+++ b/docs/events.md
@@ -75,7 +75,7 @@ section per page load.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-differentiation`, `agent-impact-examples`, `agent-use-cases`, `agent-governance`, `agent-proof`, `agent-faq`, or `agent-final-cta` |
+| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-differentiation`, `agent-impact-examples`, `agent-learning-loop`, `agent-use-cases`, `agent-governance`, `agent-proof`, `agent-faq`, or `agent-final-cta` |
 | `page` | string | Pathname (always `/` for homepage) |
 
 **Component**: Inline IntersectionObserver in `posthog.astro`. Elements opt in

--- a/docs/events.md
+++ b/docs/events.md
@@ -75,7 +75,7 @@ section per page load.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-instruction-drift`, `agent-session-comparison`, `agent-improvement-loop`, `agent-use-cases`, `agent-governance`, `agent-proof`, `agent-faq`, or `agent-final-cta` |
+| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-instruction-drift`, `agent-impact-examples`, `agent-use-cases`, `agent-governance`, `agent-proof`, `agent-faq`, or `agent-final-cta` |
 | `page` | string | Pathname (always `/` for homepage) |
 
 **Component**: Inline IntersectionObserver in `posthog.astro`. Elements opt in

--- a/docs/events.md
+++ b/docs/events.md
@@ -75,7 +75,7 @@ section per page load.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-instruction-drift`, `agent-impact-examples`, `agent-use-cases`, `agent-governance`, `agent-proof`, `agent-faq`, or `agent-final-cta` |
+| `section` | string | Section name: `overview`, `testimonials`, `demo`, `how-promptless-works`, `capabilities`, `ask-ai`, `agent-impact-examples`, `agent-use-cases`, `agent-governance`, `agent-proof`, `agent-faq`, or `agent-final-cta` |
 | `page` | string | Pathname (always `/` for homepage) |
 
 **Component**: Inline IntersectionObserver in `posthog.astro`. Elements opt in

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -79,25 +79,22 @@ const faqs = [
       <article>
         <div class="pl-agent-difference-topline">
           <span class="pl-agent-difference-icon"><ShieldCheck size={30} stroke-width={1.8} aria-hidden="true" /></span>
-          <span class="pl-agent-difference-number" aria-hidden="true">01</span>
+          <h3>Secure, on‑prem by default</h3>
         </div>
-        <h3>Secure, on‑prem by default</h3>
         <p>Promptless analyzes agent traces inside your environment, so raw session data never leaves your systems.</p>
       </article>
       <article>
         <div class="pl-agent-difference-topline">
           <span class="pl-agent-difference-icon"><Handshake size={30} stroke-width={1.8} aria-hidden="true" /></span>
-          <span class="pl-agent-difference-number" aria-hidden="true">02</span>
+          <h3>White-glove onboarding</h3>
         </div>
-        <h3>White-glove onboarding</h3>
         <p>Every customer is paired with a forward-deployed AI engineer and technical writer to ensure immediate impact.</p>
       </article>
       <article>
         <div class="pl-agent-difference-topline">
           <span class="pl-agent-difference-icon"><Workflow size={30} stroke-width={1.8} aria-hidden="true" /></span>
-          <span class="pl-agent-difference-number" aria-hidden="true">03</span>
+          <h3>From DevOps to marketing</h3>
         </div>
-        <h3>From DevOps to marketing</h3>
         <p>The same learning loop improves code, incident response, customer materials, and operational work—across any agent tool.</p>
       </article>
     </div>
@@ -578,12 +575,12 @@ const faqs = [
   .pl-agent-difference-topline {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    margin-bottom: clamp(1.5rem, 3vw, 2.25rem);
+    gap: 1rem;
   }
 
   .pl-agent-difference-icon {
     display: grid;
+    flex: 0 0 auto;
     width: 3.25rem;
     height: 3.25rem;
     place-items: center;
@@ -592,12 +589,6 @@ const faqs = [
     background: rgba(80, 106, 234, 0.12);
     color: #aab6ff;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0.06);
-  }
-
-  .pl-agent-difference-number {
-    color: #8f9fff;
-    font: 700 0.72rem/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    letter-spacing: 0.08em;
   }
 
   .pl-agent-difference-list h3 {

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -356,18 +356,24 @@ const faqs = [
 
 <style>
   .pl-agent-story {
-    --agent-ink: #111827;
-    --agent-muted: #5f6b7a;
-    --agent-line: #dfe5ec;
-    --agent-soft: #f5f7fb;
-    --agent-accent: #506aea;
-    --agent-accent-soft: #eef2ff;
+    --agent-ink: var(--pl-color-text-strong);
+    --agent-text: var(--pl-color-text);
+    --agent-muted: var(--pl-color-text-muted);
+    --agent-subtle: var(--pl-color-text-subtle);
+    --agent-line: var(--pl-color-border);
+    --agent-line-strong: var(--pl-color-border-strong);
+    --agent-surface: var(--pl-color-surface-raised);
+    --agent-surface-elevated: var(--pl-color-surface-elevated);
+    --agent-soft: var(--pl-color-surface-soft);
+    --agent-accent: var(--pl-color-accent);
+    --agent-accent-soft: var(--pl-color-accent-soft);
+    --agent-accent-border: var(--pl-color-accent-border);
     display: flex;
     flex-direction: column;
     gap: clamp(4.5rem, 9vw, 7.5rem);
     margin: clamp(3.5rem, 7vw, 6rem) auto 0;
     max-width: 1120px;
-    color: var(--agent-ink);
+    color: var(--agent-text);
   }
 
   .pl-agent-section {
@@ -433,9 +439,11 @@ const faqs = [
     margin: 0;
     border: 1px solid var(--agent-line);
     border-radius: 1rem;
-    background: #fff;
+    background:
+      linear-gradient(145deg, rgba(255, 255, 255, 0.045), transparent 48%),
+      var(--agent-surface);
     padding: 1.55rem;
-    box-shadow: 0 1px 2px rgb(15 23 42 / 0.04);
+    box-shadow: var(--pl-shadow-sm);
   }
 
   .pl-agent-card h3 {
@@ -452,11 +460,11 @@ const faqs = [
 
   .pl-agent-receipt {
     overflow: hidden;
-    border: 1px solid #2d3242;
+    border: 1px solid var(--agent-line-strong);
     border-radius: 1.1rem;
-    background: #101117;
+    background: var(--pl-color-surface);
     color: #e8eaf2;
-    box-shadow: 0 20px 50px rgb(15 23 42 / 0.16);
+    box-shadow: var(--pl-shadow-md);
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   }
 
@@ -616,8 +624,8 @@ const faqs = [
     overflow: hidden;
     border: 1px solid var(--agent-line);
     border-radius: 1rem;
-    background: #fff;
-    box-shadow: 0 15px 40px rgb(15 23 42 / 0.08);
+    background: var(--agent-surface);
+    box-shadow: var(--pl-shadow-md);
   }
 
   .pl-agent-product-bar {
@@ -661,7 +669,7 @@ const faqs = [
     flex-direction: column;
     gap: 0.35rem;
     margin: 0.75rem 0 1rem;
-    color: #207a52;
+    color: var(--pl-color-success);
     font: 0.72rem/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   }
 
@@ -670,20 +678,20 @@ const faqs = [
     margin-top: auto;
     border-radius: 999px;
     background: var(--agent-accent-soft);
-    color: #3f51bf;
+    color: var(--agent-accent);
     padding: 0.32rem 0.55rem;
     font-size: 0.68rem;
     font-weight: 700;
   }
 
   .pl-agent-status-alert {
-    background: #fff4e6;
-    color: #a15c00;
+    background: #2b2113;
+    color: #e8bc75;
   }
 
   .pl-agent-status-pass {
-    background: #e9f9f0;
-    color: #207a52;
+    background: var(--pl-color-success-soft);
+    color: var(--pl-color-success);
   }
 
   .pl-agent-example-card {
@@ -710,9 +718,13 @@ const faqs = [
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: clamp(2rem, 6vw, 5rem);
+    border: 1px solid var(--agent-line);
     border-radius: 1.25rem;
-    background: #121622;
+    background:
+      radial-gradient(circle at 12% 0%, rgba(100, 114, 246, 0.16), transparent 42%),
+      var(--agent-surface-elevated);
     padding: clamp(2rem, 6vw, 4rem);
+    box-shadow: var(--pl-shadow-sm);
   }
 
   .pl-agent-governance h2 {
@@ -843,10 +855,15 @@ const faqs = [
   }
 
   .pl-agent-final-cta {
+    border: 1px solid var(--agent-accent-border);
     border-radius: 1.25rem;
-    background: linear-gradient(135deg, #eef2ff, #f4fbff 55%, #edfaf5);
+    background:
+      radial-gradient(circle at 50% 0%, rgba(115, 221, 197, 0.12), transparent 38%),
+      linear-gradient(135deg, rgba(82, 100, 236, 0.18), rgba(114, 92, 234, 0.08) 58%, transparent),
+      var(--agent-surface);
     padding: clamp(2.25rem, 7vw, 5rem);
     text-align: center;
+    box-shadow: var(--pl-shadow-md);
   }
 
   .pl-agent-final-cta h2 {
@@ -865,7 +882,7 @@ const faqs = [
     gap: 0.55rem;
     margin-top: 1.5rem;
     border-radius: 0.5rem;
-    background: var(--agent-accent);
+    background: var(--pl-gradient-action);
     color: #fff;
     padding: 0.82rem 1.15rem;
     font-weight: 700;
@@ -875,6 +892,7 @@ const faqs = [
 
   .pl-agent-final-cta > a:hover {
     color: #fff;
+    background: var(--pl-gradient-action-hover);
     transform: translateY(-1px);
     box-shadow: 0 8px 20px rgb(80 106 234 / 0.24);
   }

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -1,0 +1,964 @@
+---
+const painPoints = [
+  {
+    title: 'Instruction sprawl',
+    body: 'Skills and conventions spread across local machines, repositories, chat threads, and shared drives. Nobody can tell which version an agent is following.',
+  },
+  {
+    title: 'Invisible performance debt',
+    body: 'Agents repeat searches, retries, and dead ends your team has already solved. The waste hides inside individual sessions until someone stops to measure it.',
+  },
+  {
+    title: 'No safe improvement loop',
+    body: 'Even when a teammate finds a better approach, there is no consistent way to review it, validate it, and distribute it to every agent that needs it.',
+  },
+];
+
+const workflowSteps = [
+  {
+    number: '01',
+    title: 'Detect',
+    body: 'Find churn, hallucinations, stale instructions, tool and MCP failures, leaks, and repeated corrections in real session traces.',
+  },
+  {
+    number: '02',
+    title: 'Draft',
+    body: 'Turn repeated failure patterns into a concrete instruction addition, update, or deletion.',
+  },
+  {
+    number: '03',
+    title: 'Review and validate',
+    body: 'Let your team inspect every remediation and optionally test it against an eval gate before merging.',
+  },
+  {
+    number: '04',
+    title: 'Distribute',
+    body: 'Refresh approved instructions through native agent plugins, with access limited to the agents and teams that need them.',
+  },
+];
+
+const dogfoodExamples = [
+  {
+    label: 'Engineering enablement',
+    title: 'Share the best development setup',
+    body: 'Promptless found one engineer’s streamlined local environment and turned it into a reusable skill for the rest of the team.',
+  },
+  {
+    label: 'GTM quality',
+    title: 'Keep placeholders out of customer work',
+    body: 'Repeated corrections in sales-deck sessions became a stronger skill, reducing the risk of unfinished placeholders reaching prospects.',
+  },
+  {
+    label: 'Developer productivity',
+    title: 'Recover from expired credentials',
+    body: 'When agents repeatedly stalled on expired authentication, Promptless proposed a hook that sends people straight to reauthentication.',
+  },
+  {
+    label: 'Incident response',
+    title: 'Route agents to the right tools',
+    body: 'Promptless saw agents bypassing the team’s Datadog workflow, then strengthened AGENTS.md and added a specialist subagent.',
+  },
+];
+
+const governanceControls = [
+  'Trace analysis runs on your systems.',
+  'Instructions are organized and versioned in one hub.',
+  'Your team reviews and merges every remediation.',
+  'Optional eval gates catch regressions before changes ship.',
+  'Access controls limit each agent to the instructions it needs.',
+];
+
+const proofMetrics = [
+  { figure: '42%', label: 'fewer human interruptions' },
+  { figure: '15%', label: 'more first-attempt completions' },
+  { figure: '32%', label: 'less wall-clock time per session' },
+  { figure: '18%', label: 'fewer tokens consumed' },
+];
+
+const faqs = [
+  {
+    question: 'What counts as an agent instruction?',
+    answer:
+      'Skills, subagent definitions, hooks, AGENTS.md files, and shared MCP server configurations—anything that tells an agent how your team works.',
+  },
+  {
+    question: 'Which agents does Promptless support?',
+    answer:
+      'Promptless works with the agent tools your team already uses, including Claude Code, Codex, Cursor, Gemini and Gemini CLI, Devin, and OpenClaw.',
+  },
+  {
+    question: 'Does Promptless change instructions automatically?',
+    answer:
+      'Promptless drafts additions, updates, and deletions from trace evidence. Your team reviews and merges the remediation; enterprise teams can also require an eval gate.',
+  },
+  {
+    question: 'Where are our session traces processed?',
+    answer:
+      'The Trace Analyzer runs on your systems so raw session traces do not need to leave your environment.',
+  },
+  {
+    question: 'How do we get started?',
+    answer:
+      'Start with a local diagnostic. Promptless analyzes where instruction debt is creating churn, interruptions, and wasted spend, then walks your team through the highest-impact opportunities.',
+  },
+];
+---
+
+<div class="pl-agent-story">
+  <section
+    class="pl-agent-section pl-agent-problem"
+    aria-labelledby="agent-problem-title"
+  >
+    <div class="pl-agent-heading" data-section-tracked="agent-instruction-drift">
+      <p class="pl-agent-eyebrow">Why capable agents still underperform</p>
+      <h2 id="agent-problem-title">Your model isn’t being nerfed. Your instruction stack is drifting.</h2>
+      <p>
+        Every stale skill, conflicting hook, and buried team convention makes capable models rediscover work your people already know how to do.
+      </p>
+    </div>
+    <div class="pl-agent-card-grid pl-agent-card-grid-three">
+      {painPoints.map((point) => (
+        <article class="pl-agent-card">
+          <h3>{point.title}</h3>
+          <p>{point.body}</p>
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section
+    class="pl-agent-section pl-agent-comparison"
+    aria-labelledby="agent-comparison-title"
+  >
+    <div class="pl-agent-heading pl-agent-heading-centered" data-section-tracked="agent-session-comparison">
+      <p class="pl-agent-eyebrow">A session receipt, not a vague promise</p>
+      <h2 id="agent-comparison-title">Same task. Better instruction stack.</h2>
+      <p>
+        Promptless sees where agents search, churn, retry, and ask for help—then turns repeated failure into a fix the whole team can use.
+      </p>
+    </div>
+
+    <div class="pl-agent-receipt" aria-label="Illustrative session comparison">
+      <div class="pl-agent-receipt-note">
+        <span>Illustrative comparison</span>
+        <span>Replace bracketed fields with a verified replay before publishing</span>
+      </div>
+      <p class="pl-agent-receipt-prompt"><span aria-hidden="true">›</span> Investigate a production incident</p>
+      <div class="pl-agent-receipt-grid">
+        <article class="pl-agent-run pl-agent-run-before">
+          <div class="pl-agent-run-heading">
+            <span>Without Promptless</span>
+            <strong>Instruction debt</strong>
+          </div>
+          <ol>
+            <li>Searches for tools and team conventions</li>
+            <li>Repeats known investigative dead ends</li>
+            <li>Needs a teammate to redirect the session</li>
+          </ol>
+          <dl>
+            <div><dt>Tokens</dt><dd>[baseline]</dd></div>
+            <div><dt>Wall clock</dt><dd>[baseline]</dd></div>
+            <div><dt>Retries</dt><dd>[baseline]</dd></div>
+            <div><dt>Interruptions</dt><dd>[baseline]</dd></div>
+          </dl>
+        </article>
+
+        <article class="pl-agent-run pl-agent-run-after">
+          <div class="pl-agent-run-heading">
+            <span>With Promptless</span>
+            <strong>Governed instructions</strong>
+          </div>
+          <ol>
+            <li>Loads the team’s approved incident skill</li>
+            <li>Routes directly to the right Datadog tools</li>
+            <li>Invokes the specialist investigation subagent</li>
+          </ol>
+          <dl>
+            <div><dt>Tokens</dt><dd>[with Promptless]</dd></div>
+            <div><dt>Wall clock</dt><dd>[with Promptless]</dd></div>
+            <div><dt>Retries</dt><dd>[with Promptless]</dd></div>
+            <div><dt>Interruptions</dt><dd>[with Promptless]</dd></div>
+          </dl>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section
+    class="pl-agent-section pl-agent-workflow"
+    aria-labelledby="agent-workflow-title"
+  >
+    <div class="pl-agent-heading pl-agent-heading-centered" data-section-tracked="agent-improvement-loop">
+      <p class="pl-agent-eyebrow">The improvement loop</p>
+      <h2 id="agent-workflow-title">From session trace to governed improvement</h2>
+      <p>
+        Real work produces the evidence. Promptless turns that evidence into a reviewed, validated instruction that every relevant agent can use.
+      </p>
+    </div>
+
+    <div class="pl-agent-workflow-overview">
+      <img
+        src="/site/virtuous-cycle-flywheel.svg"
+        alt="A continuous loop where agent session traces reveal improvements, approved changes enter the Instruction Hub, and refreshed instructions make the AI workforce more effective"
+        loading="lazy"
+        width="820"
+        height="820"
+      />
+      <ol class="pl-agent-workflow-steps">
+        {workflowSteps.map((step) => (
+          <li>
+            <span class="pl-agent-step-number">{step.number}</span>
+            <div>
+              <h3>{step.title}</h3>
+              <p>{step.body}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+
+    <div class="pl-agent-product-view" aria-label="Illustrative trace-to-remediation product workflow">
+      <div class="pl-agent-product-bar">
+        <span>Trace-to-remediation</span>
+        <span>Illustrative product view</span>
+      </div>
+      <div class="pl-agent-product-grid">
+        <article>
+          <p class="pl-agent-product-label">01 · Finding</p>
+          <h3>Repeated authentication dead end</h3>
+          <p>Agents continue working after universal credentials expire, producing stalled or degraded sessions.</p>
+          <span class="pl-agent-status pl-agent-status-alert">Repeated pattern</span>
+        </article>
+        <article>
+          <p class="pl-agent-product-label">02 · Remediation</p>
+          <h3>Add an expired-token hook</h3>
+          <div class="pl-agent-diff">
+            <span>+ Detect the authentication failure</span>
+            <span>+ Prompt the user to sign in again</span>
+            <span>+ Resume only after verification</span>
+          </div>
+          <span class="pl-agent-status">Ready for review</span>
+        </article>
+        <article>
+          <p class="pl-agent-product-label">03 · Validation</p>
+          <h3>Replay against affected sessions</h3>
+          <p>The optional eval gate checks that the hook resolves the dead end without regressing successful flows.</p>
+          <span class="pl-agent-status pl-agent-status-pass">Eval passed</span>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section
+    class="pl-agent-section pl-agent-use-cases"
+    aria-labelledby="agent-use-cases-title"
+  >
+    <div class="pl-agent-heading" data-section-tracked="agent-use-cases">
+      <p class="pl-agent-eyebrow">Promptless internal dogfooding</p>
+      <h2 id="agent-use-cases-title">Make your best work the team’s new default.</h2>
+      <p>
+        One person’s breakthrough should not stay trapped in one chat. Promptless turns proven ways of working into reusable instructions for engineering, GTM, and operations.
+      </p>
+    </div>
+    <div class="pl-agent-card-grid pl-agent-card-grid-two">
+      {dogfoodExamples.map((example) => (
+        <article class="pl-agent-card pl-agent-example-card">
+          <p class="pl-agent-card-label">{example.label}</p>
+          <h3>{example.title}</h3>
+          <p>{example.body}</p>
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section
+    class="pl-agent-section pl-agent-governance"
+    aria-labelledby="agent-governance-title"
+  >
+    <div class="pl-agent-governance-copy" data-section-tracked="agent-governance">
+      <p class="pl-agent-eyebrow">Governance built into the loop</p>
+      <h2 id="agent-governance-title">Improve the fleet without giving up control.</h2>
+      <p>
+        Continuous improvement should not mean uncontrolled change. Promptless gives technical owners a versioned, reviewable path from trace evidence to the instructions running across their organization.
+      </p>
+    </div>
+    <ul class="pl-agent-checklist">
+      {governanceControls.map((control) => (
+        <li>
+          <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+            <path d="m5 12 4 4L19 6" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+          <span>{control}</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+
+  <section
+    class="pl-agent-section pl-agent-proof"
+    aria-labelledby="agent-proof-title"
+  >
+    <div class="pl-agent-proof-heading" data-section-tracked="agent-proof">
+      <div>
+        <p class="pl-agent-eyebrow">Promptless internal dogfooding · 30-day window</p>
+        <h2 id="agent-proof-title">Thirty days. Four measurable gains.</h2>
+      </div>
+      <p>Measured against our pre-governance baseline across engineering, GTM, and operations.</p>
+    </div>
+    <div class="pl-agent-proof-grid">
+      {proofMetrics.map((metric) => (
+        <div>
+          <strong>{metric.figure}</strong>
+          <span>{metric.label}</span>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section
+    class="pl-agent-section pl-agent-faq"
+    aria-labelledby="agent-faq-title"
+  >
+    <div class="pl-agent-heading" data-section-tracked="agent-faq">
+      <p class="pl-agent-eyebrow">Common questions</p>
+      <h2 id="agent-faq-title">Agent instruction governance, explained.</h2>
+    </div>
+    <div class="pl-agent-faq-list">
+      {faqs.map((faq) => (
+        <details>
+          <summary>{faq.question}</summary>
+          <p>{faq.answer}</p>
+        </details>
+      ))}
+    </div>
+  </section>
+
+  <section
+    class="pl-agent-final-cta"
+    aria-labelledby="agent-final-cta-title"
+    data-section-tracked="agent-final-cta"
+  >
+    <p class="pl-agent-eyebrow">Start with the evidence you already have</p>
+    <h2 id="agent-final-cta-title">See what your agent traces are already trying to teach you.</h2>
+    <p>Start with a diagnostic of the instruction debt slowing down your AI workforce.</p>
+    <a
+      href="/meet#book"
+      data-track-action="book_demo"
+      data-track-funnel="conversion"
+      data-track-location="agent_governance_footer"
+      data-track-campaign="agent_instructions"
+    >
+      Get a demo
+      <span aria-hidden="true">→</span>
+    </a>
+  </section>
+</div>
+
+<style>
+  .pl-agent-story {
+    --agent-ink: #111827;
+    --agent-muted: #5f6b7a;
+    --agent-line: #dfe5ec;
+    --agent-soft: #f5f7fb;
+    --agent-accent: #506aea;
+    --agent-accent-soft: #eef2ff;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(4.5rem, 9vw, 7.5rem);
+    margin: clamp(3.5rem, 7vw, 6rem) auto 0;
+    max-width: 1120px;
+    color: var(--agent-ink);
+  }
+
+  .pl-agent-section {
+    scroll-margin-top: calc(var(--sl-nav-height) + 5rem);
+  }
+
+  .pl-agent-heading {
+    max-width: 760px;
+    margin-bottom: 2rem;
+  }
+
+  .pl-agent-heading-centered {
+    margin-inline: auto;
+    text-align: center;
+  }
+
+  .pl-agent-eyebrow,
+  .pl-agent-card-label,
+  .pl-agent-product-label {
+    margin: 0 0 0.65rem;
+    color: var(--agent-accent);
+    font-size: 0.78rem;
+    font-weight: 750;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .pl-agent-heading h2,
+  .pl-agent-governance h2,
+  .pl-agent-proof h2,
+  .pl-agent-final-cta h2 {
+    margin: 0;
+    color: var(--agent-ink);
+    font-size: clamp(2rem, 5vw, 3.45rem);
+    line-height: 1.06;
+    letter-spacing: -0.045em;
+  }
+
+  .pl-agent-heading > p:last-child,
+  .pl-agent-governance-copy > p:last-child,
+  .pl-agent-proof-heading > p,
+  .pl-agent-final-cta > p:not(.pl-agent-eyebrow) {
+    margin: 1rem 0 0;
+    color: var(--agent-muted);
+    font-size: 1.05rem;
+    line-height: 1.7;
+  }
+
+  .pl-agent-card-grid {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .pl-agent-card-grid-three {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .pl-agent-card-grid-two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .pl-agent-card {
+    margin: 0;
+    border: 1px solid var(--agent-line);
+    border-radius: 1rem;
+    background: #fff;
+    padding: 1.55rem;
+    box-shadow: 0 1px 2px rgb(15 23 42 / 0.04);
+  }
+
+  .pl-agent-card h3 {
+    margin: 0;
+    color: var(--agent-ink);
+    font-size: 1.15rem;
+  }
+
+  .pl-agent-card p:last-child {
+    margin: 0.65rem 0 0;
+    color: var(--agent-muted);
+    line-height: 1.65;
+  }
+
+  .pl-agent-receipt {
+    overflow: hidden;
+    border: 1px solid #2d3242;
+    border-radius: 1.1rem;
+    background: #101117;
+    color: #e8eaf2;
+    box-shadow: 0 20px 50px rgb(15 23 42 / 0.16);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  }
+
+  .pl-agent-receipt-note,
+  .pl-agent-product-bar {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid #2d3242;
+    padding: 0.7rem 1rem;
+    color: #9aa2b3;
+    font-size: 0.7rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .pl-agent-receipt-note span:first-child {
+    color: #f4c873;
+  }
+
+  .pl-agent-receipt-prompt {
+    margin: 0;
+    border-bottom: 1px solid #2d3242;
+    padding: 1.2rem 1.3rem;
+    color: #f8fafc;
+    font-size: 1rem;
+  }
+
+  .pl-agent-receipt-prompt span {
+    margin-right: 0.45rem;
+    color: #a5b4fc;
+    font-weight: 800;
+  }
+
+  .pl-agent-receipt-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .pl-agent-run {
+    padding: clamp(1.25rem, 3vw, 2rem);
+  }
+
+  .pl-agent-run-before {
+    border-right: 1px solid #2d3242;
+  }
+
+  .pl-agent-run-heading {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-bottom: 0.85rem;
+    border-bottom: 2px solid #ef6f6c;
+    color: #ef9a98;
+  }
+
+  .pl-agent-run-after .pl-agent-run-heading {
+    border-color: #53d39a;
+    color: #74e1ad;
+  }
+
+  .pl-agent-run-heading strong {
+    color: #c8ceda;
+    font-size: 0.72rem;
+    font-weight: 500;
+    text-transform: uppercase;
+  }
+
+  .pl-agent-run ol {
+    min-height: 9rem;
+    margin: 1.25rem 0;
+    padding-left: 1.35rem;
+    color: #c7cbd6;
+    font-size: 0.83rem;
+    line-height: 1.75;
+  }
+
+  .pl-agent-run dl {
+    margin: 0;
+    border-top: 1px solid #2d3242;
+    padding-top: 0.75rem;
+  }
+
+  .pl-agent-run dl div {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.35rem 0;
+    color: #9aa2b3;
+    font-size: 0.78rem;
+  }
+
+  .pl-agent-run dd {
+    margin: 0;
+    color: #e8eaf2;
+    text-align: right;
+  }
+
+  .pl-agent-workflow-overview {
+    display: grid;
+    grid-template-columns: minmax(280px, 0.9fr) minmax(360px, 1.1fr);
+    align-items: center;
+    gap: clamp(2rem, 5vw, 4rem);
+  }
+
+  .pl-agent-workflow-overview > img {
+    width: 100%;
+    height: auto;
+    max-width: 470px;
+    margin-inline: auto;
+  }
+
+  .pl-agent-workflow-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .pl-agent-workflow-steps li {
+    display: grid;
+    grid-template-columns: 2.7rem 1fr;
+    gap: 1rem;
+    padding: 1.2rem 0;
+    border-bottom: 1px solid var(--agent-line);
+  }
+
+  .pl-agent-workflow-steps li:first-child {
+    border-top: 1px solid var(--agent-line);
+  }
+
+  .pl-agent-step-number {
+    color: var(--agent-accent);
+    font-size: 0.8rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+  }
+
+  .pl-agent-workflow-steps h3 {
+    margin: 0;
+    color: var(--agent-ink);
+    font-size: 1.05rem;
+  }
+
+  .pl-agent-workflow-steps p {
+    margin: 0.35rem 0 0;
+    color: var(--agent-muted);
+    font-size: 0.92rem;
+    line-height: 1.6;
+  }
+
+  .pl-agent-product-view {
+    margin-top: 3rem;
+    overflow: hidden;
+    border: 1px solid var(--agent-line);
+    border-radius: 1rem;
+    background: #fff;
+    box-shadow: 0 15px 40px rgb(15 23 42 / 0.08);
+  }
+
+  .pl-agent-product-bar {
+    border-color: var(--agent-line);
+    background: var(--agent-soft);
+    color: var(--agent-muted);
+  }
+
+  .pl-agent-product-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .pl-agent-product-grid article {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    min-height: 245px;
+    padding: 1.35rem;
+  }
+
+  .pl-agent-product-grid article + article {
+    border-left: 1px solid var(--agent-line);
+  }
+
+  .pl-agent-product-grid h3 {
+    margin: 0;
+    color: var(--agent-ink);
+    font-size: 1rem;
+  }
+
+  .pl-agent-product-grid article > p:not(.pl-agent-product-label) {
+    margin: 0.65rem 0 1rem;
+    color: var(--agent-muted);
+    font-size: 0.86rem;
+    line-height: 1.6;
+  }
+
+  .pl-agent-diff {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin: 0.75rem 0 1rem;
+    color: #207a52;
+    font: 0.72rem/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  }
+
+  .pl-agent-status {
+    display: inline-flex;
+    margin-top: auto;
+    border-radius: 999px;
+    background: var(--agent-accent-soft);
+    color: #3f51bf;
+    padding: 0.32rem 0.55rem;
+    font-size: 0.68rem;
+    font-weight: 700;
+  }
+
+  .pl-agent-status-alert {
+    background: #fff4e6;
+    color: #a15c00;
+  }
+
+  .pl-agent-status-pass {
+    background: #e9f9f0;
+    color: #207a52;
+  }
+
+  .pl-agent-example-card {
+    position: relative;
+    overflow: hidden;
+  }
+
+  .pl-agent-example-card::after {
+    position: absolute;
+    right: -2rem;
+    bottom: -3rem;
+    width: 8rem;
+    height: 8rem;
+    border-radius: 999px;
+    background: radial-gradient(circle, rgb(80 106 234 / 0.1), transparent 68%);
+    content: '';
+  }
+
+  .pl-agent-card-label {
+    margin-bottom: 0.5rem !important;
+  }
+
+  .pl-agent-governance {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: clamp(2rem, 6vw, 5rem);
+    border-radius: 1.25rem;
+    background: #121622;
+    padding: clamp(2rem, 6vw, 4rem);
+  }
+
+  .pl-agent-governance h2 {
+    color: #fff;
+  }
+
+  .pl-agent-governance-copy > p:last-child {
+    color: #b6bdcb;
+  }
+
+  .pl-agent-checklist {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .pl-agent-checklist li {
+    display: grid;
+    grid-template-columns: 1.3rem 1fr;
+    gap: 0.75rem;
+    border-bottom: 1px solid #303545;
+    padding: 0.9rem 0;
+    color: #e8eaf2;
+    line-height: 1.45;
+  }
+
+  .pl-agent-checklist svg {
+    color: #75e0ae;
+  }
+
+  .pl-agent-proof {
+    border-top: 1px solid var(--agent-line);
+    border-bottom: 1px solid var(--agent-line);
+    padding: clamp(2.5rem, 6vw, 4.25rem) 0;
+  }
+
+  .pl-agent-proof-heading {
+    display: grid;
+    grid-template-columns: 1.25fr 0.75fr;
+    align-items: end;
+    gap: 2rem;
+  }
+
+  .pl-agent-proof-heading > p {
+    margin: 0 0 0.35rem;
+  }
+
+  .pl-agent-proof-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.75rem;
+    margin-top: 2.5rem;
+  }
+
+  .pl-agent-proof-grid > div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    border-left: 3px solid var(--agent-accent);
+    padding: 0.45rem 0 0.45rem 1rem;
+  }
+
+  .pl-agent-proof-grid strong {
+    color: var(--agent-ink);
+    font-size: clamp(1.8rem, 4vw, 2.75rem);
+    line-height: 1;
+  }
+
+  .pl-agent-proof-grid span {
+    color: var(--agent-muted);
+    font-size: 0.82rem;
+    line-height: 1.4;
+  }
+
+  .pl-agent-faq {
+    display: grid;
+    grid-template-columns: 0.7fr 1.3fr;
+    gap: clamp(2rem, 6vw, 5rem);
+  }
+
+  .pl-agent-faq .pl-agent-heading {
+    margin-bottom: 0;
+  }
+
+  .pl-agent-faq-list details {
+    border-bottom: 1px solid var(--agent-line);
+    padding: 1rem 0;
+  }
+
+  .pl-agent-faq-list details:first-child {
+    border-top: 1px solid var(--agent-line);
+  }
+
+  .pl-agent-faq-list summary {
+    position: relative;
+    cursor: pointer;
+    color: var(--agent-ink);
+    font-weight: 700;
+    list-style: none;
+    padding-right: 2rem;
+  }
+
+  .pl-agent-faq-list summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .pl-agent-faq-list summary::after {
+    position: absolute;
+    top: -0.1rem;
+    right: 0;
+    color: var(--agent-accent);
+    font-size: 1.35rem;
+    content: '+';
+  }
+
+  .pl-agent-faq-list details[open] summary::after {
+    content: '−';
+  }
+
+  .pl-agent-faq-list p {
+    margin: 0.75rem 2rem 0 0;
+    color: var(--agent-muted);
+    line-height: 1.65;
+  }
+
+  .pl-agent-final-cta {
+    border-radius: 1.25rem;
+    background: linear-gradient(135deg, #eef2ff, #f4fbff 55%, #edfaf5);
+    padding: clamp(2.25rem, 7vw, 5rem);
+    text-align: center;
+  }
+
+  .pl-agent-final-cta h2 {
+    max-width: 820px;
+    margin-inline: auto;
+  }
+
+  .pl-agent-final-cta > p:not(.pl-agent-eyebrow) {
+    max-width: 600px;
+    margin-inline: auto;
+  }
+
+  .pl-agent-final-cta > a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    margin-top: 1.5rem;
+    border-radius: 0.5rem;
+    background: var(--agent-accent);
+    color: #fff;
+    padding: 0.82rem 1.15rem;
+    font-weight: 700;
+    text-decoration: none;
+    transition: transform 140ms ease, box-shadow 140ms ease;
+  }
+
+  .pl-agent-final-cta > a:hover {
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 8px 20px rgb(80 106 234 / 0.24);
+  }
+
+  @media (max-width: 860px) {
+    .pl-agent-card-grid-three,
+    .pl-agent-product-grid,
+    .pl-agent-proof-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .pl-agent-card-grid-three .pl-agent-card:last-child {
+      grid-column: 1 / -1;
+    }
+
+    .pl-agent-workflow-overview,
+    .pl-agent-governance,
+    .pl-agent-faq {
+      grid-template-columns: 1fr;
+    }
+
+    .pl-agent-product-grid article:last-child {
+      grid-column: 1 / -1;
+      border-top: 1px solid var(--agent-line);
+      border-left: 0;
+    }
+
+    .pl-agent-product-grid article {
+      min-height: 220px;
+    }
+  }
+
+  @media (max-width: 620px) {
+    .pl-agent-story {
+      gap: 4rem;
+    }
+
+    .pl-agent-card-grid-three,
+    .pl-agent-card-grid-two,
+    .pl-agent-product-grid,
+    .pl-agent-proof-grid,
+    .pl-agent-proof-heading,
+    .pl-agent-receipt-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .pl-agent-card-grid-three .pl-agent-card:last-child,
+    .pl-agent-product-grid article:last-child {
+      grid-column: auto;
+    }
+
+    .pl-agent-receipt-note,
+    .pl-agent-product-bar {
+      flex-direction: column;
+      gap: 0.3rem;
+    }
+
+    .pl-agent-run-before {
+      border-right: 0;
+      border-bottom: 1px solid #2d3242;
+    }
+
+    .pl-agent-run ol {
+      min-height: auto;
+    }
+
+    .pl-agent-product-grid article + article,
+    .pl-agent-product-grid article:last-child {
+      border-top: 1px solid var(--agent-line);
+      border-left: 0;
+    }
+
+    .pl-agent-product-grid article {
+      min-height: 0;
+    }
+
+    .pl-agent-proof-heading {
+      align-items: start;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pl-agent-final-cta > a {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -352,12 +352,12 @@ const faqs = [
     aria-labelledby="agent-faq-title"
   >
     <div class="pl-agent-heading" data-section-tracked="agent-faq">
-      <p class="pl-agent-eyebrow">Common questions</p>
-      <h2 id="agent-faq-title">Agent instruction governance, explained.</h2>
+      <p class="pl-agent-eyebrow">Agent instruction governance</p>
+      <h2 id="agent-faq-title">Questions, answered.</h2>
     </div>
-    <div class="pl-agent-faq-list">
-      {faqs.map((faq) => (
-        <details>
+    <div class="pl-agent-faq-list not-content">
+      {faqs.map((faq, index) => (
+        <details open={index === 0}>
           <summary>{faq.question}</summary>
           <p>{faq.answer}</p>
         </details>
@@ -1099,44 +1099,85 @@ const faqs = [
   }
 
   .pl-agent-faq {
-    display: grid;
-    grid-template-columns: 0.7fr 1.3fr;
-    gap: clamp(2rem, 6vw, 5rem);
+    width: min(100%, 900px);
+    margin-inline: auto;
   }
 
   .pl-agent-faq .pl-agent-heading {
-    margin-bottom: 0;
+    margin: 0 auto clamp(2rem, 5vw, 3rem);
+    text-align: center;
+  }
+
+  .pl-agent-faq-list {
+    display: grid;
+    gap: 0.75rem;
   }
 
   .pl-agent-faq-list details {
-    border-bottom: 1px solid var(--agent-line);
-    padding: 1rem 0;
+    overflow: clip;
+    border: 1px solid var(--agent-line);
+    border-radius: 0.95rem;
+    background:
+      linear-gradient(145deg, rgba(255, 255, 255, 0.035), transparent 48%),
+      var(--agent-surface);
+    box-shadow: var(--pl-shadow-sm);
+    transition: border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
   }
 
-  .pl-agent-faq-list details:first-child {
-    border-top: 1px solid var(--agent-line);
+  .pl-agent-faq-list details:hover {
+    border-color: var(--agent-line-strong);
+  }
+
+  .pl-agent-faq-list details[open] {
+    border-color: var(--agent-accent-border);
+    background:
+      linear-gradient(135deg, rgba(80, 106, 234, 0.1), transparent 52%),
+      var(--agent-surface-elevated);
+    box-shadow: var(--pl-shadow-md);
   }
 
   .pl-agent-faq-list summary {
     position: relative;
+    display: flex;
+    align-items: center;
+    min-height: 4.25rem;
     cursor: pointer;
     color: var(--agent-ink);
-    font-weight: 700;
+    padding: 1rem 4rem 1rem 1.25rem;
+    font-size: 1.02rem;
+    font-weight: 720;
+    line-height: 1.35;
     list-style: none;
-    padding-right: 2rem;
   }
 
+  .pl-agent-faq-list summary::marker,
   .pl-agent-faq-list summary::-webkit-details-marker {
+    content: '';
     display: none;
+  }
+
+  .pl-agent-faq-list summary:focus-visible {
+    outline: 2px solid var(--agent-accent);
+    outline-offset: -3px;
+    border-radius: 0.85rem;
   }
 
   .pl-agent-faq-list summary::after {
     position: absolute;
-    top: -0.1rem;
-    right: 0;
+    top: 50%;
+    right: 1.15rem;
+    display: grid;
+    width: 1.75rem;
+    height: 1.75rem;
+    place-items: center;
+    border: 1px solid var(--agent-accent-border);
+    border-radius: 999px;
+    background: var(--agent-accent-soft);
     color: var(--agent-accent);
-    font-size: 1.35rem;
+    font-size: 1rem;
+    line-height: 1;
     content: '+';
+    transform: translateY(-50%);
   }
 
   .pl-agent-faq-list details[open] summary::after {
@@ -1144,8 +1185,10 @@ const faqs = [
   }
 
   .pl-agent-faq-list p {
-    margin: 0.75rem 2rem 0 0;
+    margin: 0;
+    border-top: 1px solid var(--agent-line);
     color: var(--agent-muted);
+    padding: 1rem 1.25rem 1.25rem;
     line-height: 1.65;
   }
 
@@ -1197,8 +1240,7 @@ const faqs = [
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    .pl-agent-governance,
-    .pl-agent-faq {
+    .pl-agent-governance {
       grid-template-columns: 1fr;
     }
 

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -1,20 +1,5 @@
 ---
-const painPoints = [
-  {
-    title: 'Instruction sprawl',
-    body: 'Skills and conventions spread across local machines, repositories, chat threads, and shared drives. Nobody can tell which version an agent is following.',
-  },
-  {
-    title: 'Invisible performance debt',
-    body: 'Agents repeat searches, retries, and dead ends your team has already solved. The waste hides inside individual sessions until someone stops to measure it.',
-  },
-  {
-    title: 'No safe improvement loop',
-    body: 'Even when a teammate finds a better approach, there is no consistent way to review it, validate it, and distribute it to every agent that needs it.',
-  },
-];
-
-const dogfoodExamples = [
+const impactExamples = [
   {
     label: 'Engineering enablement',
     title: 'Share the best development setup',
@@ -46,10 +31,10 @@ const governanceControls = [
 ];
 
 const proofMetrics = [
-  { figure: '42%', label: 'fewer human interruptions' },
-  { figure: '15%', label: 'more first-attempt completions' },
-  { figure: '32%', label: 'less wall-clock time per session' },
-  { figure: '18%', label: 'fewer tokens consumed' },
+  { figure: '117h', label: 'team capacity recovered' },
+  { figure: '10.7M', label: 'fewer wasted tokens' },
+  { figure: '$24K', label: 'monthly cost avoided' },
+  { figure: '0', label: 'regressions detected' },
 ];
 
 const faqs = [
@@ -83,38 +68,17 @@ const faqs = [
 
 <div class="pl-agent-story">
   <section
-    class="pl-agent-section pl-agent-problem"
-    aria-labelledby="agent-problem-title"
-  >
-    <div class="pl-agent-heading" data-section-tracked="agent-instruction-drift">
-      <p class="pl-agent-eyebrow">Why capable agents still underperform</p>
-      <h2 id="agent-problem-title">Your model isn’t being nerfed. Your instruction stack is drifting.</h2>
-      <p>
-        Every stale skill, conflicting hook, and buried team convention makes capable models rediscover work your people already know how to do.
-      </p>
-    </div>
-    <div class="pl-agent-card-grid pl-agent-card-grid-three">
-      {painPoints.map((point) => (
-        <article class="pl-agent-card">
-          <h3>{point.title}</h3>
-          <p>{point.body}</p>
-        </article>
-      ))}
-    </div>
-  </section>
-
-  <section
     class="pl-agent-section pl-agent-impact-loop"
     aria-labelledby="agent-impact-loop-title"
     data-section-tracked="agent-impact-examples"
   >
     <div class="pl-agent-heading pl-agent-heading-centered">
       <p class="pl-agent-eyebrow">What continuous improvement looks like</p>
-      <h2 id="agent-impact-loop-title">From repeated friction to a better default for everyone.</h2>
+      <h2 id="agent-impact-loop-title">Stop making your AI workforce relearn what your team already knows.</h2>
       <p>
-        Promptless finds where agents make people repeat themselves, turns the best correction into a governed instruction, and measures whether the whole fleet improves.
+        Promptless finds repeated friction caused by stale or missing instructions, turns the best correction into a governed update, and measures whether the whole fleet improves.
       </p>
-      <span class="pl-agent-illustrative-note">Illustrative examples based on Promptless internal dogfooding</span>
+      <span class="pl-agent-illustrative-note">Illustrative fleet-wide impact</span>
     </div>
 
     <div class="pl-agent-impact-stories">
@@ -133,8 +97,8 @@ const faqs = [
           </div>
           <div class="pl-agent-signal-summary">
             <div><strong>482</strong><span>sessions analyzed</span></div>
-            <div><strong>37</strong><span>human corrections</span></div>
-            <div><strong>94h</strong><span>recoverable time</span></div>
+            <div><strong>12.8M</strong><span>wasted tokens found</span></div>
+            <div><strong>$24K</strong><span>avoidable monthly cost</span></div>
           </div>
           <div class="pl-agent-signal-layout">
             <div class="pl-agent-signal-list">
@@ -166,9 +130,9 @@ const faqs = [
                 <div><dt>People affected</dt><dd>11</dd></div>
                 <div><dt>Median stall</dt><dd>29 min</dd></div>
                 <div><dt>Wasted tokens</dt><dd>1.2M</dd></div>
-                <div><dt>Confidence</dt><dd>96%</dd></div>
+                <div><dt>Estimated cost</dt><dd>$4.8K</dd></div>
               </dl>
-              <p class="pl-agent-impact-callout">The same missing instruction cost the team more than a workweek.</p>
+              <p class="pl-agent-impact-callout">One missing auth hook wasted 15 hours and $4,800 in a month.</p>
             </div>
           </div>
         </div>
@@ -176,7 +140,7 @@ const faqs = [
           <p class="pl-agent-story-number">01 · Find the drag</p>
           <h3>See the work your agents keep making humans redo.</h3>
           <p>
-            Trace evidence turns “agents feel flaky” into a ranked list of repeated, fixable costs—with the sessions, people, time, and tokens behind each one.
+            Trace evidence turns “agents feel flaky” into a ranked list of repeated, fixable costs—with the sessions, people, time, tokens, and dollars behind each one.
           </p>
         </div>
       </article>
@@ -255,7 +219,7 @@ const faqs = [
         <div
           class="pl-agent-impact-graphic"
           role="img"
-          aria-label="Illustrative thirty-day fleet impact showing fewer authentication stalls, faster incident investigations, no sales-deck placeholders, and faster development setup"
+          aria-label="Illustrative thirty-day fleet impact showing fewer authentication stalls, lower agent costs, faster incident investigations, and fewer wasted tokens"
         >
           <div class="pl-agent-graphic-bar">
             <div>
@@ -286,19 +250,19 @@ const faqs = [
               <small>stalled sessions / month</small>
             </div>
             <div>
-              <p><span class="pl-agent-signal-dot is-amber"></span>Incident investigation</p>
+              <p><span class="pl-agent-signal-dot is-amber"></span>Agent waste</p>
+              <strong>$31K <span>→</span> $7K</strong>
+              <small>monthly time + model spend</small>
+            </div>
+            <div>
+              <p><span class="pl-agent-signal-dot is-purple"></span>Incident investigation</p>
               <strong>44m <span>→</span> 13m</strong>
               <small>median time to useful finding</small>
             </div>
             <div>
-              <p><span class="pl-agent-signal-dot is-purple"></span>Customer placeholders</p>
-              <strong>9 <span>→</span> 0</strong>
-              <small>human-caught near-misses</small>
-            </div>
-            <div>
-              <p><span class="pl-agent-signal-dot is-green"></span>Local environment</p>
-              <strong>52m <span>→</span> 11m</strong>
-              <small>median time to first test</small>
+              <p><span class="pl-agent-signal-dot is-green"></span>Wasted tokens</p>
+              <strong>12.8M <span>→</span> 2.1M</strong>
+              <small>tokens per month</small>
             </div>
           </div>
           <div class="pl-agent-fleet-footer">
@@ -323,14 +287,14 @@ const faqs = [
     aria-labelledby="agent-use-cases-title"
   >
     <div class="pl-agent-heading" data-section-tracked="agent-use-cases">
-      <p class="pl-agent-eyebrow">Promptless internal dogfooding</p>
+      <p class="pl-agent-eyebrow">One lesson, shared everywhere</p>
       <h2 id="agent-use-cases-title">Make your best work the team’s new default.</h2>
       <p>
         One person’s breakthrough should not stay trapped in one chat. Promptless turns proven ways of working into reusable instructions for engineering, GTM, and operations.
       </p>
     </div>
     <div class="pl-agent-card-grid pl-agent-card-grid-two">
-      {dogfoodExamples.map((example) => (
+      {impactExamples.map((example) => (
         <article class="pl-agent-card pl-agent-example-card">
           <p class="pl-agent-card-label">{example.label}</p>
           <h3>{example.title}</h3>
@@ -369,10 +333,10 @@ const faqs = [
   >
     <div class="pl-agent-proof-heading" data-section-tracked="agent-proof">
       <div>
-        <p class="pl-agent-eyebrow">Promptless internal dogfooding · 30-day window</p>
-        <h2 id="agent-proof-title">Thirty days. Four measurable gains.</h2>
+        <p class="pl-agent-eyebrow">Illustrative 30-day impact</p>
+        <h2 id="agent-proof-title">Turn hidden agent waste into measurable savings.</h2>
       </div>
-      <p>Measured against our pre-governance baseline across engineering, GTM, and operations.</p>
+      <p>Measure the time, tokens, and money recovered as better instructions reach your entire AI workforce.</p>
     </div>
     <div class="pl-agent-proof-grid">
       {proofMetrics.map((metric) => (
@@ -493,10 +457,6 @@ const faqs = [
   .pl-agent-card-grid {
     display: grid;
     gap: 1rem;
-  }
-
-  .pl-agent-card-grid-three {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .pl-agent-card-grid-two {
@@ -1247,13 +1207,8 @@ const faqs = [
   }
 
   @media (max-width: 860px) {
-    .pl-agent-card-grid-three,
     .pl-agent-proof-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .pl-agent-card-grid-three .pl-agent-card:last-child {
-      grid-column: 1 / -1;
     }
 
     .pl-agent-governance,
@@ -1290,15 +1245,10 @@ const faqs = [
       gap: 4rem;
     }
 
-    .pl-agent-card-grid-three,
     .pl-agent-card-grid-two,
     .pl-agent-proof-grid,
     .pl-agent-proof-heading {
       grid-template-columns: 1fr;
-    }
-
-    .pl-agent-card-grid-three .pl-agent-card:last-child {
-      grid-column: auto;
     }
 
     .pl-agent-impact-loop {

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -14,29 +14,6 @@ const painPoints = [
   },
 ];
 
-const workflowSteps = [
-  {
-    number: '01',
-    title: 'Detect',
-    body: 'Find churn, hallucinations, stale instructions, tool and MCP failures, leaks, and repeated corrections in real session traces.',
-  },
-  {
-    number: '02',
-    title: 'Draft',
-    body: 'Turn repeated failure patterns into a concrete instruction addition, update, or deletion.',
-  },
-  {
-    number: '03',
-    title: 'Review and validate',
-    body: 'Let your team inspect every remediation and optionally test it against an eval gate before merging.',
-  },
-  {
-    number: '04',
-    title: 'Distribute',
-    body: 'Refresh approved instructions through native agent plugins, with access limited to the agents and teams that need them.',
-  },
-];
-
 const dogfoodExamples = [
   {
     label: 'Engineering enablement',
@@ -127,125 +104,217 @@ const faqs = [
   </section>
 
   <section
-    class="pl-agent-section pl-agent-comparison"
-    aria-labelledby="agent-comparison-title"
+    class="pl-agent-section pl-agent-impact-loop"
+    aria-labelledby="agent-impact-loop-title"
+    data-section-tracked="agent-impact-examples"
   >
-    <div class="pl-agent-heading pl-agent-heading-centered" data-section-tracked="agent-session-comparison">
-      <p class="pl-agent-eyebrow">A session receipt, not a vague promise</p>
-      <h2 id="agent-comparison-title">Same task. Better instruction stack.</h2>
+    <div class="pl-agent-heading pl-agent-heading-centered">
+      <p class="pl-agent-eyebrow">What continuous improvement looks like</p>
+      <h2 id="agent-impact-loop-title">From repeated friction to a better default for everyone.</h2>
       <p>
-        Promptless sees where agents search, churn, retry, and ask for help—then turns repeated failure into a fix the whole team can use.
+        Promptless finds where agents make people repeat themselves, turns the best correction into a governed instruction, and measures whether the whole fleet improves.
       </p>
+      <span class="pl-agent-illustrative-note">Illustrative examples based on Promptless internal dogfooding</span>
     </div>
 
-    <div class="pl-agent-receipt" aria-label="Illustrative session comparison">
-      <div class="pl-agent-receipt-note">
-        <span>Illustrative comparison</span>
-        <span>Replace bracketed fields with a verified replay before publishing</span>
-      </div>
-      <p class="pl-agent-receipt-prompt"><span aria-hidden="true">›</span> Investigate a production incident</p>
-      <div class="pl-agent-receipt-grid">
-        <article class="pl-agent-run pl-agent-run-before">
-          <div class="pl-agent-run-heading">
-            <span>Without Promptless</span>
-            <strong>Instruction debt</strong>
-          </div>
-          <ol>
-            <li>Searches for tools and team conventions</li>
-            <li>Repeats known investigative dead ends</li>
-            <li>Needs a teammate to redirect the session</li>
-          </ol>
-          <dl>
-            <div><dt>Tokens</dt><dd>[baseline]</dd></div>
-            <div><dt>Wall clock</dt><dd>[baseline]</dd></div>
-            <div><dt>Retries</dt><dd>[baseline]</dd></div>
-            <div><dt>Interruptions</dt><dd>[baseline]</dd></div>
-          </dl>
-        </article>
-
-        <article class="pl-agent-run pl-agent-run-after">
-          <div class="pl-agent-run-heading">
-            <span>With Promptless</span>
-            <strong>Governed instructions</strong>
-          </div>
-          <ol>
-            <li>Loads the team’s approved incident skill</li>
-            <li>Routes directly to the right Datadog tools</li>
-            <li>Invokes the specialist investigation subagent</li>
-          </ol>
-          <dl>
-            <div><dt>Tokens</dt><dd>[with Promptless]</dd></div>
-            <div><dt>Wall clock</dt><dd>[with Promptless]</dd></div>
-            <div><dt>Retries</dt><dd>[with Promptless]</dd></div>
-            <div><dt>Interruptions</dt><dd>[with Promptless]</dd></div>
-          </dl>
-        </article>
-      </div>
-    </div>
-  </section>
-
-  <section
-    class="pl-agent-section pl-agent-workflow"
-    aria-labelledby="agent-workflow-title"
-  >
-    <div class="pl-agent-heading pl-agent-heading-centered" data-section-tracked="agent-improvement-loop">
-      <p class="pl-agent-eyebrow">The improvement loop</p>
-      <h2 id="agent-workflow-title">From session trace to governed improvement</h2>
-      <p>
-        Real work produces the evidence. Promptless turns that evidence into a reviewed, validated instruction that every relevant agent can use.
-      </p>
-    </div>
-
-    <div class="pl-agent-workflow-overview">
-      <img
-        src="/site/virtuous-cycle-flywheel.svg"
-        alt="A continuous loop where agent session traces reveal improvements, approved changes enter the Instruction Hub, and refreshed instructions make the AI workforce more effective"
-        loading="lazy"
-        width="820"
-        height="820"
-      />
-      <ol class="pl-agent-workflow-steps">
-        {workflowSteps.map((step) => (
-          <li>
-            <span class="pl-agent-step-number">{step.number}</span>
+    <div class="pl-agent-impact-stories">
+      <article class="pl-agent-impact-story">
+        <div
+          class="pl-agent-impact-graphic"
+          role="img"
+          aria-label="Illustrative instruction debt report showing repeated authentication stalls, incident-tool detours, sales-deck placeholder corrections, and one engineer's faster development setup"
+        >
+          <div class="pl-agent-graphic-bar">
             <div>
-              <h3>{step.title}</h3>
-              <p>{step.body}</p>
+              <span class="pl-agent-graphic-icon" aria-hidden="true">↯</span>
+              <span><small>Session evidence</small>Instruction debt report</span>
             </div>
-          </li>
-        ))}
-      </ol>
-    </div>
-
-    <div class="pl-agent-product-view" aria-label="Illustrative trace-to-remediation product workflow">
-      <div class="pl-agent-product-bar">
-        <span>Trace-to-remediation</span>
-        <span>Illustrative product view</span>
-      </div>
-      <div class="pl-agent-product-grid">
-        <article>
-          <p class="pl-agent-product-label">01 · Finding</p>
-          <h3>Repeated authentication dead end</h3>
-          <p>Agents continue working after universal credentials expire, producing stalled or degraded sessions.</p>
-          <span class="pl-agent-status pl-agent-status-alert">Repeated pattern</span>
-        </article>
-        <article>
-          <p class="pl-agent-product-label">02 · Remediation</p>
-          <h3>Add an expired-token hook</h3>
-          <div class="pl-agent-diff">
-            <span>+ Detect the authentication failure</span>
-            <span>+ Prompt the user to sign in again</span>
-            <span>+ Resume only after verification</span>
+            <span class="pl-agent-graphic-window">Last 30 days</span>
           </div>
-          <span class="pl-agent-status">Ready for review</span>
-        </article>
-        <article>
-          <p class="pl-agent-product-label">03 · Validation</p>
-          <h3>Replay against affected sessions</h3>
-          <p>The optional eval gate checks that the hook resolves the dead end without regressing successful flows.</p>
-          <span class="pl-agent-status pl-agent-status-pass">Eval passed</span>
-        </article>
-      </div>
+          <div class="pl-agent-signal-summary">
+            <div><strong>482</strong><span>sessions analyzed</span></div>
+            <div><strong>37</strong><span>human corrections</span></div>
+            <div><strong>94h</strong><span>recoverable time</span></div>
+          </div>
+          <div class="pl-agent-signal-layout">
+            <div class="pl-agent-signal-list">
+              <div class="is-selected">
+                <span class="pl-agent-signal-dot is-red"></span>
+                <p><strong>Expired auth dead end</strong><small>31 sessions kept working without credentials</small></p>
+                <b>29m</b>
+              </div>
+              <div>
+                <span class="pl-agent-signal-dot is-amber"></span>
+                <p><strong>Incident-tool detour</strong><small>Agents ignored the approved Datadog path</small></p>
+                <b>18×</b>
+              </div>
+              <div>
+                <span class="pl-agent-signal-dot is-purple"></span>
+                <p><strong>Deck placeholder near-miss</strong><small>A person caught unfinished customer copy</small></p>
+                <b>9×</b>
+              </div>
+              <div>
+                <span class="pl-agent-signal-dot is-green"></span>
+                <p><strong>One engineer’s shortcut</strong><small>A better local setup stayed trapped in one session</small></p>
+                <b>4.8×</b>
+              </div>
+            </div>
+            <div class="pl-agent-signal-detail">
+              <p class="pl-agent-graphic-kicker">Highest-cost pattern</p>
+              <h3>Agents silently lose authentication</h3>
+              <dl>
+                <div><dt>People affected</dt><dd>11</dd></div>
+                <div><dt>Median stall</dt><dd>29 min</dd></div>
+                <div><dt>Wasted tokens</dt><dd>1.2M</dd></div>
+                <div><dt>Confidence</dt><dd>96%</dd></div>
+              </dl>
+              <p class="pl-agent-impact-callout">The same missing instruction cost the team more than a workweek.</p>
+            </div>
+          </div>
+        </div>
+        <div class="pl-agent-impact-copy">
+          <p class="pl-agent-story-number">01 · Find the drag</p>
+          <h3>See the work your agents keep making humans redo.</h3>
+          <p>
+            Trace evidence turns “agents feel flaky” into a ranked list of repeated, fixable costs—with the sessions, people, time, and tokens behind each one.
+          </p>
+        </div>
+      </article>
+
+      <article class="pl-agent-impact-story is-reversed">
+        <div
+          class="pl-agent-impact-graphic"
+          role="img"
+          aria-label="Illustrative governed instruction changes proposing an authentication hook, incident investigation subagent, sales-deck skill guard, and shared development environment skill"
+        >
+          <div class="pl-agent-graphic-bar">
+            <div>
+              <span class="pl-agent-graphic-icon" aria-hidden="true">＋</span>
+              <span><small>Governed remediation</small>Proposed fleet upgrades</span>
+            </div>
+            <span class="pl-agent-graphic-window is-review">Ready for review</span>
+          </div>
+          <div class="pl-agent-change-layout">
+            <div class="pl-agent-change-list">
+              <p class="pl-agent-graphic-kicker">Ranked by expected impact</p>
+              <div class="is-selected">
+                <span>Hook</span>
+                <p><strong>Recover expired credentials</strong><small>Evidence from 31 affected sessions</small></p>
+                <b>P0</b>
+              </div>
+              <div>
+                <span>Subagent</span>
+                <p><strong>Route incident investigations</strong><small>Evidence from 18 tool detours</small></p>
+                <b>P1</b>
+              </div>
+              <div>
+                <span>Skill</span>
+                <p><strong>Block customer placeholders</strong><small>Evidence from 9 corrections</small></p>
+                <b>P1</b>
+              </div>
+              <div>
+                <span>Skill</span>
+                <p><strong>Share the fastest local setup</strong><small>Evidence from the team’s best run</small></p>
+                <b>P2</b>
+              </div>
+            </div>
+            <div class="pl-agent-change-plan">
+              <div class="pl-agent-change-heading">
+                <span>Proposed hook</span>
+                <b>auth-recovery · v2</b>
+              </div>
+              <div class="pl-agent-code-diff">
+                <span>+ Detect expired universal auth</span>
+                <span>+ Stop degraded tool calls</span>
+                <span>+ Ask the user to sign in once</span>
+                <span>+ Verify access before resuming</span>
+              </div>
+              <div class="pl-agent-review-chain">
+                <div><span>Evidence</span><strong>31 sessions</strong></div>
+                <div><span>Eval gate</span><strong class="is-pass">31 / 31 pass</strong></div>
+                <div><span>Targets</span><strong>Claude + Codex</strong></div>
+                <div><span>Owner</span><strong>Platform Eng</strong></div>
+              </div>
+              <div class="pl-agent-approval">
+                <span class="pl-agent-approval-check">✓</span>
+                <p><strong>Ready to merge</strong><small>No regressions across 120 successful sessions</small></p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="pl-agent-impact-copy">
+          <p class="pl-agent-story-number">02 · Govern the change</p>
+          <h3>Turn the best correction into a team-wide standard.</h3>
+          <p>
+            Promptless proposes the exact skill, hook, subagent, or instruction change—along with its evidence, scope, owner, and validation result—so your team can improve agents without creating more instruction slop.
+          </p>
+        </div>
+      </article>
+
+      <article class="pl-agent-impact-story">
+        <div
+          class="pl-agent-impact-graphic"
+          role="img"
+          aria-label="Illustrative thirty-day fleet impact showing fewer authentication stalls, faster incident investigations, no sales-deck placeholders, and faster development setup"
+        >
+          <div class="pl-agent-graphic-bar">
+            <div>
+              <span class="pl-agent-graphic-icon" aria-hidden="true">↗</span>
+              <span><small>Measured impact</small>Before vs. governed</span>
+            </div>
+            <span class="pl-agent-graphic-window is-live">30-day replay</span>
+          </div>
+          <div class="pl-agent-impact-summary">
+            <div>
+              <span>Recovered capacity</span>
+              <strong>117 hours</strong>
+              <small>returned to the team in 30 days</small>
+            </div>
+            <div class="pl-agent-impact-bars" aria-hidden="true">
+              <span style="--bar-width: 31%"></span>
+              <span style="--bar-width: 72%"></span>
+              <span style="--bar-width: 46%"></span>
+              <span style="--bar-width: 88%"></span>
+              <span style="--bar-width: 58%"></span>
+              <span style="--bar-width: 100%"></span>
+            </div>
+          </div>
+          <div class="pl-agent-outcome-grid">
+            <div>
+              <p><span class="pl-agent-signal-dot is-red"></span>Auth dead ends</p>
+              <strong>31 <span>→</span> 2</strong>
+              <small>stalled sessions / month</small>
+            </div>
+            <div>
+              <p><span class="pl-agent-signal-dot is-amber"></span>Incident investigation</p>
+              <strong>44m <span>→</span> 13m</strong>
+              <small>median time to useful finding</small>
+            </div>
+            <div>
+              <p><span class="pl-agent-signal-dot is-purple"></span>Customer placeholders</p>
+              <strong>9 <span>→</span> 0</strong>
+              <small>human-caught near-misses</small>
+            </div>
+            <div>
+              <p><span class="pl-agent-signal-dot is-green"></span>Local environment</p>
+              <strong>52m <span>→</span> 11m</strong>
+              <small>median time to first test</small>
+            </div>
+          </div>
+          <div class="pl-agent-fleet-footer">
+            <span>4 improvements approved</span>
+            <span>6 agent tools refreshed</span>
+            <span>0 regressions detected</span>
+          </div>
+        </div>
+        <div class="pl-agent-impact-copy">
+          <p class="pl-agent-story-number">03 · Compound the impact</p>
+          <h3>Make one person’s breakthrough show up in every relevant session.</h3>
+          <p>
+            Approved instructions reach the agents that need them, then Promptless keeps measuring the result. What used to be isolated expertise becomes a visible, compounding advantage for the whole organization.
+          </p>
+        </div>
+      </article>
     </div>
   </section>
 
@@ -391,8 +460,7 @@ const faqs = [
   }
 
   .pl-agent-eyebrow,
-  .pl-agent-card-label,
-  .pl-agent-product-label {
+  .pl-agent-card-label {
     margin: 0 0 0.65rem;
     color: var(--agent-accent);
     font-size: 0.78rem;
@@ -458,240 +526,521 @@ const faqs = [
     line-height: 1.65;
   }
 
-  .pl-agent-receipt {
-    overflow: hidden;
-    border: 1px solid var(--agent-line-strong);
-    border-radius: 1.1rem;
-    background: var(--pl-color-surface);
-    color: #e8eaf2;
-    box-shadow: var(--pl-shadow-md);
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  .pl-agent-impact-loop {
+    position: relative;
+    border: 1px solid var(--agent-line);
+    border-radius: 1.75rem;
+    background:
+      radial-gradient(circle at 1px 1px, rgba(148, 163, 184, 0.09) 1px, transparent 0) 0 0 / 18px 18px,
+      linear-gradient(180deg, rgba(80, 106, 234, 0.07), transparent 18%, transparent 82%, rgba(115, 221, 197, 0.04)),
+      var(--pl-color-bg);
+    padding: clamp(2.25rem, 5vw, 4.5rem) clamp(1rem, 3vw, 2.5rem);
   }
 
-  .pl-agent-receipt-note,
-  .pl-agent-product-bar {
+  .pl-agent-impact-loop > .pl-agent-heading {
+    max-width: 800px;
+    margin-bottom: clamp(4rem, 8vw, 6.5rem);
+  }
+
+  .pl-agent-illustrative-note {
+    display: inline-flex;
+    margin-top: 1.1rem;
+    border: 1px solid var(--agent-line);
+    border-radius: 999px;
+    background: rgba(17, 20, 29, 0.82);
+    color: #aab2c3;
+    padding: 0.45rem 0.7rem;
+    font-size: 0.68rem;
+    font-weight: 650;
+    letter-spacing: 0.025em;
+  }
+
+  .pl-agent-impact-stories {
     display: flex;
-    justify-content: space-between;
-    gap: 1rem;
-    border-bottom: 1px solid #2d3242;
-    padding: 0.7rem 1rem;
-    color: #9aa2b3;
-    font-size: 0.7rem;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
+    flex-direction: column;
+    gap: clamp(5rem, 10vw, 8.5rem);
   }
 
-  .pl-agent-receipt-note span:first-child {
-    color: #f4c873;
-  }
-
-  .pl-agent-receipt-prompt {
-    margin: 0;
-    border-bottom: 1px solid #2d3242;
-    padding: 1.2rem 1.3rem;
-    color: #f8fafc;
-    font-size: 1rem;
-  }
-
-  .pl-agent-receipt-prompt span {
-    margin-right: 0.45rem;
-    color: #a5b4fc;
-    font-weight: 800;
-  }
-
-  .pl-agent-receipt-grid {
+  .pl-agent-impact-story {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .pl-agent-run {
-    padding: clamp(1.25rem, 3vw, 2rem);
-  }
-
-  .pl-agent-run-before {
-    border-right: 1px solid #2d3242;
-  }
-
-  .pl-agent-run-heading {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 1rem;
-    padding-bottom: 0.85rem;
-    border-bottom: 2px solid #ef6f6c;
-    color: #ef9a98;
-  }
-
-  .pl-agent-run-after .pl-agent-run-heading {
-    border-color: #53d39a;
-    color: #74e1ad;
-  }
-
-  .pl-agent-run-heading strong {
-    color: #c8ceda;
-    font-size: 0.72rem;
-    font-weight: 500;
-    text-transform: uppercase;
-  }
-
-  .pl-agent-run ol {
-    min-height: 9rem;
-    margin: 1.25rem 0;
-    padding-left: 1.35rem;
-    color: #c7cbd6;
-    font-size: 0.83rem;
-    line-height: 1.75;
-  }
-
-  .pl-agent-run dl {
-    margin: 0;
-    border-top: 1px solid #2d3242;
-    padding-top: 0.75rem;
-  }
-
-  .pl-agent-run dl div {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
-    padding: 0.35rem 0;
-    color: #9aa2b3;
-    font-size: 0.78rem;
-  }
-
-  .pl-agent-run dd {
-    margin: 0;
-    color: #e8eaf2;
-    text-align: right;
-  }
-
-  .pl-agent-workflow-overview {
-    display: grid;
-    grid-template-columns: minmax(280px, 0.9fr) minmax(360px, 1.1fr);
+    grid-template-columns: minmax(0, 1.35fr) minmax(250px, 0.65fr);
     align-items: center;
     gap: clamp(2rem, 5vw, 4rem);
-  }
-
-  .pl-agent-workflow-overview > img {
-    width: 100%;
-    height: auto;
-    max-width: 470px;
-    margin-inline: auto;
-  }
-
-  .pl-agent-workflow-steps {
-    display: flex;
-    flex-direction: column;
-    gap: 0;
     margin: 0;
-    padding: 0;
-    list-style: none;
   }
 
-  .pl-agent-workflow-steps li {
-    display: grid;
-    grid-template-columns: 2.7rem 1fr;
-    gap: 1rem;
-    padding: 1.2rem 0;
-    border-bottom: 1px solid var(--agent-line);
+  .pl-agent-impact-story.is-reversed {
+    grid-template-columns: minmax(250px, 0.65fr) minmax(0, 1.35fr);
   }
 
-  .pl-agent-workflow-steps li:first-child {
-    border-top: 1px solid var(--agent-line);
+  .pl-agent-impact-story.is-reversed .pl-agent-impact-graphic {
+    grid-column: 2;
   }
 
-  .pl-agent-step-number {
-    color: var(--agent-accent);
-    font-size: 0.8rem;
-    font-weight: 800;
-    letter-spacing: 0.08em;
+  .pl-agent-impact-story.is-reversed .pl-agent-impact-copy {
+    grid-column: 1;
+    grid-row: 1;
   }
 
-  .pl-agent-workflow-steps h3 {
+  .pl-agent-impact-copy h3 {
     margin: 0;
     color: var(--agent-ink);
-    font-size: 1.05rem;
+    font-size: clamp(1.7rem, 3.2vw, 2.45rem);
+    line-height: 1.08;
+    letter-spacing: -0.035em;
   }
 
-  .pl-agent-workflow-steps p {
-    margin: 0.35rem 0 0;
+  .pl-agent-impact-copy > p:last-child {
+    margin: 1rem 0 0;
     color: var(--agent-muted);
-    font-size: 0.92rem;
-    line-height: 1.6;
-  }
-
-  .pl-agent-product-view {
-    margin-top: 3rem;
-    overflow: hidden;
-    border: 1px solid var(--agent-line);
-    border-radius: 1rem;
-    background: var(--agent-surface);
-    box-shadow: var(--pl-shadow-md);
-  }
-
-  .pl-agent-product-bar {
-    border-color: var(--agent-line);
-    background: var(--agent-soft);
-    color: var(--agent-muted);
-  }
-
-  .pl-agent-product-grid {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .pl-agent-product-grid article {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    min-height: 245px;
-    padding: 1.35rem;
-  }
-
-  .pl-agent-product-grid article + article {
-    border-left: 1px solid var(--agent-line);
-  }
-
-  .pl-agent-product-grid h3 {
-    margin: 0;
-    color: var(--agent-ink);
     font-size: 1rem;
+    line-height: 1.7;
   }
 
-  .pl-agent-product-grid article > p:not(.pl-agent-product-label) {
-    margin: 0.65rem 0 1rem;
-    color: var(--agent-muted);
-    font-size: 0.86rem;
-    line-height: 1.6;
+  .pl-agent-story-number {
+    margin: 0 0 0.75rem;
+    color: var(--agent-accent);
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
   }
 
-  .pl-agent-diff {
+  .pl-agent-impact-graphic {
+    overflow: hidden;
+    border: 1px solid #323747;
+    border-radius: 0.9rem;
+    background: #11141c;
+    color: #dfe3ec;
+    box-shadow: 0 26px 70px rgba(0, 0, 0, 0.28), 0 4px 16px rgba(0, 0, 0, 0.2);
+    font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  }
+
+  .pl-agent-impact-graphic :is(div, p, dl) {
+    margin-top: 0;
+  }
+
+  .pl-agent-graphic-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    min-height: 3.4rem;
+    border-bottom: 1px solid #2b303e;
+    background: #171a23;
+    padding: 0.65rem 0.85rem;
+  }
+
+  .pl-agent-graphic-bar > div {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    min-width: 0;
+  }
+
+  .pl-agent-graphic-bar > div > span:last-child {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
-    margin: 0.75rem 0 1rem;
-    color: var(--pl-color-success);
-    font: 0.72rem/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    color: #f2f4f8;
+    font-size: 0.75rem;
+    font-weight: 680;
+    line-height: 1.2;
   }
 
-  .pl-agent-status {
-    display: inline-flex;
-    margin-top: auto;
+  .pl-agent-graphic-bar small {
+    color: #7f899d;
+    font: 0.54rem/1.2 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .pl-agent-graphic-icon {
+    display: grid;
+    width: 1.75rem;
+    height: 1.75rem;
+    place-items: center;
+    border: 1px solid #3a4050;
+    border-radius: 0.35rem;
+    background: #1d212c;
+    color: #91a2ff;
+    font-size: 0.88rem;
+    font-weight: 800;
+  }
+
+  .pl-agent-graphic-window {
+    flex: none;
+    border: 1px solid #343a49;
     border-radius: 999px;
-    background: var(--agent-accent-soft);
-    color: var(--agent-accent);
+    background: #1d212c;
+    color: #9ba4b5;
     padding: 0.32rem 0.55rem;
-    font-size: 0.68rem;
+    font-size: 0.58rem;
     font-weight: 700;
   }
 
-  .pl-agent-status-alert {
-    background: #2b2113;
-    color: #e8bc75;
+  .pl-agent-graphic-window.is-review {
+    border-color: rgba(145, 162, 255, 0.28);
+    background: rgba(80, 106, 234, 0.12);
+    color: #b5c0ff;
   }
 
-  .pl-agent-status-pass {
-    background: var(--pl-color-success-soft);
-    color: var(--pl-color-success);
+  .pl-agent-graphic-window.is-live {
+    border-color: rgba(117, 224, 174, 0.25);
+    background: rgba(54, 178, 126, 0.11);
+    color: #8be9ba;
+  }
+
+  .pl-agent-signal-summary {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1px;
+    border-bottom: 1px solid #2b303e;
+    background: #2b303e;
+  }
+
+  .pl-agent-signal-summary > div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    background: #141720;
+    padding: 0.75rem 0.85rem;
+  }
+
+  .pl-agent-signal-summary strong {
+    color: #f3f5f8;
+    font: 700 1.05rem/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  }
+
+  .pl-agent-signal-summary span {
+    color: #828b9d;
+    font-size: 0.58rem;
+  }
+
+  .pl-agent-signal-layout,
+  .pl-agent-change-layout {
+    display: grid;
+    grid-template-columns: 1.15fr 0.85fr;
+    min-height: 19rem;
+  }
+
+  .pl-agent-signal-list,
+  .pl-agent-change-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    border-right: 1px solid #2b303e;
+    padding: 0.75rem;
+  }
+
+  .pl-agent-signal-list > div,
+  .pl-agent-change-list > div {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.55rem;
+    border: 1px solid #292e3a;
+    border-radius: 0.35rem;
+    background: #171a23;
+    padding: 0.6rem;
+  }
+
+  .pl-agent-signal-list > div.is-selected,
+  .pl-agent-change-list > div.is-selected {
+    border-color: rgba(239, 111, 108, 0.38);
+    background: rgba(239, 111, 108, 0.055);
+  }
+
+  .pl-agent-signal-list p,
+  .pl-agent-change-list p,
+  .pl-agent-approval p {
+    display: flex;
+    flex-direction: column;
+    gap: 0.14rem;
+    min-width: 0;
+    margin: 0;
+  }
+
+  .pl-agent-signal-list strong,
+  .pl-agent-change-list strong,
+  .pl-agent-approval strong {
+    overflow: hidden;
+    color: #dfe3eb;
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .pl-agent-signal-list small,
+  .pl-agent-change-list small,
+  .pl-agent-approval small {
+    overflow: hidden;
+    color: #7f899b;
+    font-size: 0.54rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .pl-agent-signal-list b,
+  .pl-agent-change-list b {
+    color: #aab3c3;
+    font: 700 0.58rem/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  }
+
+  .pl-agent-signal-dot {
+    display: inline-block;
+    width: 0.42rem;
+    height: 0.42rem;
+    flex: none;
+    border-radius: 999px;
+    background: #91a2ff;
+    box-shadow: 0 0 0 3px rgba(145, 162, 255, 0.08);
+  }
+
+  .pl-agent-signal-dot.is-red { background: #ef7773; }
+  .pl-agent-signal-dot.is-amber { background: #e5b85f; }
+  .pl-agent-signal-dot.is-purple { background: #aa9bfb; }
+  .pl-agent-signal-dot.is-green { background: #6ed8a5; }
+
+  .pl-agent-signal-detail,
+  .pl-agent-change-plan {
+    padding: 0.9rem;
+  }
+
+  .pl-agent-graphic-kicker {
+    margin: 0 0 0.55rem;
+    color: #758096;
+    font: 0.54rem/1.2 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .pl-agent-signal-detail h3 {
+    margin: 0 0 0.8rem;
+    color: #f3f5f8;
+    font-size: 0.78rem;
+  }
+
+  .pl-agent-signal-detail dl {
+    margin: 0;
+  }
+
+  .pl-agent-signal-detail dl div {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    border-top: 1px solid #2a2f3b;
+    padding: 0.45rem 0;
+    font-size: 0.58rem;
+  }
+
+  .pl-agent-signal-detail dt { color: #7f899b; }
+  .pl-agent-signal-detail dd { margin: 0; color: #d8dde6; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+
+  .pl-agent-impact-callout {
+    margin: 0.7rem 0 0;
+    border-left: 2px solid #ef7773;
+    background: rgba(239, 119, 115, 0.06);
+    color: #c8ceda;
+    padding: 0.55rem 0.6rem;
+    font-size: 0.58rem;
+    line-height: 1.45;
+  }
+
+  .pl-agent-change-layout {
+    grid-template-columns: 0.9fr 1.1fr;
+  }
+
+  .pl-agent-change-list > .pl-agent-graphic-kicker {
+    margin: 0 0 0.15rem;
+  }
+
+  .pl-agent-change-list > div > span {
+    border-radius: 0.25rem;
+    background: rgba(145, 162, 255, 0.11);
+    color: #aebaff;
+    padding: 0.25rem 0.32rem;
+    font: 0.5rem/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  }
+
+  .pl-agent-change-list > div.is-selected {
+    border-color: rgba(145, 162, 255, 0.35);
+    background: rgba(80, 106, 234, 0.07);
+  }
+
+  .pl-agent-change-heading,
+  .pl-agent-approval {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    border: 1px solid #2b303d;
+    background: #171a23;
+    padding: 0.55rem 0.65rem;
+  }
+
+  .pl-agent-change-heading span {
+    color: #858fa2;
+    font-size: 0.56rem;
+  }
+
+  .pl-agent-change-heading b {
+    color: #cbd1dc;
+    font: 0.56rem/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  }
+
+  .pl-agent-code-diff {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    border-right: 1px solid #2b303d;
+    border-bottom: 1px solid #2b303d;
+    border-left: 1px solid #2b303d;
+    background: #12151c;
+    color: #80dcb0;
+    padding: 0.7rem;
+    font: 0.55rem/1.4 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  }
+
+  .pl-agent-review-chain {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1px;
+    margin-top: 0.65rem;
+    background: #2b303d;
+  }
+
+  .pl-agent-review-chain > div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    background: #171a23;
+    padding: 0.55rem;
+  }
+
+  .pl-agent-review-chain span {
+    color: #768094;
+    font-size: 0.5rem;
+    text-transform: uppercase;
+  }
+
+  .pl-agent-review-chain strong {
+    color: #dce1ea;
+    font-size: 0.58rem;
+  }
+
+  .pl-agent-review-chain strong.is-pass { color: #7fe0af; }
+
+  .pl-agent-approval {
+    justify-content: flex-start;
+    margin-top: 0.65rem;
+    border-color: rgba(117, 224, 174, 0.25);
+    background: rgba(54, 178, 126, 0.07);
+  }
+
+  .pl-agent-approval-check {
+    display: grid;
+    width: 1.5rem;
+    height: 1.5rem;
+    flex: none;
+    place-items: center;
+    border-radius: 999px;
+    background: rgba(117, 224, 174, 0.14);
+    color: #7fe0af;
+    font-size: 0.72rem;
+    font-weight: 800;
+  }
+
+  .pl-agent-impact-summary {
+    display: grid;
+    grid-template-columns: 0.72fr 1.28fr;
+    align-items: end;
+    gap: 1rem;
+    border-bottom: 1px solid #2b303e;
+    padding: 1rem;
+  }
+
+  .pl-agent-impact-summary > div:first-child {
+    display: flex;
+    flex-direction: column;
+    gap: 0.18rem;
+  }
+
+  .pl-agent-impact-summary span,
+  .pl-agent-impact-summary small {
+    color: #818b9d;
+    font-size: 0.56rem;
+  }
+
+  .pl-agent-impact-summary strong {
+    color: #f5f7fa;
+    font-size: 1.55rem;
+    line-height: 1;
+    letter-spacing: -0.04em;
+  }
+
+  .pl-agent-impact-bars {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.35rem;
+    height: 3.5rem;
+  }
+
+  .pl-agent-impact-bars span {
+    width: 100%;
+    height: var(--bar-width);
+    border-radius: 0.18rem 0.18rem 0 0;
+    background: linear-gradient(180deg, #7285f5, #485bce);
+  }
+
+  .pl-agent-outcome-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1px;
+    background: #2b303e;
+  }
+
+  .pl-agent-outcome-grid > div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    background: #141720;
+    padding: 0.85rem;
+  }
+
+  .pl-agent-outcome-grid p {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0;
+    color: #aeb6c5;
+    font-size: 0.58rem;
+  }
+
+  .pl-agent-outcome-grid strong {
+    color: #f0f3f7;
+    font: 700 1.05rem/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  }
+
+  .pl-agent-outcome-grid strong span {
+    color: #7f8bff;
+    font-size: 0.8rem;
+  }
+
+  .pl-agent-outcome-grid small {
+    color: #727d90;
+    font-size: 0.52rem;
+  }
+
+  .pl-agent-fleet-footer {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    background: rgba(54, 178, 126, 0.055);
+    color: #7edcad;
+    padding: 0.65rem 0.85rem;
+    font-size: 0.52rem;
+    font-weight: 650;
   }
 
   .pl-agent-example-card {
@@ -899,7 +1248,6 @@ const faqs = [
 
   @media (max-width: 860px) {
     .pl-agent-card-grid-three,
-    .pl-agent-product-grid,
     .pl-agent-proof-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
@@ -908,20 +1256,32 @@ const faqs = [
       grid-column: 1 / -1;
     }
 
-    .pl-agent-workflow-overview,
     .pl-agent-governance,
     .pl-agent-faq {
       grid-template-columns: 1fr;
     }
 
-    .pl-agent-product-grid article:last-child {
-      grid-column: 1 / -1;
-      border-top: 1px solid var(--agent-line);
-      border-left: 0;
+    .pl-agent-impact-story,
+    .pl-agent-impact-story.is-reversed {
+      grid-template-columns: 1fr;
+      gap: 1.75rem;
     }
 
-    .pl-agent-product-grid article {
-      min-height: 220px;
+    .pl-agent-impact-story.is-reversed .pl-agent-impact-graphic,
+    .pl-agent-impact-story.is-reversed .pl-agent-impact-copy {
+      grid-column: 1;
+    }
+
+    .pl-agent-impact-story.is-reversed .pl-agent-impact-graphic {
+      grid-row: 1;
+    }
+
+    .pl-agent-impact-story.is-reversed .pl-agent-impact-copy {
+      grid-row: 2;
+    }
+
+    .pl-agent-impact-copy {
+      max-width: 680px;
     }
   }
 
@@ -932,41 +1292,53 @@ const faqs = [
 
     .pl-agent-card-grid-three,
     .pl-agent-card-grid-two,
-    .pl-agent-product-grid,
     .pl-agent-proof-grid,
-    .pl-agent-proof-heading,
-    .pl-agent-receipt-grid {
+    .pl-agent-proof-heading {
       grid-template-columns: 1fr;
     }
 
-    .pl-agent-card-grid-three .pl-agent-card:last-child,
-    .pl-agent-product-grid article:last-child {
+    .pl-agent-card-grid-three .pl-agent-card:last-child {
       grid-column: auto;
     }
 
-    .pl-agent-receipt-note,
-    .pl-agent-product-bar {
-      flex-direction: column;
-      gap: 0.3rem;
+    .pl-agent-impact-loop {
+      margin-inline: -0.25rem;
+      border-radius: 1.25rem;
+      padding-inline: 0.65rem;
     }
 
-    .pl-agent-run-before {
+    .pl-agent-illustrative-note {
+      display: inline-block;
+      border-radius: 0.6rem;
+    }
+
+    .pl-agent-graphic-window {
+      display: none;
+    }
+
+    .pl-agent-signal-layout,
+    .pl-agent-change-layout,
+    .pl-agent-impact-summary {
+      grid-template-columns: 1fr;
+    }
+
+    .pl-agent-signal-list,
+    .pl-agent-change-list {
       border-right: 0;
-      border-bottom: 1px solid #2d3242;
+      border-bottom: 1px solid #2b303e;
     }
 
-    .pl-agent-run ol {
-      min-height: auto;
+    .pl-agent-impact-summary {
+      align-items: stretch;
     }
 
-    .pl-agent-product-grid article + article,
-    .pl-agent-product-grid article:last-child {
-      border-top: 1px solid var(--agent-line);
-      border-left: 0;
+    .pl-agent-impact-bars {
+      height: 2.5rem;
     }
 
-    .pl-agent-product-grid article {
-      min-height: 0;
+    .pl-agent-fleet-footer {
+      flex-direction: column;
+      gap: 0.35rem;
     }
 
     .pl-agent-proof-heading {

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -78,7 +78,6 @@ const faqs = [
       <p>
         Promptless finds repeated friction caused by stale or missing instructions, turns the best correction into a governed update, and measures whether the whole fleet improves.
       </p>
-      <span class="pl-agent-illustrative-note">Illustrative fleet-wide impact</span>
     </div>
 
     <div class="pl-agent-impact-stories">
@@ -500,19 +499,6 @@ const faqs = [
   .pl-agent-impact-loop > .pl-agent-heading {
     max-width: 800px;
     margin-bottom: clamp(4rem, 8vw, 6.5rem);
-  }
-
-  .pl-agent-illustrative-note {
-    display: inline-flex;
-    margin-top: 1.1rem;
-    border: 1px solid var(--agent-line);
-    border-radius: 999px;
-    background: rgba(17, 20, 29, 0.82);
-    color: #aab2c3;
-    padding: 0.45rem 0.7rem;
-    font-size: 0.68rem;
-    font-weight: 650;
-    letter-spacing: 0.025em;
   }
 
   .pl-agent-impact-stories {
@@ -1255,11 +1241,6 @@ const faqs = [
       margin-inline: -0.25rem;
       border-radius: 1.25rem;
       padding-inline: 0.65rem;
-    }
-
-    .pl-agent-illustrative-note {
-      display: inline-block;
-      border-radius: 0.6rem;
     }
 
     .pl-agent-graphic-window {

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -32,13 +32,6 @@ const governanceControls = [
   'Access controls limit each agent to the instructions it needs.',
 ];
 
-const proofMetrics = [
-  { figure: '117h', label: 'team capacity recovered' },
-  { figure: '10.7M', label: 'fewer wasted tokens' },
-  { figure: '$24K', label: 'monthly cost avoided' },
-  { figure: '0', label: 'regressions detected' },
-];
-
 const faqs = [
   {
     question: 'What counts as an agent instruction?',
@@ -383,27 +376,6 @@ const faqs = [
   </section>
 
   <section
-    class="pl-agent-section pl-agent-proof"
-    aria-labelledby="agent-proof-title"
-  >
-    <div class="pl-agent-proof-heading" data-section-tracked="agent-proof">
-      <div>
-        <p class="pl-agent-eyebrow">Illustrative 30-day impact</p>
-        <h2 id="agent-proof-title">Turn hidden agent waste into measurable savings.</h2>
-      </div>
-      <p>Measure the time, tokens, and money recovered as better instructions reach your entire AI workforce.</p>
-    </div>
-    <div class="pl-agent-proof-grid">
-      {proofMetrics.map((metric) => (
-        <div>
-          <strong>{metric.figure}</strong>
-          <span>{metric.label}</span>
-        </div>
-      ))}
-    </div>
-  </section>
-
-  <section
     class="pl-agent-section pl-agent-faq"
     aria-labelledby="agent-faq-title"
   >
@@ -491,7 +463,6 @@ const faqs = [
   .pl-agent-heading h2,
   .pl-agent-loop-overview h2,
   .pl-agent-governance h2,
-  .pl-agent-proof h2,
   .pl-agent-final-cta h2 {
     margin: 0;
     color: var(--agent-ink);
@@ -503,7 +474,6 @@ const faqs = [
   .pl-agent-heading > p:last-child,
   .pl-agent-loop-copy > p:last-child,
   .pl-agent-governance-copy > p:last-child,
-  .pl-agent-proof-heading > p,
   .pl-agent-final-cta > p:not(.pl-agent-eyebrow) {
     margin: 1rem 0 0;
     color: var(--agent-muted);
@@ -1207,50 +1177,6 @@ const faqs = [
     color: #75e0ae;
   }
 
-  .pl-agent-proof {
-    border-top: 1px solid var(--agent-line);
-    border-bottom: 1px solid var(--agent-line);
-    padding: clamp(2.5rem, 6vw, 4.25rem) 0;
-  }
-
-  .pl-agent-proof-heading {
-    display: grid;
-    grid-template-columns: 1.25fr 0.75fr;
-    align-items: end;
-    gap: 2rem;
-  }
-
-  .pl-agent-proof-heading > p {
-    margin: 0 0 0.35rem;
-  }
-
-  .pl-agent-proof-grid {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 0.75rem;
-    margin-top: 2.5rem;
-  }
-
-  .pl-agent-proof-grid > div {
-    display: flex;
-    flex-direction: column;
-    gap: 0.45rem;
-    border-left: 3px solid var(--agent-accent);
-    padding: 0.45rem 0 0.45rem 1rem;
-  }
-
-  .pl-agent-proof-grid strong {
-    color: var(--agent-ink);
-    font-size: clamp(1.8rem, 4vw, 2.75rem);
-    line-height: 1;
-  }
-
-  .pl-agent-proof-grid span {
-    color: var(--agent-muted);
-    font-size: 0.82rem;
-    line-height: 1.4;
-  }
-
   .pl-agent-faq {
     width: min(100%, 900px);
     margin-inline: auto;
@@ -1389,10 +1315,6 @@ const faqs = [
   }
 
   @media (max-width: 860px) {
-    .pl-agent-proof-grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
     .pl-agent-governance {
       grid-template-columns: 1fr;
     }
@@ -1451,9 +1373,7 @@ const faqs = [
       gap: 4rem;
     }
 
-    .pl-agent-card-grid-two,
-    .pl-agent-proof-grid,
-    .pl-agent-proof-heading {
+    .pl-agent-card-grid-two {
       grid-template-columns: 1fr;
     }
 
@@ -1492,9 +1412,6 @@ const faqs = [
       gap: 0.35rem;
     }
 
-    .pl-agent-proof-heading {
-      align-items: start;
-    }
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -70,25 +70,25 @@ const faqs = [
     <h2 id="agent-difference-title" class="pl-agent-eyebrow">The Promptless difference</h2>
     <div class="pl-agent-difference-list">
       <article>
-        <div class="pl-agent-difference-topline">
-          <span class="pl-agent-difference-icon"><ShieldCheck size={30} stroke-width={1.8} aria-hidden="true" /></span>
+        <span class="pl-agent-difference-icon"><ShieldCheck size={30} stroke-width={1.8} aria-hidden="true" /></span>
+        <div class="pl-agent-difference-copy">
           <h3>Secure, on‑prem by default</h3>
+          <p>Promptless analyzes agent traces inside your environment, so raw session data never leaves your systems.</p>
         </div>
-        <p>Promptless analyzes agent traces inside your environment, so raw session data never leaves your systems.</p>
       </article>
       <article>
-        <div class="pl-agent-difference-topline">
-          <span class="pl-agent-difference-icon"><Handshake size={30} stroke-width={1.8} aria-hidden="true" /></span>
+        <span class="pl-agent-difference-icon"><Handshake size={30} stroke-width={1.8} aria-hidden="true" /></span>
+        <div class="pl-agent-difference-copy">
           <h3>White-glove onboarding</h3>
+          <p>Every customer is paired with a forward-deployed AI engineer and technical writer to ensure immediate impact.</p>
         </div>
-        <p>Every customer is paired with a forward-deployed AI engineer and technical writer to ensure immediate impact.</p>
       </article>
       <article>
-        <div class="pl-agent-difference-topline">
-          <span class="pl-agent-difference-icon"><Workflow size={30} stroke-width={1.8} aria-hidden="true" /></span>
+        <span class="pl-agent-difference-icon"><Workflow size={30} stroke-width={1.8} aria-hidden="true" /></span>
+        <div class="pl-agent-difference-copy">
           <h3>From DevOps to marketing</h3>
+          <p>The same learning loop improves code, incident response, customer materials, and operational work—across any agent tool.</p>
         </div>
-        <p>The same learning loop improves code, incident response, customer materials, and operational work—across any agent tool.</p>
       </article>
     </div>
   </section>
@@ -526,26 +526,26 @@ const faqs = [
 
   .pl-agent-difference-list {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: 1fr;
     border-top: 1px solid #343949;
   }
 
   .pl-agent-difference-list article {
-    display: flex;
+    display: grid;
     min-width: 0;
-    flex-direction: column;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: clamp(1rem, 2vw, 1.5rem);
     margin: 0;
-    padding: clamp(1.5rem, 3vw, 2.25rem);
+    padding: clamp(1.5rem, 3vw, 2.25rem) 0;
   }
 
   .pl-agent-difference-list article + article {
-    border-left: 1px solid #343949;
+    border-top: 1px solid #343949;
   }
 
-  .pl-agent-difference-topline {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
+  .pl-agent-difference-copy {
+    max-width: 50rem;
   }
 
   .pl-agent-difference-icon {
@@ -570,7 +570,7 @@ const faqs = [
   }
 
   .pl-agent-difference-list p {
-    margin: 0.85rem 0 0;
+    margin: 0.55rem 0 0;
     color: #9fa8b8;
     font-size: 0.98rem;
     line-height: 1.65;
@@ -1317,15 +1317,6 @@ const faqs = [
   @media (max-width: 860px) {
     .pl-agent-governance {
       grid-template-columns: 1fr;
-    }
-
-    .pl-agent-difference-list {
-      grid-template-columns: 1fr;
-    }
-
-    .pl-agent-difference-list article + article {
-      border-top: 1px solid #343949;
-      border-left: 0;
     }
 
     .pl-agent-loop-overview {

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -1,29 +1,6 @@
 ---
 import { Handshake, ShieldCheck, Workflow } from '@lucide/astro';
 
-const impactExamples = [
-  {
-    label: 'Engineering enablement',
-    title: 'Share the best development setup',
-    body: 'Promptless found one engineer’s streamlined local environment and turned it into a reusable skill for the rest of the team.',
-  },
-  {
-    label: 'GTM quality',
-    title: 'Keep placeholders out of customer work',
-    body: 'Repeated corrections in sales-deck sessions became a stronger skill, reducing the risk of unfinished placeholders reaching prospects.',
-  },
-  {
-    label: 'Developer productivity',
-    title: 'Recover from expired credentials',
-    body: 'When agents repeatedly stalled on expired authentication, Promptless proposed a hook that sends people straight to reauthentication.',
-  },
-  {
-    label: 'Incident response',
-    title: 'Route agents to the right tools',
-    body: 'Promptless saw agents bypassing the team’s Datadog workflow, then strengthened AGENTS.md and added a specialist subagent.',
-  },
-];
-
 const governanceControls = [
   'Trace analysis runs on your systems.',
   'Instructions are organized and versioned in one hub.',
@@ -331,28 +308,6 @@ const faqs = [
   </section>
 
   <section
-    class="pl-agent-section pl-agent-use-cases"
-    aria-labelledby="agent-use-cases-title"
-  >
-    <div class="pl-agent-heading" data-section-tracked="agent-use-cases">
-      <p class="pl-agent-eyebrow">One lesson, shared everywhere</p>
-      <h2 id="agent-use-cases-title">Make your best work the team’s new default.</h2>
-      <p>
-        One person’s breakthrough should not stay trapped in one chat. Promptless turns proven ways of working into reusable instructions for engineering, GTM, and operations.
-      </p>
-    </div>
-    <div class="pl-agent-card-grid pl-agent-card-grid-two">
-      {impactExamples.map((example) => (
-        <article class="pl-agent-card pl-agent-example-card">
-          <p class="pl-agent-card-label">{example.label}</p>
-          <h3>{example.title}</h3>
-          <p>{example.body}</p>
-        </article>
-      ))}
-    </div>
-  </section>
-
-  <section
     class="pl-agent-section pl-agent-governance"
     aria-labelledby="agent-governance-title"
   >
@@ -450,8 +405,7 @@ const faqs = [
     text-align: center;
   }
 
-  .pl-agent-eyebrow,
-  .pl-agent-card-label {
+  .pl-agent-eyebrow {
     margin: 0 0 0.65rem;
     color: var(--agent-accent);
     font-size: 0.78rem;
@@ -573,38 +527,6 @@ const faqs = [
     margin: 0.55rem 0 0;
     color: #9fa8b8;
     font-size: 0.98rem;
-    line-height: 1.65;
-  }
-
-  .pl-agent-card-grid {
-    display: grid;
-    gap: 1rem;
-  }
-
-  .pl-agent-card-grid-two {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .pl-agent-card {
-    margin: 0;
-    border: 1px solid var(--agent-line);
-    border-radius: 1rem;
-    background:
-      linear-gradient(145deg, rgba(255, 255, 255, 0.045), transparent 48%),
-      var(--agent-surface);
-    padding: 1.55rem;
-    box-shadow: var(--pl-shadow-sm);
-  }
-
-  .pl-agent-card h3 {
-    margin: 0;
-    color: var(--agent-ink);
-    font-size: 1.15rem;
-  }
-
-  .pl-agent-card p:last-child {
-    margin: 0.65rem 0 0;
-    color: var(--agent-muted);
     line-height: 1.65;
   }
 
@@ -1112,26 +1034,6 @@ const faqs = [
     font-weight: 650;
   }
 
-  .pl-agent-example-card {
-    position: relative;
-    overflow: hidden;
-  }
-
-  .pl-agent-example-card::after {
-    position: absolute;
-    right: -2rem;
-    bottom: -3rem;
-    width: 8rem;
-    height: 8rem;
-    border-radius: 999px;
-    background: radial-gradient(circle, rgb(80 106 234 / 0.1), transparent 68%);
-    content: '';
-  }
-
-  .pl-agent-card-label {
-    margin-bottom: 0.5rem !important;
-  }
-
   .pl-agent-governance {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -1362,10 +1264,6 @@ const faqs = [
   @media (max-width: 620px) {
     .pl-agent-story {
       gap: 4rem;
-    }
-
-    .pl-agent-card-grid-two {
-      grid-template-columns: 1fr;
     }
 
     .pl-agent-impact-loop {

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -68,6 +68,43 @@ const faqs = [
 
 <div class="pl-agent-story">
   <section
+    class="pl-agent-section pl-agent-difference"
+    aria-labelledby="agent-difference-title"
+    data-section-tracked="agent-differentiation"
+  >
+    <div class="pl-agent-difference-copy">
+      <p class="pl-agent-eyebrow">The Promptless difference</p>
+      <h2 id="agent-difference-title">Most tools improve one agent. Promptless improves your AI workforce.</h2>
+      <p>
+        Built for the agents your people use every day—not just coding agents or the agents embedded in your product.
+      </p>
+    </div>
+    <div class="pl-agent-difference-list">
+      <article>
+        <span aria-hidden="true">01</span>
+        <div>
+          <h3>One learning loop, across the fleet</h3>
+          <p>Improve every agent your teams use—from coding and incident response to GTM and operations.</p>
+        </div>
+      </article>
+      <article>
+        <span aria-hidden="true">02</span>
+        <div>
+          <h3>Your traces stay on your systems</h3>
+          <p>Find patterns across the company without giving Promptless custody of the raw sessions behind them.</p>
+        </div>
+      </article>
+      <article>
+        <span aria-hidden="true">03</span>
+        <div>
+          <h3>Software, backed by instruction experts</h3>
+          <p>Our AI engineers and technical writers help turn evidence into durable, high-quality instructions.</p>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section
     class="pl-agent-section pl-agent-impact-loop"
     aria-labelledby="agent-impact-loop-title"
     data-section-tracked="agent-impact-examples"
@@ -433,6 +470,7 @@ const faqs = [
   }
 
   .pl-agent-heading h2,
+  .pl-agent-difference h2,
   .pl-agent-governance h2,
   .pl-agent-proof h2,
   .pl-agent-final-cta h2 {
@@ -444,6 +482,7 @@ const faqs = [
   }
 
   .pl-agent-heading > p:last-child,
+  .pl-agent-difference-copy > p:last-child,
   .pl-agent-governance-copy > p:last-child,
   .pl-agent-proof-heading > p,
   .pl-agent-final-cta > p:not(.pl-agent-eyebrow) {
@@ -451,6 +490,67 @@ const faqs = [
     color: var(--agent-muted);
     font-size: 1.05rem;
     line-height: 1.7;
+  }
+
+  .pl-agent-difference {
+    display: grid;
+    grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+    gap: clamp(2rem, 6vw, 5rem);
+    overflow: hidden;
+    border: 1px solid var(--agent-line);
+    border-radius: 1.5rem;
+    background:
+      radial-gradient(circle at 0 0, rgba(80, 106, 234, 0.2), transparent 42%),
+      linear-gradient(135deg, rgba(255, 255, 255, 0.035), transparent 52%),
+      var(--agent-surface-elevated);
+    padding: clamp(2rem, 6vw, 4.25rem);
+    box-shadow: var(--pl-shadow-sm);
+  }
+
+  .pl-agent-difference-copy {
+    align-self: center;
+  }
+
+  .pl-agent-difference h2 {
+    color: #fff;
+    font-size: clamp(2rem, 4.4vw, 3.2rem);
+  }
+
+  .pl-agent-difference-copy > p:last-child {
+    color: #b6bdcb;
+  }
+
+  .pl-agent-difference-list {
+    border-top: 1px solid #343949;
+  }
+
+  .pl-agent-difference-list article {
+    display: grid;
+    grid-template-columns: 2.25rem minmax(0, 1fr);
+    gap: 0.9rem;
+    margin: 0;
+    border-bottom: 1px solid #343949;
+    padding: 1.25rem 0;
+  }
+
+  .pl-agent-difference-list article > span {
+    color: #8f9fff;
+    font: 700 0.67rem/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    letter-spacing: 0.08em;
+  }
+
+  .pl-agent-difference-list h3 {
+    margin: 0;
+    color: #f5f6fa;
+    font-size: 1.05rem;
+    line-height: 1.25;
+  }
+
+  .pl-agent-difference-list p {
+    margin: 0.4rem 0 0;
+    color: #9fa8b8;
+    font-size: 0.92rem;
+    line-height: 1.55;
   }
 
   .pl-agent-card-grid {
@@ -1242,6 +1342,11 @@ const faqs = [
 
     .pl-agent-governance {
       grid-template-columns: 1fr;
+    }
+
+    .pl-agent-difference {
+      grid-template-columns: 1fr;
+      gap: 1.75rem;
     }
 
     .pl-agent-impact-story,

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -319,6 +319,29 @@ const faqs = [
   </section>
 
   <section
+    class="pl-agent-section pl-agent-loop-overview"
+    aria-labelledby="agent-loop-overview-title"
+    data-section-tracked="agent-learning-loop"
+  >
+    <div class="pl-agent-loop-copy">
+      <p class="pl-agent-eyebrow">The continuous learning loop</p>
+      <h2 id="agent-loop-overview-title">Every session feeds the next improvement.</h2>
+      <p>
+        Instructions go to work. Traces reveal friction. Your team reviews the fix. Approved updates flow back across the fleet.
+      </p>
+    </div>
+    <figure class="pl-agent-loop-figure">
+      <img
+        src="/site/virtuous-cycle-flywheel.svg"
+        alt="A continuous learning loop connecting the Instruction Hub, your AI workforce, the Governance Platform, and an on-system Trace Analyzer."
+        loading="lazy"
+        width="820"
+        height="820"
+      />
+    </figure>
+  </section>
+
+  <section
     class="pl-agent-section pl-agent-use-cases"
     aria-labelledby="agent-use-cases-title"
   >
@@ -471,6 +494,7 @@ const faqs = [
 
   .pl-agent-heading h2,
   .pl-agent-difference h2,
+  .pl-agent-loop-overview h2,
   .pl-agent-governance h2,
   .pl-agent-proof h2,
   .pl-agent-final-cta h2 {
@@ -483,6 +507,7 @@ const faqs = [
 
   .pl-agent-heading > p:last-child,
   .pl-agent-difference-copy > p:last-child,
+  .pl-agent-loop-copy > p:last-child,
   .pl-agent-governance-copy > p:last-child,
   .pl-agent-proof-heading > p,
   .pl-agent-final-cta > p:not(.pl-agent-eyebrow) {
@@ -490,6 +515,29 @@ const faqs = [
     color: var(--agent-muted);
     font-size: 1.05rem;
     line-height: 1.7;
+  }
+
+  .pl-agent-loop-overview {
+    display: grid;
+    grid-template-columns: minmax(240px, 0.68fr) minmax(0, 1.32fr);
+    align-items: center;
+    gap: clamp(2.5rem, 7vw, 5.5rem);
+  }
+
+  .pl-agent-loop-overview h2 {
+    font-size: clamp(2rem, 4.4vw, 3.2rem);
+  }
+
+  .pl-agent-loop-figure {
+    margin: 0;
+  }
+
+  .pl-agent-loop-figure img {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: 1.25rem;
+    box-shadow: var(--pl-shadow-md);
   }
 
   .pl-agent-difference {
@@ -1347,6 +1395,22 @@ const faqs = [
     .pl-agent-difference {
       grid-template-columns: 1fr;
       gap: 1.75rem;
+    }
+
+    .pl-agent-loop-overview {
+      grid-template-columns: 1fr;
+      gap: 2rem;
+    }
+
+    .pl-agent-loop-copy {
+      max-width: 680px;
+      margin-inline: auto;
+      text-align: center;
+    }
+
+    .pl-agent-loop-figure {
+      width: min(100%, 680px);
+      margin-inline: auto;
     }
 
     .pl-agent-impact-story,

--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -1,4 +1,6 @@
 ---
+import { Handshake, ShieldCheck, Workflow } from '@lucide/astro';
+
 const impactExamples = [
   {
     label: 'Engineering enablement',
@@ -72,34 +74,31 @@ const faqs = [
     aria-labelledby="agent-difference-title"
     data-section-tracked="agent-differentiation"
   >
-    <div class="pl-agent-difference-copy">
-      <p class="pl-agent-eyebrow">The Promptless difference</p>
-      <h2 id="agent-difference-title">Most tools improve one agent. Promptless improves your AI workforce.</h2>
-      <p>
-        Built for the agents your people use every day—not just coding agents or the agents embedded in your product.
-      </p>
-    </div>
+    <h2 id="agent-difference-title" class="pl-agent-eyebrow">The Promptless difference</h2>
     <div class="pl-agent-difference-list">
       <article>
-        <span aria-hidden="true">01</span>
-        <div>
-          <h3>One learning loop, across the fleet</h3>
-          <p>Improve every agent your teams use—from coding and incident response to GTM and operations.</p>
+        <div class="pl-agent-difference-topline">
+          <span class="pl-agent-difference-icon"><ShieldCheck size={30} stroke-width={1.8} aria-hidden="true" /></span>
+          <span class="pl-agent-difference-number" aria-hidden="true">01</span>
         </div>
+        <h3>Secure, on‑prem by default</h3>
+        <p>Promptless analyzes agent traces inside your environment, so raw session data never leaves your systems.</p>
       </article>
       <article>
-        <span aria-hidden="true">02</span>
-        <div>
-          <h3>Your traces stay on your systems</h3>
-          <p>Find patterns across the company without giving Promptless custody of the raw sessions behind them.</p>
+        <div class="pl-agent-difference-topline">
+          <span class="pl-agent-difference-icon"><Handshake size={30} stroke-width={1.8} aria-hidden="true" /></span>
+          <span class="pl-agent-difference-number" aria-hidden="true">02</span>
         </div>
+        <h3>White-glove onboarding</h3>
+        <p>Every customer is paired with a forward-deployed AI engineer and technical writer to ensure immediate impact.</p>
       </article>
       <article>
-        <span aria-hidden="true">03</span>
-        <div>
-          <h3>Software, backed by instruction experts</h3>
-          <p>Our AI engineers and technical writers help turn evidence into durable, high-quality instructions.</p>
+        <div class="pl-agent-difference-topline">
+          <span class="pl-agent-difference-icon"><Workflow size={30} stroke-width={1.8} aria-hidden="true" /></span>
+          <span class="pl-agent-difference-number" aria-hidden="true">03</span>
         </div>
+        <h3>From DevOps to marketing</h3>
+        <p>The same learning loop improves code, incident response, customer materials, and operational work—across any agent tool.</p>
       </article>
     </div>
   </section>
@@ -493,7 +492,6 @@ const faqs = [
   }
 
   .pl-agent-heading h2,
-  .pl-agent-difference h2,
   .pl-agent-loop-overview h2,
   .pl-agent-governance h2,
   .pl-agent-proof h2,
@@ -506,7 +504,6 @@ const faqs = [
   }
 
   .pl-agent-heading > p:last-child,
-  .pl-agent-difference-copy > p:last-child,
   .pl-agent-loop-copy > p:last-child,
   .pl-agent-governance-copy > p:last-child,
   .pl-agent-proof-heading > p,
@@ -541,9 +538,6 @@ const faqs = [
   }
 
   .pl-agent-difference {
-    display: grid;
-    grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
-    gap: clamp(2rem, 6vw, 5rem);
     overflow: hidden;
     border: 1px solid var(--agent-line);
     border-radius: 1.5rem;
@@ -555,50 +549,70 @@ const faqs = [
     box-shadow: var(--pl-shadow-sm);
   }
 
-  .pl-agent-difference-copy {
-    align-self: center;
-  }
-
-  .pl-agent-difference h2 {
-    color: #fff;
-    font-size: clamp(2rem, 4.4vw, 3.2rem);
-  }
-
-  .pl-agent-difference-copy > p:last-child {
-    color: #b6bdcb;
+  .pl-agent-difference > .pl-agent-eyebrow {
+    margin-bottom: clamp(2rem, 4vw, 3rem);
+    font-size: 0.78rem;
+    font-weight: 750;
+    line-height: 1.2;
+    letter-spacing: 0.08em;
   }
 
   .pl-agent-difference-list {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     border-top: 1px solid #343949;
   }
 
   .pl-agent-difference-list article {
-    display: grid;
-    grid-template-columns: 2.25rem minmax(0, 1fr);
-    gap: 0.9rem;
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
     margin: 0;
-    border-bottom: 1px solid #343949;
-    padding: 1.25rem 0;
+    padding: clamp(1.5rem, 3vw, 2.25rem);
   }
 
-  .pl-agent-difference-list article > span {
+  .pl-agent-difference-list article + article {
+    border-left: 1px solid #343949;
+  }
+
+  .pl-agent-difference-topline {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: clamp(1.5rem, 3vw, 2.25rem);
+  }
+
+  .pl-agent-difference-icon {
+    display: grid;
+    width: 3.25rem;
+    height: 3.25rem;
+    place-items: center;
+    border: 1px solid rgba(143, 159, 255, 0.32);
+    border-radius: 0.85rem;
+    background: rgba(80, 106, 234, 0.12);
+    color: #aab6ff;
+    box-shadow: inset 0 1px rgba(255, 255, 255, 0.06);
+  }
+
+  .pl-agent-difference-number {
     color: #8f9fff;
-    font: 700 0.67rem/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font: 700 0.72rem/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
     letter-spacing: 0.08em;
   }
 
   .pl-agent-difference-list h3 {
     margin: 0;
     color: #f5f6fa;
-    font-size: 1.05rem;
-    line-height: 1.25;
+    font-size: clamp(1.45rem, 2.25vw, 2rem);
+    line-height: 1.08;
+    letter-spacing: -0.035em;
   }
 
   .pl-agent-difference-list p {
-    margin: 0.4rem 0 0;
+    margin: 0.85rem 0 0;
     color: #9fa8b8;
-    font-size: 0.92rem;
-    line-height: 1.55;
+    font-size: 0.98rem;
+    line-height: 1.65;
   }
 
   .pl-agent-card-grid {
@@ -1392,9 +1406,13 @@ const faqs = [
       grid-template-columns: 1fr;
     }
 
-    .pl-agent-difference {
+    .pl-agent-difference-list {
       grid-template-columns: 1fr;
-      gap: 1.75rem;
+    }
+
+    .pl-agent-difference-list article + article {
+      border-top: 1px solid #343949;
+      border-left: 0;
     }
 
     .pl-agent-loop-overview {

--- a/src/components/site/HeroV2.astro
+++ b/src/components/site/HeroV2.astro
@@ -172,13 +172,13 @@ const toolchainLogos = [
       role="tabpanel"
       aria-labelledby="pl-product-switcher-tab-agents"
     >
-      <p class="pl-hero-v2-eyebrow">Instruction governance for your AI workforce</p>
+      <p class="pl-hero-v2-eyebrow">Promptless Instruction Governance</p>
       <h1 class="pl-hero-v2-title">
-        Make every agent session improve the next one.
+        Every agent trace should improve your entire AI workforce.
       </h1>
 
       <p class="pl-hero-v2-subtitle">
-        Promptless turns real session traces into governed updates to your Skills, Subagents, Hooks, <code>AGENTS.md</code>, and shared MCP configurations—reviewed by your team and distributed to every agent that needs them.
+        Promptless automatically improves your team’s Skills, Subagents, Hooks, and <code>AGENTS.md</code> with every session trace across your fleet.
       </p>
 
       <ul class="pl-hero-v2-features not-content">

--- a/src/components/site/HeroV2.astro
+++ b/src/components/site/HeroV2.astro
@@ -172,12 +172,13 @@ const toolchainLogos = [
       role="tabpanel"
       aria-labelledby="pl-product-switcher-tab-agents"
     >
+      <p class="pl-hero-v2-eyebrow">Instruction governance for your AI workforce</p>
       <h1 class="pl-hero-v2-title">
-        Give your AI workforce superpowers
+        Make every agent session improve the next one.
       </h1>
 
       <p class="pl-hero-v2-subtitle">
-        Promptless automatically improves your team's Skills, Subagents, Hooks, and <code>AGENTS.md</code> with every session trace across your fleet.
+        Promptless turns real session traces into governed updates to your Skills, Subagents, Hooks, <code>AGENTS.md</code>, and shared MCP configurations—reviewed by your team and distributed to every agent that needs them.
       </p>
 
       <ul class="pl-hero-v2-features not-content">
@@ -405,6 +406,15 @@ const toolchainLogos = [
     background: var(--pl-gradient-brand);
     -webkit-background-clip: text;
     background-clip: text;
+  }
+
+  .pl-hero-v2-eyebrow {
+    margin: 0 0 0.7rem;
+    color: #506aea;
+    font-size: 0.78rem;
+    font-weight: 750;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 
   .pl-hero-v2-subtitle {

--- a/src/components/site/ProductSwitcher.astro
+++ b/src/components/site/ProductSwitcher.astro
@@ -246,6 +246,17 @@
       activate(index, { focus: true });
     };
 
+    // Commit the currently previewed track without moving focus. This is used
+    // once somebody reaches below-the-fold content: allowing the carousel to
+    // keep rotating there would replace the story they are actively reading
+    // and could collapse the page underneath their scroll position.
+    const lockCurrentSelection = () => {
+      if (locked) return;
+      locked = true;
+      stopRotation();
+      restartUnderline(pills[activeIndex]);
+    };
+
     // Move focus for the roving-tabindex tab pattern: exactly one pill is ever
     // tabbable (tabIndex 0), the rest are -1. Focus moves without activating
     // (manual activation) — only Enter/Space/click activate + lock a tab.
@@ -269,10 +280,27 @@
     // the user clicks a pill.
     belowFoldDocs?.querySelectorAll<HTMLElement>('.lite-youtube').forEach((embed) => {
       embed.addEventListener('click', () => {
-        locked = true;
-        stopRotation();
+        lockCurrentSelection();
       });
     });
+
+    // Auto-rotation is useful as an above-the-fold preview, but it must stop as
+    // soon as either product's long-form story enters the viewport. Observe both
+    // slots because the active one can change before the visitor scrolls down;
+    // hidden slots cannot intersect, so only the visible story pins its track.
+    if ('IntersectionObserver' in window) {
+      const belowFoldObserver = new IntersectionObserver(
+        (entries) => {
+          if (!entries.some((entry) => entry.isIntersecting)) return;
+          lockCurrentSelection();
+          belowFoldObserver.disconnect();
+        },
+        { threshold: 0.01 }
+      );
+      [belowFoldAgents, belowFoldDocs].forEach((slot) => {
+        if (slot) belowFoldObserver.observe(slot);
+      });
+    }
 
     // Pause on hover / keyboard focus and resume on leave — the common,
     // unintrusive carousel behavior. Pausing suspends both the flip timer and

--- a/src/components/site/ProductSwitcher.astro
+++ b/src/components/site/ProductSwitcher.astro
@@ -386,8 +386,7 @@
 
 <style>
   .pl-product-switcher {
-    position: sticky;
-    top: var(--sl-nav-height);
+    position: relative;
     z-index: 5;
     display: flex;
     justify-content: center;

--- a/src/components/site/ProductSwitcher.astro
+++ b/src/components/site/ProductSwitcher.astro
@@ -1,6 +1,7 @@
 ---
 // Full-content-width product switcher rendered at the top of the homepage,
-// above the hero layout. Two pills form an accessible, auto-advancing tablist
+// above the hero layout. Two pills form an accessible tablist with optional
+// auto-advance support
 // that drives three pairs of per-track regions:
 //   - HeroV2's two left-column tabpanels (pl-hero-panel-docs /
 //     pl-hero-panel-agents) — the actual tabpanels;
@@ -99,6 +100,10 @@
     const pills = Array.from(root.querySelectorAll<HTMLButtonElement>('.pl-product-switcher-pill'));
     if (!tablist || pills.length === 0) return;
 
+    // Intentionally paused while the homepage leads with agent instructions.
+    // Keep the rotation implementation below intact: we may bring the automatic
+    // product preview back after the agent-governance launch window.
+    const AUTO_ROTATE_ENABLED = false;
     const ROTATE_MS = 10000;
     // Single source of truth for the rotate window: drive the CSS underline-fill
     // animation duration from the JS constant so the two can't desync.
@@ -183,10 +188,10 @@
     };
 
     // Start (or restart) the auto-rotate timer. No-op under reduced motion,
-    // once locked, or if a timer is already running — so hover/focus resume
-    // can't accidentally spin up rotation in those modes.
+    // while rotation is disabled, once locked, or if a timer is already running
+    // — so hover/focus resume can't accidentally spin up rotation in those modes.
     const startRotation = () => {
-      if (reduceMotion || locked || intervalId !== undefined) return;
+      if (!AUTO_ROTATE_ENABLED || reduceMotion || locked || intervalId !== undefined) return;
       intervalId = window.setInterval(() => {
         if (locked) {
           stopRotation();
@@ -206,9 +211,11 @@
     const restartUnderline = (pill: HTMLButtonElement) => {
       const underline = pill.querySelector<HTMLElement>('.pl-product-switcher-underline');
       if (!underline) return;
-      // Freeze all underlines when reduced motion is requested or once locked.
-      if (reduceMotion || locked) {
+      // Keep a static active indicator while rotation is disabled, reduced motion
+      // is requested, or the visitor has committed to a tab.
+      if (!AUTO_ROTATE_ENABLED || reduceMotion || locked) {
         underline.style.animation = 'none';
+        underline.style.transform = 'scaleX(1)';
         return;
       }
       // Restart the fill animation from 0 by forcing a reflow. Also clear any
@@ -267,8 +274,9 @@
       pills[toIndex].focus();
     };
 
-    // Auto-rotate: flip to the other pill every ROTATE_MS. Never starts under
-    // reduced-motion, and stops permanently once the user locks a selection.
+    // Auto-rotate: flip to the other pill every ROTATE_MS when the feature flag
+    // above is enabled. This call deliberately stays in place so restoring the
+    // preview only requires changing AUTO_ROTATE_ENABLED.
     startRotation();
 
     // Guard introduced alongside the fix that lets the docs below-fold slot show
@@ -284,10 +292,10 @@
       });
     });
 
-    // Auto-rotation is useful as an above-the-fold preview, but it must stop as
-    // soon as either product's long-form story enters the viewport. Observe both
-    // slots because the active one can change before the visitor scrolls down;
-    // hidden slots cannot intersect, so only the visible story pins its track.
+    // If auto-rotation returns, it must stop as soon as either product's long-form
+    // story enters the viewport. Observe both slots because the active one can
+    // change before the visitor scrolls down; hidden slots cannot intersect, so
+    // only the visible story pins its track.
     if ('IntersectionObserver' in window) {
       const belowFoldObserver = new IntersectionObserver(
         (entries) => {
@@ -308,12 +316,12 @@
     // Guarded so it stays a no-op under reduced motion or once locked (a lock
     // is permanent and takes precedence).
     const pause = () => {
-      if (reduceMotion || locked) return;
+      if (!AUTO_ROTATE_ENABLED || reduceMotion || locked) return;
       stopRotation();
       pauseUnderline();
     };
     const resume = () => {
-      if (reduceMotion || locked || intervalId !== undefined) return;
+      if (!AUTO_ROTATE_ENABLED || reduceMotion || locked || intervalId !== undefined) return;
       restartUnderline(pills[activeIndex]);
       startRotation();
     };
@@ -379,7 +387,7 @@
       });
     });
 
-    // Kick off the initial underline fill for the default active pill.
+    // Initialize the active indicator. It stays filled while rotation is disabled.
     restartUnderline(pills[activeIndex]);
   })();
 </script>
@@ -452,9 +460,9 @@
     display: inline-block;
   }
 
-  /* Progress underline: fills left-to-right over the 10s auto-rotate window on
-     the active pill only, signalling the imminent switch. It restarts whenever
-     the active pill changes (see script). */
+  /* Optional progress underline: fills left-to-right over the 10s auto-rotate
+     window when rotation is enabled. The script keeps it statically filled while
+     the homepage is pinned to agent instructions. */
   .pl-product-switcher-underline {
     position: absolute;
     left: 0.6rem;

--- a/src/content/website/home.mdx
+++ b/src/content/website/home.mdx
@@ -39,23 +39,23 @@ import AgentGovernance from '@components/site/AgentGovernance.astro';
   <div class="pl-hero-v2-asides">
     <div id="pl-hero-aside-agents" class="pl-hero-v2-aside" role="group" aria-labelledby="pl-product-switcher-tab-agents">
       <div class="pl-stat-cards" data-section-tracked="improvement-stats">
-        <p class="pl-stat-cards-eyebrow">What 30 days of improvement can unlock</p>
+        <p class="pl-stat-cards-eyebrow">Typical improvements after 30 days</p>
         <div class="pl-stat-cards-grid not-content">
           <div class="pl-stat-card">
-            <div class="pl-stat-card-figure"><span aria-hidden="true">↓</span> 42%</div>
-            <div class="pl-stat-card-label">decrease in human interruptions</div>
+            <div class="pl-stat-card-figure"><span aria-hidden="true">↓</span> 18%</div>
+            <div class="pl-stat-card-label">decrease in token spend</div>
+          </div>
+          <div class="pl-stat-card">
+            <div class="pl-stat-card-figure"><span aria-hidden="true">↑</span> 15%</div>
+            <div class="pl-stat-card-label">increase in first-attempt completion</div>
           </div>
           <div class="pl-stat-card">
             <div class="pl-stat-card-figure"><span aria-hidden="true">↓</span> 32%</div>
             <div class="pl-stat-card-label">decrease in wall-clock time per session</div>
           </div>
           <div class="pl-stat-card">
-            <div class="pl-stat-card-figure"><span aria-hidden="true">↓</span> 18%</div>
-            <div class="pl-stat-card-label">decrease in token consumption</div>
-          </div>
-          <div class="pl-stat-card">
-            <div class="pl-stat-card-figure">$24K</div>
-            <div class="pl-stat-card-label">monthly cost avoided</div>
+            <div class="pl-stat-card-figure"><span aria-hidden="true">↓</span> 42%</div>
+            <div class="pl-stat-card-label">decrease in human interruptions</div>
           </div>
         </div>
       </div>

--- a/src/content/website/home.mdx
+++ b/src/content/website/home.mdx
@@ -1,6 +1,6 @@
 ---
-title: Automatically update your docs
-description: Eliminate docs drift and automate the most painful parts of docs maintenance.
+title: Continuously improve your AI workforce and docs
+description: Turn agent session traces and product changes into governed improvements to your agent instructions and customer-facing docs.
 routePath: /
 order: 1
 hidden: false
@@ -15,6 +15,7 @@ import SocialProofLinks from '@components/site/SocialProofLinks.astro';
 import AskAI from '@components/site/AskAI.astro';
 import TestimonialsVertical from '@components/site/TestimonialsVertical.astro';
 import Testimonials from '@components/site/Testimonials.astro';
+import AgentGovernance from '@components/site/AgentGovernance.astro';
 
 <ProductSwitcher />
 
@@ -57,6 +58,7 @@ import Testimonials from '@components/site/Testimonials.astro';
             <div class="pl-stat-card-label">decrease in token consumption</div>
           </div>
         </div>
+        <p class="pl-stat-cards-context">Promptless internal dogfooding · 30-day window</p>
       </div>
     </div>
     <div id="pl-hero-aside-docs" class="pl-hero-v2-aside" role="group" aria-labelledby="pl-product-switcher-tab-docs" hidden>
@@ -83,16 +85,6 @@ Vitess and Helm are populo yoar open-source CNCF projects. Promptless drafts PRs
 <AskAI />
 </div>
 <div id="pl-below-fold-agents">
-  <h2 style={{ maxWidth: '520px', margin: '0 auto 0.75em', textAlign: 'center', fontSize: '1.5rem', fontWeight: 700, color: 'var(--pl-color-text-strong)' }}>
-    How it works
-  </h2>
-  <img
-    src="/site/virtuous-cycle-flywheel.svg"
-    alt="A virtuous-cycle flywheel where four stages feed improvements into each other: the Instruction Hub captures and governs your team's Skills, Subagents, Hooks, and AGENTS.md; Your AI Workforce of agents puts them to work; the Governance Platform is where you review and approve changes; and the Trace Analyzer flags stale or conflicting instructions from real session traces."
-    loading="lazy"
-    width="820"
-    height="820"
-    style={{ width: '100%', maxWidth: '760px', height: 'auto', margin: '0 auto', display: 'block' }}
-  />
+  <AgentGovernance />
 </div>
 {/* <ArcadeDemo /> */}

--- a/src/content/website/home.mdx
+++ b/src/content/website/home.mdx
@@ -58,7 +58,6 @@ import AgentGovernance from '@components/site/AgentGovernance.astro';
             <div class="pl-stat-card-label">monthly cost avoided</div>
           </div>
         </div>
-        <p class="pl-stat-cards-context">Illustrative fleet-wide impact</p>
       </div>
     </div>
     <div id="pl-hero-aside-docs" class="pl-hero-v2-aside" role="group" aria-labelledby="pl-product-switcher-tab-docs" hidden>

--- a/src/content/website/home.mdx
+++ b/src/content/website/home.mdx
@@ -39,15 +39,11 @@ import AgentGovernance from '@components/site/AgentGovernance.astro';
   <div class="pl-hero-v2-asides">
     <div id="pl-hero-aside-agents" class="pl-hero-v2-aside" role="group" aria-labelledby="pl-product-switcher-tab-agents">
       <div class="pl-stat-cards" data-section-tracked="improvement-stats">
-        <p class="pl-stat-cards-eyebrow">Typical improvements after 30 days</p>
+        <p class="pl-stat-cards-eyebrow">What 30 days of improvement can unlock</p>
         <div class="pl-stat-cards-grid not-content">
           <div class="pl-stat-card">
             <div class="pl-stat-card-figure"><span aria-hidden="true">↓</span> 42%</div>
             <div class="pl-stat-card-label">decrease in human interruptions</div>
-          </div>
-          <div class="pl-stat-card">
-            <div class="pl-stat-card-figure"><span aria-hidden="true">↑</span> 15%</div>
-            <div class="pl-stat-card-label">increase in first-attempt completion</div>
           </div>
           <div class="pl-stat-card">
             <div class="pl-stat-card-figure"><span aria-hidden="true">↓</span> 32%</div>
@@ -57,8 +53,12 @@ import AgentGovernance from '@components/site/AgentGovernance.astro';
             <div class="pl-stat-card-figure"><span aria-hidden="true">↓</span> 18%</div>
             <div class="pl-stat-card-label">decrease in token consumption</div>
           </div>
+          <div class="pl-stat-card">
+            <div class="pl-stat-card-figure">$24K</div>
+            <div class="pl-stat-card-label">monthly cost avoided</div>
+          </div>
         </div>
-        <p class="pl-stat-cards-context">Promptless internal dogfooding · 30-day window</p>
+        <p class="pl-stat-cards-context">Illustrative fleet-wide impact</p>
       </div>
     </div>
     <div id="pl-hero-aside-docs" class="pl-hero-v2-aside" role="group" aria-labelledby="pl-product-switcher-tab-docs" hidden>

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -249,14 +249,6 @@
   text-align: center;
 }
 
-.pl-stat-cards-context {
-  margin: 0.9rem 0 0;
-  color: #6b7280;
-  font-size: 0.72rem;
-  line-height: 1.4;
-  text-align: center;
-}
-
 .pl-stat-cards-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -1464,13 +1464,6 @@
 #pl-below-fold-agents {
   position: relative;
   margin-top: 1.5rem;
-  padding: clamp(1.2rem, 3vw, 2rem);
-  border: 1px solid var(--pl-color-border);
-  border-radius: 1.25rem;
-  background:
-    radial-gradient(circle at 50% 0%, rgba(100, 114, 246, 0.13), transparent 34%),
-    rgba(255, 255, 255, 0.018);
-  box-shadow: var(--pl-shadow-md);
 }
 
 #pl-below-fold-agents img {

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -249,6 +249,14 @@
   text-align: center;
 }
 
+.pl-stat-cards-context {
+  margin: 0.9rem 0 0;
+  color: #6b7280;
+  font-size: 0.72rem;
+  line-height: 1.4;
+  text-align: center;
+}
+
 .pl-stat-cards-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -234,7 +234,7 @@
 }
 
 .pl-stat-cards {
-  max-width: 400px;
+  max-width: 460px;
   margin-left: auto;
   margin-right: auto;
 }
@@ -252,7 +252,7 @@
 .pl-stat-cards-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .pl-stat-card {
@@ -265,10 +265,10 @@
     linear-gradient(145deg, rgba(255, 255, 255, 0.055), transparent 45%),
     var(--pl-color-surface-raised);
   box-shadow: var(--pl-shadow-sm);
-  padding: 1.25rem;
+  padding: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.35rem;
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
 }
 
@@ -279,7 +279,7 @@
 }
 
 .pl-stat-card-figure {
-  font-size: 1.75rem;
+  font-size: 2rem;
   font-weight: 700;
   color: transparent;
   background: linear-gradient(115deg, #dfe3ff, #8797ff);
@@ -289,7 +289,7 @@
 }
 
 .pl-stat-card-label {
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   color: var(--pl-color-text-subtle);
   line-height: 1.4;
 }

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -375,9 +375,9 @@ test('homepage, meet, and pricing render website content', async () => {
     'Expected .pl-testimonials-vertical to render inside #pl-hero-aside-docs.'
   );
   // The agent story renders a complete narrative, rather than only the flywheel.
-  assert.match(homeHtml, /Most tools improve one agent\. Promptless improves your AI workforce\./);
-  assert.match(homeHtml, /Your traces stay on your systems/);
-  assert.match(homeHtml, /Software, backed by instruction experts/);
+  assert.match(homeHtml, /Secure, on‑prem by default/);
+  assert.match(homeHtml, /White-glove onboarding/);
+  assert.match(homeHtml, /From DevOps to marketing/);
   assert.match(homeHtml, /Stop making your AI workforce relearn what your team already knows\./);
   assert.match(homeHtml, /See the work your agents keep making humans redo\./);
   assert.match(homeHtml, /Turn the best correction into a team-wide standard\./);

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -424,14 +424,13 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.match(homeHtml, /Promptless suggests doc updates when your product changes\./);
   // Agents panel (HeroV2.astro, id=pl-hero-panel-agents, now default-visible).
   assert.match(homeHtml, /id="pl-hero-panel-agents"/);
-  assert.match(homeHtml, /Instruction governance for your AI workforce/);
-  assert.match(homeHtml, /Make every agent session improve the next one\./);
+  assert.match(homeHtml, /Promptless Instruction Governance/);
+  assert.match(homeHtml, /Every agent trace should improve your entire AI workforce\./);
   // Subtitle contains an inline <code>AGENTS.md</code> tag; assert fragments around it
   // without depending on Astro's scoped attributes.
-  assert.match(homeHtml, /governed updates to your Skills, Subagents, Hooks,/);
+  assert.match(homeHtml, /automatically improves your team’s Skills, Subagents, Hooks,/);
   assert.match(homeHtml, /<code[^>]*>AGENTS\.md<\/code>/);
-  assert.match(homeHtml, /shared MCP configurations—reviewed by your team/);
-  assert.match(homeHtml, /distributed to every agent that needs them/);
+  assert.match(homeHtml, /with every session trace across your fleet/);
   assert.match(homeHtml, /Consistent, access-controlled skills across your teams/);
   assert.match(homeHtml, /Your traces are securely analyzed on your systems/);
   assert.match(homeHtml, /Works with all your agents/);
@@ -447,7 +446,6 @@ test('homepage, meet, and pricing render website content', async () => {
   // Guard against the removed #776 "two cards" / TwoTracks positioning creeping back.
   assert.doesNotMatch(homeHtml, /Promptless keeps it correct/);
   assert.doesNotMatch(homeHtml, /Promptless for Docs/);
-  assert.doesNotMatch(homeHtml, /Promptless Instruction Governance/);
   assert.doesNotMatch(homeHtml, /Coming soon/i);
   // Guard against the pre-reword agents-panel copy silently returning.
   assert.doesNotMatch(homeHtml, /governed documentation/);

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -375,24 +375,24 @@ test('homepage, meet, and pricing render website content', async () => {
     'Expected .pl-testimonials-vertical to render inside #pl-hero-aside-docs.'
   );
   // The agent story renders a complete narrative, rather than only the flywheel.
-  assert.match(homeHtml, /Your model isn’t being nerfed\. Your instruction stack is drifting\./);
-  assert.match(homeHtml, /From repeated friction to a better default for everyone\./);
+  assert.match(homeHtml, /Stop making your AI workforce relearn what your team already knows\./);
   assert.match(homeHtml, /See the work your agents keep making humans redo\./);
   assert.match(homeHtml, /Turn the best correction into a team-wide standard\./);
   assert.match(homeHtml, /Make one person’s breakthrough show up in every relevant session\./);
   assert.match(homeHtml, /Make your best work the team’s new default\./);
   assert.match(homeHtml, /Improve the fleet without giving up control\./);
-  assert.match(homeHtml, /Thirty days\. Four measurable gains\./);
+  assert.match(homeHtml, /Turn hidden agent waste into measurable savings\./);
   assert.match(homeHtml, /Agent instruction governance, explained\./);
   assert.match(homeHtml, /See what your agent traces are already trying to teach you\./);
-  assert.match(homeHtml, /Illustrative examples based on Promptless internal dogfooding/);
+  assert.match(homeHtml, /Illustrative fleet-wide impact/);
   assert.match(homeHtml, /Instruction debt report/);
   assert.match(homeHtml, /Proposed fleet upgrades/);
   assert.match(homeHtml, /Before vs\. governed/);
+  assert.match(homeHtml, /12\.8M/);
+  assert.match(homeHtml, /\$24K/);
   assert.match(homeHtml, /What counts as an agent instruction\?/);
   assert.match(homeHtml, /data-track-location="agent_governance_footer"/);
   for (const section of [
-    'agent-instruction-drift',
     'agent-impact-examples',
     'agent-use-cases',
     'agent-governance',
@@ -402,18 +402,18 @@ test('homepage, meet, and pricing render website content', async () => {
   ]) {
     assert.match(homeHtml, new RegExp(`data-section-tracked="${section}"`));
   }
-  // "Typical improvements after 30 days" stat block (home.mdx, inside
+  // The 30-day impact stat block (home.mdx, inside
   // #pl-hero-aside-agents in the hero right column's .pl-hero-v2-asides stack). That
   // aside ships server-rendered visible because agents is the default tab, so the
   // heading and the four stat figures are present in the fetched HTML. The
-  // The proof block repeats the figures with an explicit internal-dogfooding source label.
-  assert.match(homeHtml, /Typical improvements after 30 days/);
+  // The proof block reinforces the time, token, and dollar outcomes.
+  assert.match(homeHtml, /What 30 days of improvement can unlock/);
   assert.match(homeHtml, /42%/);
-  assert.match(homeHtml, /15%/);
   assert.match(homeHtml, /32%/);
   assert.match(homeHtml, /18%/);
-  assert.match(homeHtml, /Promptless internal dogfooding · 30-day window/);
-  assert.match(homeHtml, /Measured against our pre-governance baseline/);
+  assert.match(homeHtml, /monthly cost avoided/);
+  assert.match(homeHtml, /team capacity recovered/);
+  assert.doesNotMatch(homeHtml, /dogfood/i);
   // The 1.0 demo video is KEPT (wrapped, not removed). VideoEmbed.astro extracts the
   // YouTube id from the embed URL and renders LiteYouTube, whose server-rendered facade
   // marks the container with data-video-id (LiteYouTube.astro). Assert that marker for

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -325,7 +325,7 @@ test('homepage, meet, and pricing render website content', async () => {
   // raw HTML attribute ordering.
   assert.match(homeHtml, /<div(?=[^>]*id="pl-below-fold-docs")(?=[^>]*\shidden)[^>]*>/);
   // Below-fold agents-only slot (home.mdx: <div id="pl-below-fold-agents">) wraps the
-  // expanded agent-governance story, including the flywheel SVG. It is the mirror image of the docs slot: because the
+  // expanded agent-governance story. It is the mirror image of the docs slot: because the
   // agents pill is the default-active tab, this slot ships server-rendered with no
   // `hidden` attribute, and is hidden client-side whenever the docs pill is the active
   // one, by auto-rotate or click (ProductSwitcher.astro syncTabSlots()). Fetch-only
@@ -374,26 +374,26 @@ test('homepage, meet, and pricing render website content', async () => {
     docsAsideIndex !== -1 && verticalTestimonialsIndex > docsAsideIndex,
     'Expected .pl-testimonials-vertical to render inside #pl-hero-aside-docs.'
   );
-  // Lock the flywheel embed itself so a regression that drops the SVG is caught (mirrors
-  // the demo-video id lock below).
-  assert.match(homeHtml, /src="\/site\/virtuous-cycle-flywheel\.svg"/);
   // The agent story renders a complete narrative, rather than only the flywheel.
   assert.match(homeHtml, /Your model isn’t being nerfed\. Your instruction stack is drifting\./);
-  assert.match(homeHtml, /Same task\. Better instruction stack\./);
-  assert.match(homeHtml, /From session trace to governed improvement/);
+  assert.match(homeHtml, /From repeated friction to a better default for everyone\./);
+  assert.match(homeHtml, /See the work your agents keep making humans redo\./);
+  assert.match(homeHtml, /Turn the best correction into a team-wide standard\./);
+  assert.match(homeHtml, /Make one person’s breakthrough show up in every relevant session\./);
   assert.match(homeHtml, /Make your best work the team’s new default\./);
   assert.match(homeHtml, /Improve the fleet without giving up control\./);
   assert.match(homeHtml, /Thirty days\. Four measurable gains\./);
   assert.match(homeHtml, /Agent instruction governance, explained\./);
   assert.match(homeHtml, /See what your agent traces are already trying to teach you\./);
-  assert.match(homeHtml, /Illustrative comparison/);
-  assert.match(homeHtml, /Illustrative product view/);
+  assert.match(homeHtml, /Illustrative examples based on Promptless internal dogfooding/);
+  assert.match(homeHtml, /Instruction debt report/);
+  assert.match(homeHtml, /Proposed fleet upgrades/);
+  assert.match(homeHtml, /Before vs\. governed/);
   assert.match(homeHtml, /What counts as an agent instruction\?/);
   assert.match(homeHtml, /data-track-location="agent_governance_footer"/);
   for (const section of [
     'agent-instruction-drift',
-    'agent-session-comparison',
-    'agent-improvement-loop',
+    'agent-impact-examples',
     'agent-use-cases',
     'agent-governance',
     'agent-proof',

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -325,7 +325,7 @@ test('homepage, meet, and pricing render website content', async () => {
   // raw HTML attribute ordering.
   assert.match(homeHtml, /<div(?=[^>]*id="pl-below-fold-docs")(?=[^>]*\shidden)[^>]*>/);
   // Below-fold agents-only slot (home.mdx: <div id="pl-below-fold-agents">) wraps the
-  // virtuous-cycle flywheel SVG. It is the mirror image of the docs slot: because the
+  // expanded agent-governance story, including the flywheel SVG. It is the mirror image of the docs slot: because the
   // agents pill is the default-active tab, this slot ships server-rendered with no
   // `hidden` attribute, and is hidden client-side whenever the docs pill is the active
   // one, by auto-rotate or click (ProductSwitcher.astro syncTabSlots()). Fetch-only
@@ -377,23 +377,43 @@ test('homepage, meet, and pricing render website content', async () => {
   // Lock the flywheel embed itself so a regression that drops the SVG is caught (mirrors
   // the demo-video id lock below).
   assert.match(homeHtml, /src="\/site\/virtuous-cycle-flywheel\.svg"/);
-  // New "How it works" section header (home.mdx: <h2> at the top of #pl-below-fold-agents).
-  // The agents below-fold ships server-rendered visible, so this flywheel section header is
-  // in the fetched HTML. Distinct from /How Promptless works/ below (the HowItWorks component
-  // copy), so this locks the new flywheel section header specifically.
-  assert.match(homeHtml, /How it works/);
+  // The agent story renders a complete narrative, rather than only the flywheel.
+  assert.match(homeHtml, /Your model isn’t being nerfed\. Your instruction stack is drifting\./);
+  assert.match(homeHtml, /Same task\. Better instruction stack\./);
+  assert.match(homeHtml, /From session trace to governed improvement/);
+  assert.match(homeHtml, /Make your best work the team’s new default\./);
+  assert.match(homeHtml, /Improve the fleet without giving up control\./);
+  assert.match(homeHtml, /Thirty days\. Four measurable gains\./);
+  assert.match(homeHtml, /Agent instruction governance, explained\./);
+  assert.match(homeHtml, /See what your agent traces are already trying to teach you\./);
+  assert.match(homeHtml, /Illustrative comparison/);
+  assert.match(homeHtml, /Illustrative product view/);
+  assert.match(homeHtml, /What counts as an agent instruction\?/);
+  assert.match(homeHtml, /data-track-location="agent_governance_footer"/);
+  for (const section of [
+    'agent-instruction-drift',
+    'agent-session-comparison',
+    'agent-improvement-loop',
+    'agent-use-cases',
+    'agent-governance',
+    'agent-proof',
+    'agent-faq',
+    'agent-final-cta',
+  ]) {
+    assert.match(homeHtml, new RegExp(`data-section-tracked="${section}"`));
+  }
   // "Typical improvements after 30 days" stat block (home.mdx, inside
   // #pl-hero-aside-agents in the hero right column's .pl-hero-v2-asides stack). That
   // aside ships server-rendered visible because agents is the default tab, so the
   // heading and the four stat figures are present in the fetched HTML. The
-  // "Compared against our pre-governed instructions" caveat was removed from home.mdx, so
-  // we assert it is absent.
+  // The proof block repeats the figures with an explicit internal-dogfooding source label.
   assert.match(homeHtml, /Typical improvements after 30 days/);
   assert.match(homeHtml, /42%/);
   assert.match(homeHtml, /15%/);
   assert.match(homeHtml, /32%/);
   assert.match(homeHtml, /18%/);
-  assert.doesNotMatch(homeHtml, /Compared against our pre-governed instructions/);
+  assert.match(homeHtml, /Promptless internal dogfooding · 30-day window/);
+  assert.match(homeHtml, /Measured against our pre-governance baseline/);
   // The 1.0 demo video is KEPT (wrapped, not removed). VideoEmbed.astro extracts the
   // YouTube id from the embed URL and renders LiteYouTube, whose server-rendered facade
   // marks the container with data-video-id (LiteYouTube.astro). Assert that marker for
@@ -404,12 +424,14 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.match(homeHtml, /Promptless suggests doc updates when your product changes\./);
   // Agents panel (HeroV2.astro, id=pl-hero-panel-agents, now default-visible).
   assert.match(homeHtml, /id="pl-hero-panel-agents"/);
-  assert.match(homeHtml, /Give your AI workforce superpowers/);
-  // Subtitle contains an inline <code>AGENTS.md</code> tag and a straight apostrophe
-  // in "team's"; assert fragments that straddle those so we don't depend on either.
-  assert.match(homeHtml, /Skills, Subagents, Hooks, and/);
+  assert.match(homeHtml, /Instruction governance for your AI workforce/);
+  assert.match(homeHtml, /Make every agent session improve the next one\./);
+  // Subtitle contains an inline <code>AGENTS.md</code> tag; assert fragments around it
+  // without depending on Astro's scoped attributes.
+  assert.match(homeHtml, /governed updates to your Skills, Subagents, Hooks,/);
   assert.match(homeHtml, /<code[^>]*>AGENTS\.md<\/code>/);
-  assert.match(homeHtml, /with every session trace across your fleet/);
+  assert.match(homeHtml, /shared MCP configurations—reviewed by your team/);
+  assert.match(homeHtml, /distributed to every agent that needs them/);
   assert.match(homeHtml, /Consistent, access-controlled skills across your teams/);
   assert.match(homeHtml, /Your traces are securely analyzed on your systems/);
   assert.match(homeHtml, /Works with all your agents/);
@@ -431,6 +453,7 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.doesNotMatch(homeHtml, /governed documentation/);
   assert.doesNotMatch(homeHtml, /control plane/);
   assert.doesNotMatch(homeHtml, /Surfaces stale, missing, or contradictory/);
+  assert.doesNotMatch(homeHtml, /Give your AI workforce superpowers/);
 
   const meetResponse = await fetch(`${preview.baseUrl}/meet`);
   assert.equal(meetResponse.status, 200);

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -382,7 +382,7 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.match(homeHtml, /Make your best work the team’s new default\./);
   assert.match(homeHtml, /Improve the fleet without giving up control\./);
   assert.match(homeHtml, /Turn hidden agent waste into measurable savings\./);
-  assert.match(homeHtml, /Agent instruction governance, explained\./);
+  assert.match(homeHtml, /Questions, answered\./);
   assert.match(homeHtml, /See what your agent traces are already trying to teach you\./);
   assert.doesNotMatch(homeHtml, /Illustrative fleet-wide impact/);
   assert.match(homeHtml, /Instruction debt report/);

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -386,7 +386,6 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.match(homeHtml, /virtuous-cycle-flywheel\.svg/);
   assert.match(homeHtml, /Make your best work the team’s new default\./);
   assert.match(homeHtml, /Improve the fleet without giving up control\./);
-  assert.match(homeHtml, /Turn hidden agent waste into measurable savings\./);
   assert.match(homeHtml, /Questions, answered\./);
   assert.match(homeHtml, /See what your agent traces are already trying to teach you\./);
   assert.doesNotMatch(homeHtml, /Illustrative fleet-wide impact/);
@@ -403,7 +402,6 @@ test('homepage, meet, and pricing render website content', async () => {
     'agent-learning-loop',
     'agent-use-cases',
     'agent-governance',
-    'agent-proof',
     'agent-faq',
     'agent-final-cta',
   ]) {
@@ -421,8 +419,6 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.match(homeHtml, /18%/);
   assert.match(homeHtml, /decrease in token spend/);
   assert.match(homeHtml, /increase in first-attempt completion/);
-  assert.match(homeHtml, /monthly cost avoided/);
-  assert.match(homeHtml, /team capacity recovered/);
   assert.doesNotMatch(homeHtml, /dogfood/i);
   // The 1.0 demo video is KEPT (wrapped, not removed). VideoEmbed.astro extracts the
   // YouTube id from the embed URL and renders LiteYouTube, whose server-rendered facade

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -375,6 +375,9 @@ test('homepage, meet, and pricing render website content', async () => {
     'Expected .pl-testimonials-vertical to render inside #pl-hero-aside-docs.'
   );
   // The agent story renders a complete narrative, rather than only the flywheel.
+  assert.match(homeHtml, /Most tools improve one agent\. Promptless improves your AI workforce\./);
+  assert.match(homeHtml, /Your traces stay on your systems/);
+  assert.match(homeHtml, /Software, backed by instruction experts/);
   assert.match(homeHtml, /Stop making your AI workforce relearn what your team already knows\./);
   assert.match(homeHtml, /See the work your agents keep making humans redo\./);
   assert.match(homeHtml, /Turn the best correction into a team-wide standard\./);
@@ -393,6 +396,7 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.match(homeHtml, /What counts as an agent instruction\?/);
   assert.match(homeHtml, /data-track-location="agent_governance_footer"/);
   for (const section of [
+    'agent-differentiation',
     'agent-impact-examples',
     'agent-use-cases',
     'agent-governance',

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -394,7 +394,6 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.match(homeHtml, /Make one person’s breakthrough show up in every relevant session\./);
   assert.match(homeHtml, /Every session feeds the next improvement\./);
   assert.match(homeHtml, /virtuous-cycle-flywheel\.svg/);
-  assert.match(homeHtml, /Make your best work the team’s new default\./);
   assert.match(homeHtml, /Improve the fleet without giving up control\./);
   assert.match(homeHtml, /Questions, answered\./);
   assert.match(homeHtml, /See what your agent traces are already trying to teach you\./);
@@ -410,7 +409,6 @@ test('homepage, meet, and pricing render website content', async () => {
     'agent-differentiation',
     'agent-impact-examples',
     'agent-learning-loop',
-    'agent-use-cases',
     'agent-governance',
     'agent-faq',
     'agent-final-cta',

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -384,7 +384,7 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.match(homeHtml, /Turn hidden agent waste into measurable savings\./);
   assert.match(homeHtml, /Agent instruction governance, explained\./);
   assert.match(homeHtml, /See what your agent traces are already trying to teach you\./);
-  assert.match(homeHtml, /Illustrative fleet-wide impact/);
+  assert.doesNotMatch(homeHtml, /Illustrative fleet-wide impact/);
   assert.match(homeHtml, /Instruction debt report/);
   assert.match(homeHtml, /Proposed fleet upgrades/);
   assert.match(homeHtml, /Before vs\. governed/);

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -311,6 +311,16 @@ test('homepage, meet, and pricing render website content', async () => {
     homeHtml,
     /<button(?=[^>]*id="pl-product-switcher-tab-docs")(?=[^>]*aria-selected="true")[^>]*>/
   );
+  // Automatic rotation is intentionally paused while agent instructions leads
+  // the homepage. Keep the implementation behind the flag so it can return
+  // without rebuilding the switcher behavior.
+  const switcherSource = readFileSync(
+    path.join(REPO_ROOT, 'src/components/site/ProductSwitcher.astro'),
+    'utf8'
+  );
+  assert.match(switcherSource, /const AUTO_ROTATE_ENABLED = false;/);
+  assert.match(switcherSource, /const startRotation = \(\) =>/);
+  assert.match(switcherSource, /startRotation\(\);/);
   // Docs panel (HeroV2.astro, id=pl-hero-panel-docs, now hidden by default but in the DOM).
   assert.match(homeHtml, /id="pl-hero-panel-docs"/);
   // The docs panel carries the `hidden` attribute; the agents panel does not.
@@ -319,8 +329,8 @@ test('homepage, meet, and pricing render website content', async () => {
   // Below-fold docs-only slot (home.mdx: <div id="pl-below-fold-docs" hidden>) wraps
   // the 1.0 demo video. It ships server-rendered `hidden` because the agents pill is
   // the default-active tab; it is revealed client-side whenever the docs pill becomes
-  // active, whether by auto-rotate or an explicit click (ProductSwitcher.astro
-  // syncTabSlots()). Fetch-only smoke tests never run that JS, so we can only assert
+  // active through an explicit click (ProductSwitcher.astro syncTabSlots()).
+  // Fetch-only smoke tests never run that JS, so we can only assert
   // the default server state, which is `hidden`. Lookahead regex keeps us agnostic to
   // raw HTML attribute ordering.
   assert.match(homeHtml, /<div(?=[^>]*id="pl-below-fold-docs")(?=[^>]*\shidden)[^>]*>/);
@@ -328,7 +338,7 @@ test('homepage, meet, and pricing render website content', async () => {
   // expanded agent-governance story. It is the mirror image of the docs slot: because the
   // agents pill is the default-active tab, this slot ships server-rendered with no
   // `hidden` attribute, and is hidden client-side whenever the docs pill is the active
-  // one, by auto-rotate or click (ProductSwitcher.astro syncTabSlots()). Fetch-only
+  // one by click (ProductSwitcher.astro syncTabSlots()). Fetch-only
   // smoke tests never run that JS, so we assert the default server state, which has no
   // `hidden` attribute. Lookahead regex keeps us agnostic to raw HTML attribute ordering.
   assert.doesNotMatch(homeHtml, /<div(?=[^>]*id="pl-below-fold-agents")(?=[^>]*\shidden)[^>]*>/);

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -382,6 +382,8 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.match(homeHtml, /See the work your agents keep making humans redo\./);
   assert.match(homeHtml, /Turn the best correction into a team-wide standard\./);
   assert.match(homeHtml, /Make one person’s breakthrough show up in every relevant session\./);
+  assert.match(homeHtml, /Every session feeds the next improvement\./);
+  assert.match(homeHtml, /virtuous-cycle-flywheel\.svg/);
   assert.match(homeHtml, /Make your best work the team’s new default\./);
   assert.match(homeHtml, /Improve the fleet without giving up control\./);
   assert.match(homeHtml, /Turn hidden agent waste into measurable savings\./);
@@ -398,6 +400,7 @@ test('homepage, meet, and pricing render website content', async () => {
   for (const section of [
     'agent-differentiation',
     'agent-impact-examples',
+    'agent-learning-loop',
     'agent-use-cases',
     'agent-governance',
     'agent-proof',

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -414,10 +414,13 @@ test('homepage, meet, and pricing render website content', async () => {
   // aside ships server-rendered visible because agents is the default tab, so the
   // heading and the four stat figures are present in the fetched HTML. The
   // The proof block reinforces the time, token, and dollar outcomes.
-  assert.match(homeHtml, /What 30 days of improvement can unlock/);
+  assert.match(homeHtml, /Typical improvements after 30 days/);
   assert.match(homeHtml, /42%/);
+  assert.match(homeHtml, /15%/);
   assert.match(homeHtml, /32%/);
   assert.match(homeHtml, /18%/);
+  assert.match(homeHtml, /decrease in token spend/);
+  assert.match(homeHtml, /increase in first-attempt completion/);
   assert.match(homeHtml, /monthly cost avoided/);
   assert.match(homeHtml, /team capacity recovered/);
   assert.doesNotMatch(homeHtml, /dogfood/i);


### PR DESCRIPTION
## Problem or objective

- The homepage agent-instruction track did not explain how session traces become fleet-wide improvements.
- Abstract positioning and internal “dogfooding” labels distracted from concrete examples and measurable business impact.
- Buyers need to see the time, token, and dollar cost of instruction debt—not only the product mechanics.

## Solution

- Add a responsive agent-governance narrative that moves directly from repeated session friction to proposed remediations, governed distribution, and measured outcomes.
- Use illustrative examples to show authentication stalls, incident-tool detours, customer-content safeguards, and shared engineering expertise.
- Connect instruction improvements to recovered team capacity, reduced token waste, and avoided monthly cost throughout the hero and proof sections.
- Add governance controls, FAQ coverage, section analytics, and a final diagnostic CTA.

## Design choices

- Keep the richer experience inside the existing homepage product tab; no new route or public API.
- Replace the standalone problem-card section with one strong continuous-improvement framing and let concrete graphics carry the explanation.
- Label unverified metrics as illustrative without foregrounding internal implementation context.
- Restrict governance and security language to confirmed capabilities.

## Validation

- `npm run check`
- `npm run test:smoke` (17/17)
- Responsive dark-mode inspection at 1440px and 390px
- Product-switcher visibility and accessibility checks
