### PR TITLE
Consolidate #582 and #625 into the published developer relations docs article

### DIFF
--- a/src/content/blog/technical/developer-relations-docs.mdx
+++ b/src/content/blog/technical/developer-relations-docs.mdx
@@ -20,7 +20,7 @@ Developer relations documentation has a structural problem. The way teams assign
 
 ## The ownership gap in DevRel docs
 
-Most developer relations teams produce a lot of documentation. They write getting-started guides, tutorials, SDK reference docs, changelog entries, sample apps, and blog posts.
+Most developer relations teams produce a lot of documentation: getting-started guides, tutorials, SDK reference docs, changelog entries, sample apps, and blog posts.
 
 The real problem is how teams share responsibility for that documentation. Different teams own different pieces. No single trigger tells them to update at the same time.
 
@@ -28,13 +28,13 @@ Engineering owns the API reference, and product owns the changelog. DevRel write
 
 When the product changes, the API reference gets updated. Engineering's definition of done requires it. The changelog gets an entry because product runs the release process. The getting-started guide, the code samples, and the tutorial for the old authentication flow update on a slower cycle. Sometimes they do not update at all.
 
-After six months, documentation becomes unreliable. After a year, developers learn to distrust it by default. They go straight to the source code, or they open a support ticket. Once developers lose trust, it is expensive to rebuild. One case study measured this cost for a single stale tutorial. The stale tutorial caused 47 support hours of extra work and three churned customers. Developer community trust took six months to recover.
+Developers do not see the org chart. They see documentation that contradicts the product. In [Postman's 2024 State of the API report](https://www.postman.com/state-of-api/2024), 39% of developers named inconsistent documentation as their biggest roadblock when working with APIs.
+
+After six months, documentation becomes unreliable. After a year, developers learn to distrust it by default. They go straight to the source code, or they open a support ticket. Once developers lose trust, it is expensive to rebuild. One case study measured this cost for a single stale tutorial: 47 extra support hours and three churned customers. Developer community trust took six months to recover.
 
 <BlogNewsletterCTA />
 
 ## Two audiences, one set of docs
-
-Accuracy in developer relations documentation matters more now than before.
 
 In 2026, AI coding assistants became the primary consumers of developer documentation. When a developer asks an AI coding assistant to integrate with an API, the assistant reads the docs first. The assistant takes the documentation at face value. It skips the changelog, and it skips asking a colleague whether a function still works. Then it generates code directly from what the docs say.
 
@@ -42,7 +42,9 @@ In 2026, AI coding assistants became the primary consumers of developer document
 
 This matters most for DevRel teams. Human developers can compensate for incomplete documentation by drawing on experience and community resources, but an AI coding assistant cannot. It follows the documented path exactly. A stale getting-started guide then produces broken integrations at scale, one for every developer who uses an AI coding assistant to onboard.
 
-The feedback loop has also become faster. When a developer follows broken docs, they may debug for a day before filing a support ticket. When an AI coding assistant follows broken docs, the developer sees the error within seconds. Errors now surface more often, and they surface faster.
+The damage also compounds within a single session. An assistant works in steps, and each step builds on what the earlier ones produced. A stale authentication page read at the start becomes an assumption behind every step after it, including the code the assistant finally writes. Nothing later in the session goes back to question it, which is the failure mode [context engineering](/blog/technical/agent-context-engineering) describes.
+
+The feedback loop has also become faster. When a developer follows broken docs, they may debug for a day before filing a support ticket. When an AI coding assistant follows broken docs, the developer sees the error within seconds.
 
 For more on how AI coding assistants consume developer documentation, see [Agent Context Files Explained: AGENTS.md, CLAUDE.md, and llms.txt](/blog/technical/agent-context-files-explained).
 
@@ -52,7 +54,9 @@ Developer documentation does not go stale at the same rate for every type of con
 
 Procedural content breaks when the API changes. API changes happen constantly in developer-facing products. New endpoints, deprecated parameters, revised authentication flows, and updated rate limits each create a potential gap. That gap sits between what the docs say and what the API does.
 
-This gap persists because API changes do not automatically trigger a documentation review. Engineering's release process ends when the code ships. The documentation review is a separate step. It requires someone to remember it and have time to do it. In practice, teams often do this late, or they skip it entirely.
+Within procedural content, the risk is not spread evenly. Quickstarts carry the most traffic and the most exposure, because a developer who hits a broken first step usually leaves before becoming a customer. Code samples break whenever the SDK changes, and a sample that does not run casts doubt on every other page. Authentication flows change rarely and break every existing integration when they do. Quickstarts, code samples, and authentication flows need a check on every release. Conceptual pages can wait for a quarterly cycle.
+
+This gap persists because API changes do not automatically trigger a documentation review. Engineering's release process ends when the code ships. The documentation review is a separate step. It requires someone to remember it and have time to do it. In practice, teams do this late or skip it.
 
 [Documentation drift](/blog/technical/documentation-drift-detection-problem) is a detection problem. Teams rarely discover stale docs through a monitoring system. Instead, they discover stale docs through developer complaints. By the time a support ticket arrives, many other developers have already hit the same broken path. Most of them just move on without reporting it.
 
@@ -60,24 +64,26 @@ The documentation versioning problem is related. Every API version you support a
 
 ## What the ownership model needs
 
-The fix changes how teams assign responsibility for accuracy. Three things need to be explicit:
+The fix changes how teams assign responsibility for accuracy. Four things need to be explicit:
 
 **Who owns each piece of documentation.** Each piece needs a named owner. One person owns the getting-started guide, and one team owns the SDK reference. Shared ownership without a named individual equals no ownership at all.
 
 **What triggers a documentation review.** An API change, a deprecation, or a new SDK release should each trigger a review. Document these triggers in the same place as the ownership assignments. When a trigger fires, the owner reviews the affected docs.
 
+**Which pages a given change can break.** A trigger only helps if the owner knows what to open. Map which tutorials, quickstarts, and reference pages depend on each endpoint, field, and SDK method. A spreadsheet is enough to start. Then a renamed endpoint immediately names the pages to check.
+
 **How drift is detected when triggers are missed.** Ownership and triggers work only when everyone follows the process. They fail when a change ships without the right people knowing. They also fail when a doc page isn't connected to the code it describes. Automated monitoring compares documentation against the current API spec or codebase. This monitoring closes the gap.
 
-This is what [treating documentation like code](/blog/technical/help-center-to-docs-as-code) means in practice. Teams assign explicit ownership. They keep content under version control. They build a process that detects when content diverges from the system it describes.
+This is what [treating documentation like code](/blog/technical/help-center-to-docs-as-code) means in practice: explicit ownership, content under version control, and a process that detects when content diverges from the system it describes.
 
 ## The cost of losing developer trust
 
-Developer trust in your documentation takes a long time to build. It takes almost no time to lose. Picture a developer who follows your getting-started guide and hits a wall because the docs are wrong. That developer spends two hours debugging an issue that accurate documentation would have solved in ten minutes. Most of these developers do not try again. They move on.
+Developer trust in your documentation takes a long time to build. It takes almost no time to lose. Picture a developer who follows your getting-started guide, hits a wall, and spends two hours debugging what accurate documentation would have solved in ten minutes. Most of these developers do not try again. They move on.
 
 At scale, this affects developer experience metrics across your whole product. Time to First Call measures how long it takes a developer to make a successful API call. Documentation accuracy directly affects this metric. Inaccurate getting-started guides inflate the number, even when the API itself has not changed.
 
 [Developer Documentation ROI: The Metrics That Actually Matter](/blog/technical/developer-documentation-roi) covers how to make this case to leadership.
 
-The cost of accurate documentation is the time it takes to maintain it. The cost of inaccurate documentation is much higher, because it drains developer trust and increases support load over time. Integration failures increase too, at scale. For most developer-facing companies, accurate documentation costs far less than inaccurate documentation.
+The cost of accurate documentation is the time it takes to maintain it. The cost of inaccurate documentation is much higher, because it drains developer trust, increases support load, and multiplies integration failures over time. For most developer-facing companies, accurate documentation costs far less than inaccurate documentation.
 
 <BlogRequestDemo />

--- a/src/content/blog/technical/developer-relations-docs.mdx
+++ b/src/content/blog/technical/developer-relations-docs.mdx
@@ -20,7 +20,7 @@ Developer relations documentation has a structural problem. The way teams assign
 
 ## The ownership gap in DevRel docs
 
-Most developer relations teams produce a lot of documentation: getting-started guides, tutorials, SDK reference docs, changelog entries, sample apps, and blog posts.
+Most developer relations teams produce a lot of documentation. They write getting-started guides, tutorials, SDK reference docs, changelog entries, sample apps, and blog posts.
 
 The real problem is how teams share responsibility for that documentation. Different teams own different pieces. No single trigger tells them to update at the same time.
 
@@ -30,11 +30,13 @@ When the product changes, the API reference gets updated. Engineering's definiti
 
 Developers do not see the org chart. They see documentation that contradicts the product. In [Postman's 2024 State of the API report](https://www.postman.com/state-of-api/2024), 39% of developers named inconsistent documentation as their biggest roadblock when working with APIs.
 
-After six months, documentation becomes unreliable. After a year, developers learn to distrust it by default. They go straight to the source code, or they open a support ticket. Once developers lose trust, it is expensive to rebuild. One case study measured this cost for a single stale tutorial: 47 extra support hours and three churned customers. Developer community trust took six months to recover.
+After six months, documentation becomes unreliable. After a year, developers learn to distrust it by default. They go straight to the source code, or they open a support ticket. Once developers lose trust, it is expensive to rebuild. One case study measured this cost for a single stale tutorial. The stale tutorial caused 47 support hours of extra work and three churned customers. Developer community trust took six months to recover.
 
 <BlogNewsletterCTA />
 
 ## Two audiences, one set of docs
+
+Accuracy in developer relations documentation matters more now than before.
 
 In 2026, AI coding assistants became the primary consumers of developer documentation. When a developer asks an AI coding assistant to integrate with an API, the assistant reads the docs first. The assistant takes the documentation at face value. It skips the changelog, and it skips asking a colleague whether a function still works. Then it generates code directly from what the docs say.
 
@@ -44,7 +46,7 @@ This matters most for DevRel teams. Human developers can compensate for incomple
 
 The damage also compounds within a single session. An assistant works in steps, and each step builds on what the earlier ones produced. A stale authentication page read at the start becomes an assumption behind every step after it, including the code the assistant finally writes. Nothing later in the session goes back to question it, which is the failure mode [context engineering](/blog/technical/agent-context-engineering) describes.
 
-The feedback loop has also become faster. When a developer follows broken docs, they may debug for a day before filing a support ticket. When an AI coding assistant follows broken docs, the developer sees the error within seconds.
+The feedback loop has also become faster. When a developer follows broken docs, they may debug for a day before filing a support ticket. When an AI coding assistant follows broken docs, the developer sees the error within seconds. Errors now surface more often, and they surface faster.
 
 For more on how AI coding assistants consume developer documentation, see [Agent Context Files Explained: AGENTS.md, CLAUDE.md, and llms.txt](/blog/technical/agent-context-files-explained).
 
@@ -54,9 +56,9 @@ Developer documentation does not go stale at the same rate for every type of con
 
 Procedural content breaks when the API changes. API changes happen constantly in developer-facing products. New endpoints, deprecated parameters, revised authentication flows, and updated rate limits each create a potential gap. That gap sits between what the docs say and what the API does.
 
-Within procedural content, the risk is not spread evenly. Quickstarts carry the most traffic and the most exposure, because a developer who hits a broken first step usually leaves before becoming a customer. Code samples break whenever the SDK changes, and a sample that does not run casts doubt on every other page. Authentication flows change rarely and break every existing integration when they do. Quickstarts, code samples, and authentication flows need a check on every release. Conceptual pages can wait for a quarterly cycle.
+This gap persists because API changes do not automatically trigger a documentation review. Engineering's release process ends when the code ships. The documentation review is a separate step. It requires someone to remember it and have time to do it. In practice, teams often do this late, or they skip it entirely.
 
-This gap persists because API changes do not automatically trigger a documentation review. Engineering's release process ends when the code ships. The documentation review is a separate step. It requires someone to remember it and have time to do it. In practice, teams do this late or skip it.
+Within procedural content, the risk is not spread evenly. Quickstarts carry the most traffic and the most exposure, because a developer who hits a broken first step usually leaves before becoming a customer. Code samples break whenever the SDK changes, and a sample that does not run casts doubt on every other page. Authentication flows change rarely and break every existing integration when they do. Quickstarts, code samples, and authentication flows need a check on every release. Conceptual pages can wait for a quarterly cycle.
 
 [Documentation drift](/blog/technical/documentation-drift-detection-problem) is a detection problem. Teams rarely discover stale docs through a monitoring system. Instead, they discover stale docs through developer complaints. By the time a support ticket arrives, many other developers have already hit the same broken path. Most of them just move on without reporting it.
 
@@ -74,16 +76,16 @@ The fix changes how teams assign responsibility for accuracy. Four things need t
 
 **How drift is detected when triggers are missed.** Ownership and triggers work only when everyone follows the process. They fail when a change ships without the right people knowing. They also fail when a doc page isn't connected to the code it describes. Automated monitoring compares documentation against the current API spec or codebase. This monitoring closes the gap.
 
-This is what [treating documentation like code](/blog/technical/help-center-to-docs-as-code) means in practice: explicit ownership, content under version control, and a process that detects when content diverges from the system it describes.
+This is what [treating documentation like code](/blog/technical/help-center-to-docs-as-code) means in practice. Teams assign explicit ownership. They keep content under version control. They build a process that detects when content diverges from the system it describes.
 
 ## The cost of losing developer trust
 
-Developer trust in your documentation takes a long time to build. It takes almost no time to lose. Picture a developer who follows your getting-started guide, hits a wall, and spends two hours debugging what accurate documentation would have solved in ten minutes. Most of these developers do not try again. They move on.
+Developer trust in your documentation takes a long time to build. It takes almost no time to lose. Picture a developer who follows your getting-started guide and hits a wall because the docs are wrong. That developer spends two hours debugging an issue that accurate documentation would have solved in ten minutes. Most of these developers do not try again. They move on.
 
 At scale, this affects developer experience metrics across your whole product. Time to First Call measures how long it takes a developer to make a successful API call. Documentation accuracy directly affects this metric. Inaccurate getting-started guides inflate the number, even when the API itself has not changed.
 
 [Developer Documentation ROI: The Metrics That Actually Matter](/blog/technical/developer-documentation-roi) covers how to make this case to leadership.
 
-The cost of accurate documentation is the time it takes to maintain it. The cost of inaccurate documentation is much higher, because it drains developer trust, increases support load, and multiplies integration failures over time. For most developer-facing companies, accurate documentation costs far less than inaccurate documentation.
+The cost of accurate documentation is the time it takes to maintain it. The cost of inaccurate documentation is much higher, because it drains developer trust and increases support load over time. Integration failures increase too, at scale. For most developer-facing companies, accurate documentation costs far less than inaccurate documentation.
 
 <BlogRequestDemo />


### PR DESCRIPTION
Consolidates the two remaining add/add collisions on `src/content/blog/technical/developer-relations-docs.mdx` into the canonical page published by #815, then clears the way to close both source PRs.

#582 and #625 were each written as a whole competing article on the same thesis the incumbent already argues: DevRel docs go stale because ownership is split and nothing triggers a synchronized update. Neither can be merged as-is. This PR takes the parts that add a distinct mechanism or a defensible piece of evidence and folds them into the existing structure and voice, rather than bolting on new sections.

## Salvaged from #582

| What | Rationale |
|---|---|
| Postman 2024 State of the API statistic: 39% of developers named inconsistent documentation their biggest roadblock when working with APIs, with the report linked | The incumbent had zero linked external citations. This is the only statistic across both PRs that survived verification. |
| The compounding mechanism inside a single assistant session: each step builds on earlier steps, so a stale page read at the start becomes an assumption behind everything after it, and nothing later revisits it | The incumbent said assistants follow docs literally. It did not explain how one stale read propagates through an entire run. Distinct mechanism, not a restatement. Cross-links `agent-context-engineering`. |

## Salvaged from #625

| What | Rationale |
|---|---|
| Drift-rate ordering within procedural content, with a differentiated review cadence: quickstarts, code samples, and authentication flows checked every release; conceptual pages quarterly | The incumbent had only a binary conceptual/procedural split. This turns it into an operational prioritization rule, including the point that a code sample which fails to run casts doubt on every other page. |
| The docs-to-API-surface dependency map, added as a fourth explicit item in the ownership model, with the note that a spreadsheet is enough to start | The incumbent prescribed triggers and automated monitoring but never the page-level mapping that makes a trigger actionable. A trigger only helps if the owner knows which pages to open. |

## Deliberately dropped

**From #582**

| What | Why |
|---|---|
| The entire ownership-gap argument and the org-chart framing | This is the incumbent's own thesis and title. |
| The "documentation as distribution" AI section, including the 65% AI-context claim | Duplicates the incumbent's "Two audiences, one set of docs" section, which already carries the 65% claim. |
| "68% of developers cite outdated documentation as their top frustration," attributed to Postman 2024 | Misattributed. The 2024 report's documentation figure is the 39% inconsistency number. There is no 68% outdated-docs finding in it. Per the editorial plan I did not go hunting for a substitute source to make the number work. |
| "Around 50% of developers abandon an API when documentation fails them," linked to userguiding.com | The linked page is a general SaaS user-onboarding statistics roundup. It contains nothing about developers or APIs. The link works but does not support the claim. |
| Checklists decay after two sprints; connect docs to the source of truth; silent abandonment leaves dashboards clean | All three are already in the incumbent, in its ownership-model bullets and its drift-detection paragraph. |

**From #625**

| What | Why |
|---|---|
| "A 2026 AngelHack report found that 65%…" | Unlinked. The incumbent already carries the 65% claim; adding a bare source name to it would be inventing a citation, not fixing one. |
| "Research from documentation teams tracked by HelpSite found that most teams allocate zero hours for maintenance" | Bare source name, no link. |
| "Four to eight user-facing changes per week, each touching two to five articles" | Unsourced. The editorial plan already flagged this same claim as unsupported when it appeared in #508. |
| The two-audiences section, the "where DevRel teams learn about broken docs" section, and the code-change-to-doc-review workflow | Duplicate the incumbent's AI section, its detection-problem paragraph, and its trigger bullet. |
| "The companies with the highest developer satisfaction scores have closed the gap between shipping and updating" | Unsourced claim about named-but-unidentified companies. |

## Word count and house style

The 800-1400 house range was **deliberately lifted for this article** by the reviewing human after the first round. This is a consolidation of three articles into one canonical page, so the length is an intentional decision, not an oversight or a missed check.

| | Before | After |
|---|---:|---:|
| Body words | 1,212 | 1,446 |
| Em dashes | 0 | 0 |
| Linked external citations | 0 | 1 |

The first version of this PR came in at 1,399 words because eight passages of published prose had been compressed to fit the salvage under the old ceiling. With the ceiling lifted, all eight were restored to their #815 wording verbatim. The diff against the published article is now purely additive: the four salvaged items and the bullet-count change, and nothing else. No published sentence is altered or removed.

Nothing on the dropped list was reinstated when the room appeared. Those items were rejected for duplicating the incumbent or for resting on unsourced or misattributed claims, and neither reason has anything to do with length.

## Plain-language review

Ran `plain-language-review` on the first draft and acted on all six findings: moved the new drift-ordering paragraph so it stops interrupting a thread, named the three content types instead of a vague "those three" back-reference, completed the Postman claim with the scope the statistic actually has and cut a straw contrast, replaced agent-engineering vocabulary with the article's own authentication example, folded a standalone cross-reference into its paragraph, and replaced a hedged bullet ending with a concrete consequence.

Ran a second pass scoped to the restored passages and their seams. It surfaced one real defect, which came from my own insertion rather than from the restoration: the risk-ordering paragraph had been placed between "That gap sits between what the docs say and what the API does" and "This gap persists because…", leaving that demonstrative reaching back over two paragraphs of new subjects. The paragraph now sits after the gap-persists paragraph instead, which restores the published adjacency exactly. That is the only seam fix; the other seven restorations were clean reverts.

Closes #582 and #625 by consolidation. No other PR in the `developer-relations-docs` cluster was touched.
