### PR TITLE
Give the customer-facing-docs track its own ambient hue

### DIFF
--- a/src/components/site/ProductSwitcher.astro
+++ b/src/components/site/ProductSwitcher.astro
@@ -447,6 +447,18 @@
     box-shadow: inset 0 0 0 1px rgba(151, 162, 255, 0.13), 0 8px 20px rgba(0, 0, 0, 0.2);
   }
 
+  /* The docs pill carries the steel-blue of the ambient wash that selecting it
+     applies to the page (see .main-frame:has(.pl-site-page-home) in custom.css).
+     The agents pill keeps the brand indigo from the shared .is-active rule
+     above. Pill and page must stay the same hue — the pill previewing where
+     you're about to land is what makes the switch read as two products rather
+     than a recolor. Hues come from the --pl-track-docs-* vars so both live in
+     one place. */
+  #pl-product-switcher-tab-docs.is-active {
+    background: linear-gradient(135deg, var(--pl-track-docs-tint), rgba(255, 255, 255, 0.045));
+    box-shadow: inset 0 0 0 1px var(--pl-track-docs-ring), 0 8px 20px rgba(0, 0, 0, 0.2);
+  }
+
   .pl-product-switcher-pill:focus-visible {
     outline: 2px solid var(--pl-color-accent);
     outline-offset: 2px;
@@ -480,6 +492,11 @@
   .pl-product-switcher-pill.is-active .pl-product-switcher-underline {
     opacity: 1;
     animation: pl-product-switcher-fill var(--pl-switcher-rotate, 10s) linear forwards;
+  }
+
+  #pl-product-switcher-tab-docs .pl-product-switcher-underline {
+    background: linear-gradient(90deg, var(--pl-track-docs-accent), var(--pl-track-docs-accent-bright));
+    box-shadow: 0 0 12px rgba(70, 160, 230, 0.55);
   }
 
   @keyframes pl-product-switcher-fill {

--- a/src/content/website/home.mdx
+++ b/src/content/website/home.mdx
@@ -76,7 +76,7 @@ import CustomerLogoCarousel from '@components/site/CustomerLogoCarousel.astro';
 
 ## See Promptless-drafted docs shipping in Vitess and Helm
 
-Vitess and Helm are populo yoar open-source CNCF projects. Promptless drafts PRs and suggests changes; their docs maintainers review, revise, and ship them. Every commit is public.
+Vitess and Helm are popular open-source CNCF projects. Promptless drafts PRs and suggests changes; their docs maintainers review, revise, and ship them. Every commit is public.
 
 <SocialProofLinks />
 

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -45,6 +45,24 @@
   --pl-color-success-soft: #102824;
   --pl-color-danger: #ffaaa9;
   --pl-color-danger-soft: #32191d;
+  /* Per-product-track hues for the homepage product switcher. The
+     agent-instructions track keeps the brand indigo; the customer-facing-docs
+     track shifts to a cooler steel-blue so switching pills reads as moving
+     between two products. Deliberately a near neighbour of the indigo rather
+     than a jump to teal or cyan: it stays a decorative wash behind unchanged
+     body text, so no text, link, or icon color has to move with it.
+
+     Every docs-track hue lives here — the wash below and the pill in
+     ProductSwitcher.astro both read these, so retuning the hue is a one-place
+     edit. Keep wash and pill on the same hue: the pill previewing the wash it
+     activates is what sells the switch. */
+  --pl-track-docs-wash-near: rgba(46, 124, 224, 0.15);
+  --pl-track-docs-wash-far: rgba(56, 172, 216, 0.09);
+  --pl-track-docs-tint: rgba(56, 150, 232, 0.18);
+  --pl-track-docs-ring: rgba(110, 180, 240, 0.16);
+  --pl-track-docs-accent: #3a92e6;
+  --pl-track-docs-accent-bright: #63c6e8;
+
   --pl-gradient-action: linear-gradient(135deg, #5264ec 0%, #725cea 100%);
   --pl-gradient-action-hover: linear-gradient(135deg, #5868ec 0%, #7459e8 100%);
   --pl-gradient-brand: linear-gradient(115deg, #ffffff 12%, #d9ddff 52%, #9daaff 100%);
@@ -616,11 +634,32 @@ button[aria-controls='starlight__sidebar']:hover {
     var(--sl-color-bg);
 }
 
+/* The homepage ambient wash follows the active product-switcher pill. Only the
+   two gradient colors change between tracks — geometry and alpha stay put, so
+   neither product reads as brighter or heavier than the other, just different.
+   The wash vars are declared here rather than on :root so they stay scoped to
+   the homepage frame.
+
+   The swap is deliberately instant. ProductSwitcher.astro toggles the hero
+   panels with `hidden`, so every bit of copy changes in one frame; a background
+   that cross-faded over ~400ms would trail the content it is describing and
+   read as a repaint bug rather than a transition. */
 .main-frame:has(.pl-site-page-home) {
+  --pl-home-wash-near: rgba(82, 100, 236, 0.14);
+  --pl-home-wash-far: rgba(114, 92, 234, 0.08);
   background:
-    radial-gradient(ellipse 72% 34rem at 50% 0, rgba(82, 100, 236, 0.14), transparent 74%),
-    radial-gradient(ellipse 48% 28rem at 68% 2rem, rgba(114, 92, 234, 0.08), transparent 78%),
+    radial-gradient(ellipse 72% 34rem at 50% 0, var(--pl-home-wash-near), transparent 74%),
+    radial-gradient(ellipse 48% 28rem at 68% 2rem, var(--pl-home-wash-far), transparent 78%),
     var(--sl-color-bg);
+}
+
+/* Keyed off the docs tabpanel's `hidden` state, which is the same signal
+   HeroV2.astro already uses for its per-track layout switches. The docs panel
+   ships `hidden` in the markup, so the indigo default above is what paints
+   before the switcher's script runs — no flash of the wrong track. */
+.main-frame:has(.pl-site-page-home):has(#pl-hero-panel-docs:not([hidden])) {
+  --pl-home-wash-near: var(--pl-track-docs-wash-near);
+  --pl-home-wash-far: var(--pl-track-docs-wash-far);
 }
 
 .right-sidebar-panel {


### PR DESCRIPTION
## Why

Switching the homepage product switcher currently changes every word on the page and nothing about the page itself — headline, subtitle, feature list, right column, and all below-the-fold content swap in a single frame against a background that says nothing happened. It reads as a content toggle rather than a move between two products.

## What

The homepage ambient wash now follows the active pill. The agent-instructions track keeps the brand indigo; the customer-facing-docs track shifts to a cooler steel-blue.

- **Hue only.** Gradient geometry and alpha are identical between tracks, so neither product reads as brighter or heavier than the other — just different. Every card on the page is `#111319` on `#090a0f`, and shifting the page's lightness would shift every surface's relationship to it.
- **The pill previews the page.** The docs pill and its underline carry the same steel-blue, so the switcher shows you where you are about to land. The wash alone is a low-alpha gradient in the top band; the pill tint is the stronger signal, and the two only work together.
- **CTAs stay on brand.** `Start for free` / `Get a demo` remain indigo. Recoloring those tips "different product" into "different company."
- **No text colors move.** The steel-blue is a deliberate near neighbour of the indigo rather than a jump to teal or cyan, so it stays a decorative wash behind unchanged body text.

Keyed off the docs tabpanel's `hidden` attribute — the same signal `HeroV2.astro` already uses for its per-track layout switches. The docs panel ships `hidden` in the markup, so the indigo default paints before the switcher's script runs; there is no flash of the wrong track. Scoped with `:has(.pl-site-page-home)`, so `/docs` and every other page keep the original wash.

All docs-track hues live in the `--pl-track-docs-*` vars in `custom.css`, so retuning the hue is a one-place edit.

### Contrast

Worst case, taking the wash at full strength and ignoring the radial falloff:

| | hero title | muted body text |
|---|---|---|
| agents track (unchanged) | 16.7:1 | 7.7:1 |
| docs track (new) | 15.4:1 | 7.1:1 |

Both clear WCAG AAA, so no text, link, or icon color has to change.

### Deliberately not done

No cross-fade on the background. Interpolating gradient colors needs `@property`, and more importantly the panels swap via `hidden` in one frame — a background easing over ~400ms would trail the content it is describing and read as a repaint bug. The reasoning is in a comment so it doesn't get re-litigated.

## Also

Fixes garbled copy in the homepage social proof line, which shipped as "Vitess and Helm are **populo yoar** open-source CNCF projects" in #762 and is live on this same tab.

## Verification

- `npm run typecheck` — 0 errors
- `npm run build` — succeeds
- `npm run test:smoke` — 20/20 pass
- Checked both tracks at desktop and mobile widths; confirmed the wash reverts to indigo when switching back, and that `/docs` pages are untouched

## Follow-on

The wash only covers the top band — scroll into the docs story (demo video, how-it-works, why-Promptless) and it is back to neutral. Extending the separation below the fold is a larger change, not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)