### PR TITLE
Rebalance the agent homepage hero

### DIFF
--- a/src/components/site/AgentGovernance.astro
+++ b/src/components/site/AgentGovernance.astro
@@ -459,6 +459,8 @@ const faqs = [
   }
 
   .pl-agent-difference {
+    width: min(100%, 940px);
+    margin-inline: auto;
     overflow: hidden;
     border: 1px solid var(--agent-line);
     border-radius: 1.5rem;
@@ -466,12 +468,12 @@ const faqs = [
       radial-gradient(circle at 0 0, rgba(80, 106, 234, 0.2), transparent 42%),
       linear-gradient(135deg, rgba(255, 255, 255, 0.035), transparent 52%),
       var(--agent-surface-elevated);
-    padding: clamp(2rem, 6vw, 4.25rem);
+    padding: clamp(1.75rem, 4vw, 3.25rem);
     box-shadow: var(--pl-shadow-sm);
   }
 
   .pl-agent-difference > .pl-agent-eyebrow {
-    margin-bottom: clamp(2rem, 4vw, 3rem);
+    margin-bottom: clamp(1.5rem, 3vw, 2.25rem);
     font-size: 0.78rem;
     font-weight: 750;
     line-height: 1.2;
@@ -491,7 +493,7 @@ const faqs = [
     align-items: start;
     gap: clamp(1rem, 2vw, 1.5rem);
     margin: 0;
-    padding: clamp(1.5rem, 3vw, 2.25rem) 0;
+    padding: clamp(1.25rem, 2.2vw, 1.75rem) 0;
   }
 
   .pl-agent-difference-list article + article {
@@ -499,7 +501,7 @@ const faqs = [
   }
 
   .pl-agent-difference-copy {
-    max-width: 50rem;
+    max-width: 42rem;
   }
 
   .pl-agent-difference-icon {

--- a/src/components/site/HeroV2.astro
+++ b/src/components/site/HeroV2.astro
@@ -22,7 +22,7 @@ const toolchainLogos = [
   <div class="pl-hero-v2-panels">
     <div
       id="pl-hero-panel-docs"
-      class="pl-hero-v2-panel"
+      class="pl-hero-v2-panel pl-hero-v2-panel-docs"
       role="tabpanel"
       aria-labelledby="pl-product-switcher-tab-docs"
       hidden
@@ -164,24 +164,40 @@ const toolchainLogos = [
           </div>
         </li>
       </ul>
+
+      <form
+        id="book-a-demo-docs"
+        class="pl-hero-v2-form"
+        action="https://submit-form.com/roBOd2Oxb"
+        method="post"
+        data-redirect="/meet#book"
+      >
+        <label class="sr-only" for="work-email-docs">Work email</label>
+        <input id="work-email-docs" type="email" name="email" placeholder="Work email" required />
+        <input type="hidden" name="_redirect" value="/meet#book" />
+        <button type="submit" name="submit" data-track-action="book_demo" data-track-funnel="conversion" data-track-location="hero">Get a demo</button>
+      </form>
     </div>
 
     <div
       id="pl-hero-panel-agents"
-      class="pl-hero-v2-panel"
+      class="pl-hero-v2-panel pl-hero-v2-panel-agents"
       role="tabpanel"
       aria-labelledby="pl-product-switcher-tab-agents"
     >
-      <p class="pl-hero-v2-eyebrow">Promptless Instruction Governance</p>
-      <h1 class="pl-hero-v2-title">
-        Every agent trace should improve your entire AI workforce.
-      </h1>
+      <div class="pl-hero-v2-copy">
+        <p class="pl-hero-v2-eyebrow">Promptless Instruction Governance</p>
+        <h1 class="pl-hero-v2-title">
+          Every agent trace should improve your entire AI workforce.
+        </h1>
 
-      <p class="pl-hero-v2-subtitle">
-        Promptless automatically improves your team’s Skills, Subagents, Hooks, and <code>AGENTS.md</code> with every session trace across your fleet.
-      </p>
+        <p class="pl-hero-v2-subtitle">
+          Promptless automatically improves your team’s Skills, Subagents, Hooks, and <code>AGENTS.md</code> with every session trace across your fleet.
+        </p>
+      </div>
 
-      <ul class="pl-hero-v2-features not-content">
+      <div class="pl-hero-v2-support">
+        <ul class="pl-hero-v2-features not-content">
         <li class="pl-hero-v2-feature">
           <svg
             class="pl-hero-v2-feature-icon"
@@ -267,108 +283,110 @@ const toolchainLogos = [
             </ul>
           </div>
         </li>
-      </ul>
+        </ul>
+
+        <form
+          id="book-a-demo"
+          class="pl-hero-v2-form"
+          action="https://submit-form.com/roBOd2Oxb"
+          method="post"
+          data-redirect="/meet#book"
+        >
+          <label class="sr-only" for="work-email">Work email</label>
+          <input id="work-email" type="email" name="email" placeholder="Work email" required />
+          <input type="hidden" name="_redirect" value="/meet#book" />
+          <button type="submit" name="submit" data-track-action="book_demo" data-track-funnel="conversion" data-track-location="hero">Get a demo</button>
+        </form>
+      </div>
     </div>
   </div>
-
-  <form
-    id="book-a-demo"
-    class="pl-hero-v2-form"
-    action="https://submit-form.com/roBOd2Oxb"
-    method="post"
-    data-redirect="/meet#book"
-  >
-    <label class="sr-only" for="work-email">Work email</label>
-    <input id="work-email" type="email" name="email" placeholder="Work email" required />
-    <input type="hidden" name="_redirect" value="/meet#book" />
-    <button type="submit" name="submit" data-track-action="book_demo" data-track-funnel="conversion" data-track-location="hero">Get a demo</button>
-  </form>
 </section>
 
 <script>
   (() => {
-    const form = document.getElementById('book-a-demo');
-    if (!(form instanceof HTMLFormElement)) return;
+    const forms = document.querySelectorAll<HTMLFormElement>('.pl-hero-v2-form');
 
-    const submitButton = form.querySelector('button[type="submit"]');
-    const redirectInput = form.querySelector('input[name="_redirect"]');
+    for (const form of forms) {
+      const submitButton = form.querySelector('button[type="submit"]');
+      const redirectInput = form.querySelector('input[name="_redirect"]');
 
-    if (redirectInput instanceof HTMLInputElement) {
-      redirectInput.value = `${window.location.origin}/meet#book`;
-    }
+      if (redirectInput instanceof HTMLInputElement) {
+        redirectInput.value = `${window.location.origin}/meet#book`;
+      }
 
-    form.addEventListener('submit', async (event) => {
-      event.preventDefault();
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
 
-      const gtag = (window as any).gtag;
-      if (typeof gtag === 'function') {
-        gtag('event', 'cta_click', {
-          funnel_stage: 'conversion',
-          action: 'book_demo',
+        const gtag = (window as any).gtag;
+        if (typeof gtag === 'function') {
+          gtag('event', 'cta_click', {
+            funnel_stage: 'conversion',
+            action: 'book_demo',
+            location: 'hero',
+            campaign: '',
+            link_url: form.action,
+          });
+        }
+
+        const email = (form.querySelector('input[name="email"]') as HTMLInputElement)?.value?.trim();
+        if (email) {
+          try { sessionStorage.setItem('pl_demo_email', email); } catch {}
+        }
+        (window as any).posthog?.capture('email_captured', {
+          intent: 'demo',
           location: 'hero',
           campaign: '',
-          link_url: form.action,
-        });
-      }
-
-      const email = (form.querySelector('input[name="email"]') as HTMLInputElement)?.value?.trim();
-      if (email) {
-        try { sessionStorage.setItem('pl_demo_email', email); } catch {}
-      }
-      (window as any).posthog?.capture('email_captured', {
-        intent: 'demo',
-        location: 'hero',
-        campaign: '',
-        ...(email ? { $set: { email } } : {}),
-      });
-
-      // Stash PostHog identifiers so /meet can forward them to Cal.com
-      // as booking metadata, letting the webhook stitch demo_booked onto
-      // the same session/person timeline.
-      try {
-        const ph = (window as any).posthog;
-        const distinctId = ph?.get_distinct_id?.();
-        const sessionId = ph?.get_session_id?.();
-        if (distinctId) sessionStorage.setItem('pl_ph_distinct_id', distinctId);
-        if (sessionId) sessionStorage.setItem('pl_ph_session_id', sessionId);
-      } catch {}
-
-      if (submitButton instanceof HTMLButtonElement) {
-        submitButton.disabled = true;
-        submitButton.textContent = 'Submitting...';
-      }
-
-      try {
-        const formData = new FormData(form);
-        const payload = new URLSearchParams();
-        for (const [key, value] of formData.entries()) {
-          if (typeof value === 'string') payload.append(key, value);
-        }
-
-        const response = await fetch(form.action, {
-          method: 'POST',
-          body: payload.toString(),
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            Accept: 'application/json',
-          },
+          ...(email ? { $set: { email } } : {}),
         });
 
-        if (!response.ok) {
-          throw new Error(`Formspark submission failed with status ${response.status}`);
-        }
+        // Stash PostHog identifiers so /meet can forward them to Cal.com
+        // as booking metadata, letting the webhook stitch demo_booked onto
+        // the same session/person timeline.
+        try {
+          const ph = (window as any).posthog;
+          const distinctId = ph?.get_distinct_id?.();
+          const sessionId = ph?.get_session_id?.();
+          if (distinctId) sessionStorage.setItem('pl_ph_distinct_id', distinctId);
+          if (sessionId) sessionStorage.setItem('pl_ph_session_id', sessionId);
+        } catch {}
 
-        const redirectTo = form.dataset.redirect || '/meet';
-        window.location.assign(redirectTo);
-      } catch (_error) {
-        HTMLFormElement.prototype.submit.call(form);
-      } finally {
         if (submitButton instanceof HTMLButtonElement) {
-          submitButton.disabled = false;
-          submitButton.textContent = 'Get a demo';
+          submitButton.disabled = true;
+          submitButton.textContent = 'Submitting...';
         }
-      }
-    });
+
+        try {
+          const formData = new FormData(form);
+          const payload = new URLSearchParams();
+          for (const [key, value] of formData.entries()) {
+            if (typeof value === 'string') payload.append(key, value);
+          }
+
+          const response = await fetch(form.action, {
+            method: 'POST',
+            body: payload.toString(),
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+              Accept: 'application/json',
+            },
+          });
+
+          if (!response.ok) {
+            throw new Error(`Formspark submission failed with status ${response.status}`);
+          }
+
+          const redirectTo = form.dataset.redirect || '/meet';
+          window.location.assign(redirectTo);
+        } catch (_error) {
+          HTMLFormElement.prototype.submit.call(form);
+        } finally {
+          if (submitButton instanceof HTMLButtonElement) {
+            submitButton.disabled = false;
+            submitButton.textContent = 'Get a demo';
+          }
+        }
+      });
+    }
   })();
 </script>
 
@@ -377,12 +395,13 @@ const toolchainLogos = [
     padding: clamp(3rem, 6vw, 5.25rem) 0 3rem;
   }
 
-  /* Both hero panels occupy the same left-column slot so switching between
-     the docs and agents views causes no layout shift. Stacking them in a single
-     grid cell lets the wrapper reserve the height of the tallest panel. The
-     inactive panel keeps the `hidden` attribute (removing it from the a11y tree
-     and tab order) but stays in layout via visibility:hidden so nothing reflows
-     when the active panel changes. */
+  .pl-hero-v2:has(.pl-hero-v2-panel-agents:not([hidden])) {
+    padding-bottom: 0;
+  }
+
+  /* Both product panels share one grid cell. Their compositions intentionally
+     differ, so the inactive panel follows the native `hidden` behavior and
+     leaves both the visual layout and accessibility tree. */
   .pl-hero-v2-panels {
     display: grid;
   }
@@ -391,9 +410,30 @@ const toolchainLogos = [
     grid-area: 1 / 1;
   }
 
+  .pl-hero-v2-panel-agents {
+    display: grid;
+    grid-template-columns: minmax(0, 1.08fr) minmax(20rem, 0.92fr);
+    align-items: center;
+    gap: clamp(3rem, 7vw, 6rem);
+  }
+
   .pl-hero-v2-panel[hidden] {
-    display: block;
-    visibility: hidden;
+    display: none;
+  }
+
+  .pl-hero-v2-copy,
+  .pl-hero-v2-support {
+    min-width: 0;
+  }
+
+  .pl-hero-v2-support {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .pl-hero-v2-support .pl-hero-v2-features {
+    margin-top: 0;
   }
 
   .pl-hero-v2-title {
@@ -582,7 +622,12 @@ const toolchainLogos = [
     transform: translateY(-1px);
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 860px) {
+    .pl-hero-v2-panel-agents {
+      grid-template-columns: 1fr;
+      gap: 2.25rem;
+    }
+
     .pl-hero-v2 {
       padding: 2rem 0 1rem;
     }

--- a/src/content/website/home.mdx
+++ b/src/content/website/home.mdx
@@ -46,7 +46,7 @@ import AgentGovernance from '@components/site/AgentGovernance.astro';
             <div class="pl-stat-card-figure" aria-label="18 percent decrease"><span aria-hidden="true">↓</span><strong>18%</strong></div>
           </div>
           <div class="pl-stat-card">
-            <div class="pl-stat-card-label">First-attempt completion</div>
+            <div class="pl-stat-card-label">1st attempt completion</div>
             <div class="pl-stat-card-figure" aria-label="15 percent increase"><span aria-hidden="true">↑</span><strong>15%</strong></div>
           </div>
           <div class="pl-stat-card">

--- a/src/content/website/home.mdx
+++ b/src/content/website/home.mdx
@@ -20,10 +20,10 @@ import AgentGovernance from '@components/site/AgentGovernance.astro';
 <ProductSwitcher />
 
 {/*
-  The hero right column holds one aside per product-switcher tab: the 30-day
-  improvement stats belong to the agent-instructions track, the testimonials to
-  the customer-facing-docs track. ProductSwitcher.astro keeps them in visibility
-  lockstep with the active pill.
+  The hero aside holds one region per product-switcher tab. For agent
+  instructions it becomes a full-width metric row beneath the hero; for
+  customer-facing docs it remains the original right-hand testimonial column.
+  ProductSwitcher.astro keeps both in visibility lockstep with the active pill.
   A11y note on why these are not tabpanels. Each pill's `aria-controls` names
   exactly one element, and the WAI tabs pattern expects one tabpanel per tab. So
   the hero left-column panels (`pl-hero-panel-agents` / `pl-hero-panel-docs`, in

--- a/src/content/website/home.mdx
+++ b/src/content/website/home.mdx
@@ -42,20 +42,20 @@ import AgentGovernance from '@components/site/AgentGovernance.astro';
         <p class="pl-stat-cards-eyebrow">Typical improvements after 30 days</p>
         <div class="pl-stat-cards-grid not-content">
           <div class="pl-stat-card">
-            <div class="pl-stat-card-figure"><span aria-hidden="true">↓</span> 18%</div>
-            <div class="pl-stat-card-label">decrease in token spend</div>
+            <div class="pl-stat-card-label">Token spend</div>
+            <div class="pl-stat-card-figure" aria-label="18 percent decrease"><span aria-hidden="true">↓</span><strong>18%</strong></div>
           </div>
           <div class="pl-stat-card">
-            <div class="pl-stat-card-figure"><span aria-hidden="true">↑</span> 15%</div>
-            <div class="pl-stat-card-label">increase in first-attempt completion</div>
+            <div class="pl-stat-card-label">First-attempt completion</div>
+            <div class="pl-stat-card-figure" aria-label="15 percent increase"><span aria-hidden="true">↑</span><strong>15%</strong></div>
           </div>
           <div class="pl-stat-card">
-            <div class="pl-stat-card-figure"><span aria-hidden="true">↓</span> 32%</div>
-            <div class="pl-stat-card-label">decrease in wall-clock time per session</div>
+            <div class="pl-stat-card-label">Session time</div>
+            <div class="pl-stat-card-figure" aria-label="32 percent decrease"><span aria-hidden="true">↓</span><strong>32%</strong></div>
           </div>
           <div class="pl-stat-card">
-            <div class="pl-stat-card-figure"><span aria-hidden="true">↓</span> 42%</div>
-            <div class="pl-stat-card-label">decrease in human interruptions</div>
+            <div class="pl-stat-card-label">Human interruptions</div>
+            <div class="pl-stat-card-figure" aria-label="42 percent decrease"><span aria-hidden="true">↓</span><strong>42%</strong></div>
           </div>
         </div>
       </div>

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -309,14 +309,15 @@
 
 .pl-stat-card-label {
   color: var(--pl-color-text-muted);
-  font-size: 0.75rem;
+  font-size: clamp(0.75rem, 1vw, 0.9rem);
   font-weight: 750;
   line-height: 1.25;
-  letter-spacing: 0.09em;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
   text-transform: uppercase;
 }
 
-@media (max-width: 980px) {
+@media (max-width: 1040px) {
   .pl-stat-cards-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -166,12 +166,20 @@
   height: 1.1rem;
 }
 
-/* Hero V2 two-column layout */
+/* The docs hero keeps its original two-column composition. When agent
+   instructions are active, the hero panel spans the full width and its metrics
+   become a proof row beneath it. */
 .pl-hero-v2-layout {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: clamp(2rem, 4vw, 3rem);
   align-items: center;
+}
+
+.pl-hero-v2-layout:has(#pl-hero-panel-agents:not([hidden])) {
+  grid-template-columns: 1fr;
+  gap: clamp(2.5rem, 5vw, 4rem);
+  align-items: stretch;
 }
 
 /* The full testimonials carousel is a mobile-only stand-in for the hero's
@@ -201,15 +209,12 @@
   }
 }
 
-/* Per-tab hero asides (home.mdx: #pl-hero-aside-agents holds the 30-day
-   improvement stats, #pl-hero-aside-docs the testimonials). Same reasoning as
-   HeroV2's left-column panel stack: both asides occupy the same grid cell so the
-   wrapper reserves the height of the taller one and switching tabs causes no
-   layout shift. The inactive aside keeps the `hidden` attribute (removing it from
-   the a11y tree and tab order) but stays in layout via visibility:hidden. That
-   matters concretely here — `.pl-stat-cards` and `.pl-testimonials-vertical`
-   (fixed height: 24rem) have different intrinsic heights, so a display:none swap
-   would visibly jump the hero on every auto-rotate.
+/* Per-tab hero supporting regions (home.mdx: #pl-hero-aside-agents holds the
+   30-day improvement stats, #pl-hero-aside-docs the testimonials). Both occupy
+   the same grid cell. The inactive aside keeps the `hidden` attribute (removing
+   it from the a11y tree and tab order) but normally stays in layout via
+   visibility:hidden. The agent-specific override below removes the hidden docs
+   aside because this view intentionally uses a shorter, full-width proof row.
 
    The `min-width: 0` on both boxes is load-bearing and must not be removed. Grid
    and flex items default to `min-width: auto`, which sizes them to their content's
@@ -233,10 +238,15 @@
   visibility: hidden;
 }
 
+/* The docs testimonial column still reserves its original height when the docs
+   tab is active. In the agent layout, the hidden docs aside drops out so the
+   shorter metric row does not leave a large empty gap beneath the cards. */
+.pl-hero-v2-layout:has(#pl-hero-panel-agents:not([hidden])) .pl-hero-v2-aside[hidden] {
+  display: none;
+}
+
 .pl-stat-cards {
-  max-width: 460px;
-  margin-left: auto;
-  margin-right: auto;
+  width: 100%;
 }
 
 .pl-stat-cards-eyebrow {
@@ -246,12 +256,12 @@
   font-weight: 700;
   letter-spacing: 0.11em;
   text-transform: uppercase;
-  text-align: center;
+  text-align: left;
 }
 
 .pl-stat-cards-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1.1rem;
 }
 
@@ -304,6 +314,12 @@
   line-height: 1.25;
   letter-spacing: 0.09em;
   text-transform: uppercase;
+}
+
+@media (max-width: 980px) {
+  .pl-stat-cards-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 480px) {

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -265,10 +265,12 @@
     linear-gradient(145deg, rgba(255, 255, 255, 0.055), transparent 45%),
     var(--pl-color-surface-raised);
   box-shadow: var(--pl-shadow-sm);
-  padding: 1.5rem;
+  min-height: 9.25rem;
+  padding: 1.65rem;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  justify-content: space-between;
+  gap: 1rem;
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
 }
 
@@ -279,7 +281,10 @@
 }
 
 .pl-stat-card-figure {
-  font-size: 2rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  font-size: clamp(2.5rem, 4.5vw, 3.15rem);
   font-weight: 700;
   color: transparent;
   background: linear-gradient(115deg, #dfe3ff, #8797ff);
@@ -288,10 +293,17 @@
   line-height: 1.1;
 }
 
+.pl-stat-card-figure strong {
+  font: inherit;
+}
+
 .pl-stat-card-label {
-  font-size: 0.9rem;
-  color: var(--pl-color-text-subtle);
-  line-height: 1.4;
+  color: var(--pl-color-text-muted);
+  font-size: 0.75rem;
+  font-weight: 750;
+  line-height: 1.25;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
 }
 
 @media (max-width: 480px) {

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -425,8 +425,12 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.match(homeHtml, /15%/);
   assert.match(homeHtml, /32%/);
   assert.match(homeHtml, /18%/);
-  assert.match(homeHtml, /decrease in token spend/);
-  assert.match(homeHtml, /increase in first-attempt completion/);
+  assert.match(homeHtml, />Token spend</);
+  assert.match(homeHtml, />First-attempt completion</);
+  assert.match(homeHtml, />Session time</);
+  assert.match(homeHtml, />Human interruptions</);
+  assert.match(homeHtml, /aria-label="18 percent decrease"/);
+  assert.match(homeHtml, /aria-label="15 percent increase"/);
   assert.doesNotMatch(homeHtml, /dogfood/i);
   // The 1.0 demo video is KEPT (wrapped, not removed). VideoEmbed.astro extracts the
   // YouTube id from the embed URL and renders LiteYouTube, whose server-rendered facade

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -426,7 +426,7 @@ test('homepage, meet, and pricing render website content', async () => {
   assert.match(homeHtml, /32%/);
   assert.match(homeHtml, /18%/);
   assert.match(homeHtml, />Token spend</);
-  assert.match(homeHtml, />First-attempt completion</);
+  assert.match(homeHtml, />1st attempt completion</);
   assert.match(homeHtml, />Session time</);
   assert.match(homeHtml, />Human interruptions</);
   assert.match(homeHtml, /aria-label="18 percent decrease"/);


### PR DESCRIPTION
## Problem or objective

- Make the agent-instructions hero easier to scan and more balanced in dark mode.
- Give the four 30-day improvement metrics enough prominence to read as proof, not supporting copy.
- Preserve the customer-facing docs tab's existing composition.

## Solution

- Move the agent benefits, supported-agent logos, and demo form into the right side of the agent hero.
- Place `Token spend`, `First-attempt completion`, `Session time`, and `Human interruptions` in one full-width row beneath the agent hero.
- Keep the docs hero in its original left-copy/right-testimonial layout.
- Retain responsive 2×2 and single-column metric layouts at tablet and mobile widths.

## Design choices

- Scope the alternate composition to the active agent tab instead of imposing one shared layout on both products.
- Lead each metric card with a compact category label and oversized directional percentage.
- Preserve the existing metric values and claims; this revision changes hierarchy and presentation only.
- Keep hidden product content out of the accessibility tree while maintaining valid tab/tabpanel relationships.

## Validation

- Visually inspected both product tabs at desktop width and the agent layout at mobile width.
- `npm run check`
- `npm run test:smoke` — 17 passed
