### PR TITLE
content: Documentation Freshness: The Quality Metric Missing from Most Docs Dashboards

### DIFF
--- a/src/content/blog/technical/documentation-freshness-quality-metric.mdx
+++ b/src/content/blog/technical/documentation-freshness-quality-metric.mdx
@@ -1,0 +1,79 @@
+---
+title: 'Documentation Freshness: The Quality Metric Missing from Most Docs Dashboards'
+subtitle: Published August 2026
+description: >-
+  Traffic metrics tell you who visits your docs. They don't tell you if the docs are accurate. Here's how to measure documentation freshness and why it matters.
+date: '2026-08-13T00:00:00.000Z'
+author: Frances
+tag: Technical
+section: Use Cases
+hidden: false
+---
+import BlogNewsletterCTA from '@components/site/BlogNewsletterCTA.astro';
+import BlogRequestDemo from '@components/site/BlogRequestDemo.astro';
+
+Your docs analytics dashboard probably shows page views and average time on page. Neither of those numbers tells you whether the content is accurate.
+
+That's the gap. Traffic metrics measure reach. They don't measure quality. A page that gets 500 visits per month and contains wrong information looks identical in your analytics to a page that gets 500 visits and contains correct information. You can't tell the difference from a pageview count.
+
+For developer-facing companies that ship frequently, this gap has a specific cost. Every time a new version ships without a corresponding docs update, the accuracy of your docs degrades. That degradation is invisible to traffic-based analytics until it surfaces as a support ticket or a churned developer.
+
+Documentation freshness is the metric that fills this gap. It measures how current your docs are relative to your product. It's predictive in a way that page views aren't.
+
+## Why the metrics most teams track don't capture quality
+
+Page views measure interest, not success. A developer who lands on a setup guide, follows the instructions, and hits an error because the guide describes a deprecated flow counts as a page view. So does a developer who found what they needed in 30 seconds.
+
+Time on page has the same problem, in reverse. High time on page can mean engaged reading, or it can mean a developer stuck trying to reconcile what the docs say with what the product actually does.
+
+Search volume tells you what topics developers care about. It doesn't tell you whether the content they find answers their questions accurately.
+
+These aren't worthless metrics. Page views help you prioritize which content to improve. Zero-result searches reveal missing topics. But none of them can detect the core quality problem: content that used to be accurate and no longer is.
+
+The [State of Docs Report 2025](https://www.stateofdocs.com/2025/) found that 39% of teams track no documentation metrics at all. Most of the rest measure page views or time-on-page. Almost no one measures freshness systematically.
+
+This is why the problem compounds quietly. According to Postman survey data, 56% of API documentation teams name keeping docs current as their top challenge. This ranks ahead of writing quality, tooling, and structure. The issue is consistently identified, and consistently under-measured.
+
+## What documentation freshness actually measures
+
+Documentation freshness is the gap between when a doc was last updated and when the code or product behavior it describes last changed.
+
+A page updated six months ago might be fresh if nothing in that feature area has changed. The same page might be severely stale if the feature was substantially redesigned last sprint. Freshness is relational. It requires comparing the doc's last-updated date to the product's last-changed date for the same area.
+
+Two metrics make this concrete:
+
+**Docs-to-code lag.** For any given API endpoint, SDK method, or product feature, how many days have passed since the last code change, and how many days have passed since the corresponding documentation was updated? The difference is the lag. A lag of zero means the docs were updated at the same time as the code (or after, and before the next code change). A lag of 45 days on a frequently-changing feature is a problem. A lag of 45 days on a stable reference that hasn't changed in a year might be fine.
+
+**Coverage drift.** What percentage of your documented endpoints, SDK methods, or product flows were last updated within a threshold you've defined (say, 90 days for reference docs, 30 days for getting-started guides)? Coverage drift is the share that has exceeded the threshold without an update. A 10% coverage drift means roughly 1 in 10 documented items is overdue for review. A 40% drift means nearly half of your docs may not reflect current behavior.
+
+Neither metric is perfect. Docs can be updated for cosmetic reasons without fixing accuracy problems. Code can change in ways that don't affect documented behavior. But directionally, these metrics surface where documentation risk is accumulating. They do so before the support tickets arrive.
+
+<BlogNewsletterCTA />
+
+## Freshness as a leading indicator
+
+Support ticket deflection is the most commonly cited business metric for documentation quality. Industry benchmarks put the median deflection rate at 40-45%, with top-performing teams reaching 55-60%. When deflection drops, it's a signal that something in the documentation is broken.
+
+The problem with deflection as a primary quality metric is that it's lagging. A drop in deflection means developers already ran into wrong or missing information and contacted support. The documentation failure happened before you saw it in your data.
+
+Documentation freshness works as a leading indicator. If you know that 35% of your API reference docs are overdue for review after a major release, you can address the gap before it shows up in your support queue. You're measuring the precondition for quality failure, not the failure itself.
+
+The relationship is direct. Postman's research on API documentation found that outdated docs are the number-one developer frustration, cited by 68% of developers in their survey. That frustration accumulates silently in your traffic analytics and then surfaces in support volume after a product change.
+
+Tracking freshness closes the feedback loop. Instead of waiting to discover that a feature was redesigned three weeks ago and nobody updated the docs, you're monitoring the drift as it accumulates. [Documentation drift detection](/blog/technical/documentation-drift-detection-problem) is hard to do manually at scale. Freshness metrics make it systematic.
+
+## Getting started
+
+You don't need a sophisticated tool to start tracking freshness. You need two things: the last-updated date for each docs page, and the last-changed date for the code or product behavior each page describes.
+
+If your docs are in a git repository, the first is straightforward. `git log --follow -1 --format="%ai" -- <file>` gives you the last commit date for any file.
+
+The second requires mapping docs pages to the code areas they describe. This mapping is the hard part. For API reference docs, the mapping is usually explicit: each endpoint page corresponds to a specific route in the codebase. For conceptual guides and tutorials, the mapping is looser and requires judgment.
+
+Start with the areas where freshness risk is highest: getting-started guides, authentication docs, and any reference page covering a product area that shipped a change in the last 90 days. Those are the pages most likely to have accumulated lag without anyone noticing.
+
+For teams that ship frequently, this kind of monitoring needs to be continuous, not quarterly. A quarterly docs review finds problems after they've been misleading developers for weeks. Automated freshness tracking flags problems when they form. It gives your team the specific pages and code areas to address, rather than a general directive to "review the docs."
+
+Promptless monitors documentation against your codebase automatically, surfaces pages with accumulated lag, and tracks coverage drift over time. If you want to see what your current freshness state looks like, the [documentation metrics guide](/blog/technical/documentation-metrics-and-analytics-a-complete-guide-for-dev) covers the broader metrics picture alongside freshness.
+
+<BlogRequestDemo />


### PR DESCRIPTION
**Keyword:** `technical documentation metrics`

## Article plan

**Format:** A focused argument for one underused quality metric (documentation freshness), written for technical writers and DevRel engineers who have traffic analytics on their docs but keep getting complaints that content is wrong or outdated.

**Thesis:** Traffic metrics like page views measure reach, not accuracy. Documentation freshness — how current your docs are relative to your product — is the most predictive quality signal, and almost no team tracks it.

**Angle vs. existing coverage:** The existing [documentation metrics guide](src/content/blog/technical/documentation-metrics-and-analytics-a-complete-guide-for-dev.mdx) covers TTFC, DTTV, zero-result search, and support deflection. This article specifically addresses freshness as a *leading* indicator, which that article does not cover.

**Key evidence used:**
- 56% of API documentation teams name keeping docs current as their top challenge (Postman survey data)
- 68% of developers cite outdated docs as their top API frustration (Postman)
- 39% of teams track no docs metrics at all; most of the rest track page views (State of Docs Report 2025)
- Support deflection benchmarks: 40-45% median, 55-60% top quartile

**Promptless connection:** Promptless monitors documentation against code changes and surfaces freshness gaps automatically — it implements the freshness metric this article argues teams need.

## File

`src/content/blog/technical/documentation-freshness-quality-metric.mdx`

This is an AI-generated draft and needs human review before publishing. The frontmatter already has `hidden: false` — review content before it goes live.

---
_Generated by [Claude Code](https://claude.ai/code/session_011dYLwCG3Qd4EWqUbpCaDKH)_